### PR TITLE
makefile variable fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all test fmt clean tools tool_rust tool_fmt
 
-RUSTFLAGS += "-D warnings"
+RUSTFLAGS += -D warnings
 
 SHELL = /usr/bin/env sh
 RUST_VER_WANT = "rustc 1.33.0-nightly (19f8958f8 2019-01-23)"
@@ -11,12 +11,12 @@ CLP_VER_WANT = "clippy 0.0.212 (280069d 2019-01-22)"
 all: test
 
 test: tools
-	RUSTFLAGS=$(RUSTFLAGS) cargo fmt -- --check
-	RUSTFLAGS=$(RUSTFLAGS) cargo clippy -- \
+	RUSTFLAGS='$(RUSTFLAGS)' cargo fmt -- --check
+	RUSTFLAGS='$(RUSTFLAGS)' cargo clippy -- \
 		-A clippy::nursery -A clippy::style -A clippy::cargo \
 		-A clippy::pedantic -A clippy::restriction \
 		-D clippy::complexity -D clippy::perf -D clippy::correctness
-	RUSTFLAGS=$(RUSTFLAGS) RUST_BACKTRACE=1 cargo test
+	RUSTFLAGS='$(RUSTFLAGS)' RUST_BACKTRACE=1 cargo test
 
 fmt: tools
 	cargo fmt


### PR DESCRIPTION
It was working for me if RUSTFLAGS didn't exist in the shell, but breaking if it was set to an empty string...

Let me know if this works for you @struktured !

Makefile variable handling often seems very arcane to me.