### PR TITLE
clippy according to Montreal accord

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,11 +5,10 @@ jobs:
  # is actually unit tests
  build:
   docker:
-   - image: holochain/holochain-rust:latest
+    - image: rust:1.34.2-slim-stretch
   resource_class: small
   working_directory: ~/repo
   steps:
-   - checkout
-   - run: nix-shell -p git --run 'git clone https://github.com/holochain/holochain-rust.git'
-   - run: nix-shell holochain-rust/default.nix --run 'cargo install rustfmt-nightly --vers 1.0.1'
-   - run: nix-shell holochain-rust/default.nix --run 'make test'
+    - run: apt-get update && apt-get install -y --no-install-recommends git make pkg-config libssl-dev
+    - checkout
+    - run: make test

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,17 @@
 SHELL = /usr/bin/env sh
 RUST_VER_WANT = "rustc 1.33.0-nightly (19f8958f8 2019-01-23)"
 RUST_TAG_WANT = "nightly-2019-01-24"
-FMT_VER_WANT = "rustfmt 1.0.1-nightly ( )"
+FMT_VER_WANT = "rustfmt 1.0.1-nightly (be13559 2018-12-10)"
+CLP_VER_WANT = "clippy 0.0.212 (280069d 2019-01-22)"
 
 all: test
 
 test: tools
 	cargo fmt -- --check
+	cargo clippy -- \
+		-A clippy::nursery -A clippy::style -A clippy::cargo \
+		-A clippy::pedantic -A clippy::restriction \
+		-D clippy::complexity -D clippy::perf -D clippy::correctness
 	RUST_BACKTRACE=1 cargo test
 
 fmt: tools
@@ -17,7 +22,7 @@ fmt: tools
 clean:
 	rm -rf target
 
-tools: tool_rust tool_fmt
+tools: tool_rust tool_fmt tool_clippy
 
 tool_rust:
 	@if [ "$$(rustc --version 2>/dev/null || true)" != ${RUST_VER_WANT} ]; \
@@ -47,4 +52,18 @@ tool_fmt: tool_rust
 		fi; \
 	else \
 		echo "# Makefile # rustfmt ok:" ${FMT_VER_WANT}; \
+	fi;
+
+tool_clippy: tool_rust
+	@if [ "$$(cargo clippy --version 2>/dev/null || true)" != ${CLP_VER_WANT} ]; \
+	then \
+		if rustup --version >/dev/null 2>&1; then \
+			echo "# Makefile # installing clippy with rustup"; \
+			rustup component add clippy-preview; \
+		else \
+			echo "# Makefile # rustup not found, cannot install rustfmt"; \
+			exit 1; \
+		fi; \
+	else \
+		echo "# Makefile # clippy ok:" ${CLP_VER_WANT}; \
 	fi;

--- a/sodium/src/pwhash.rs
+++ b/sodium/src/pwhash.rs
@@ -53,7 +53,7 @@ pub fn hash(
             raw_ptr_char_immut!(salt),
             ops_limit as libc::c_ulonglong,
             mem_limit,
-            alg as libc::c_int,
+            libc::c_int::from(alg),
         )
     };
     match res {


### PR DESCRIPTION
RESOLVES #39

```
cargo clippy -- \
  -A clippy::nursery -A clippy::style -A clippy::cargo \
  -A clippy::pedantic -A clippy::restriction \
  -D clippy::complexity -D clippy::perf -D clippy::correctness
```

clippy is no longer supported via `cargo install` and `rustup` is not supported in the nix environment... soooo I moved away from nix-shell for CI for now. I know @thedavidmeister was looking into bundling tools within the nix shell, so things like clippy would be available. Once that work is complete we can look at using nix again in CI. (unless someone has an idea how to fix this in the short term)