### PR TITLE
switch to logging crate

### DIFF
--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -24,9 +24,11 @@ rmp-serde = "=0.13.7"
 serde = "=1.0.89"
 serde_derive = "=1.0.89"
 failure = "=0.1.5"
+log = "=0.4.6"
 # Should be dev only
 lazy_static = "=1.2.0"
 
 [dev-dependencies]
 unwrap_to = "=0.1.0"
 backtrace = "=0.3.14"
+env_logger = "=0.6.1"

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -92,7 +92,7 @@ impl Dht for MirrorDht {
     // -- Processing -- //
 
     fn post(&mut self, cmd: DhtCommand) -> Lib3hResult<()> {
-        // println!("(log.d) >>> '(MirrorDht)' recv cmd: {:?}", cmd);
+        debug!("(log.d) >>> '(MirrorDht)' recv cmd: {:?}", cmd);
         self.inbox.push_back(cmd);
         Ok(())
     }
@@ -111,7 +111,7 @@ impl Dht for MirrorDht {
                 did_work = true;
                 outbox.append(&mut output);
             } else {
-                println!("[e] serve_DhtCommand() failed: {:?}", res);
+                debug!("[e] serve_DhtCommand() failed: {:?}", res);
             }
         }
         Ok((did_work, outbox))
@@ -122,21 +122,21 @@ impl Dht for MirrorDht {
 impl MirrorDht {
     /// Return true if new peer or updated peer
     fn add_peer(&mut self, peer_info: &PeerData) -> bool {
-        println!("[t] @MirrorDht@ Adding peer: {:?}", peer_info);
+        debug!("[t] @MirrorDht@ Adding peer: {:?}", peer_info);
         let maybe_peer = self.peer_list.get_mut(&peer_info.peer_address);
         match maybe_peer {
             None => {
-                println!("[t] @MirrorDht@ Adding peer - OK NEW");
+                debug!("[t] @MirrorDht@ Adding peer - OK NEW");
                 self.peer_list
                     .insert(peer_info.peer_address.clone(), peer_info.clone());
                 true
             }
             Some(mut peer) => {
                 if peer_info.timestamp <= peer.timestamp {
-                    println!("[t] @MirrorDht@ Adding peer - BAD");
+                    debug!("[t] @MirrorDht@ Adding peer - BAD");
                     return false;
                 }
-                println!("[t] @MirrorDht@ Adding peer - OK UPDATED");
+                debug!("[t] @MirrorDht@ Adding peer - OK UPDATED");
                 peer.timestamp = peer_info.timestamp;
                 true
             }
@@ -163,12 +163,12 @@ impl MirrorDht {
     /// Return a list of DhtEvent to owner.
     #[allow(non_snake_case)]
     fn serve_DhtCommand(&mut self, cmd: &DhtCommand) -> Lib3hResult<Vec<DhtEvent>> {
-        println!("[d] @MirrorDht@ serving cmd: {:?}", cmd);
+        debug!("[d] @MirrorDht@ serving cmd: {:?}", cmd);
         // Note: use same order as the enum
         match cmd {
             // Received gossip from remote node. Bundle must be a serialized MirrorGossip
             DhtCommand::HandleGossip(msg) => {
-                println!("Deserializer msg.bundle: {:?}", msg.bundle);
+                debug!("Deserializer msg.bundle: {:?}", msg.bundle);
                 let mut de = Deserializer::new(&msg.bundle[..]);
                 let maybe_gossip: Result<MirrorGossip, rmp_serde::decode::Error> =
                     Deserialize::deserialize(&mut de);
@@ -220,7 +220,7 @@ impl MirrorDht {
                 peer_gossip
                     .serialize(&mut Serializer::new(&mut buf))
                     .unwrap();
-                println!("[t] @MirrorDht@ gossiping peer: {:?}", peer);
+                debug!("[t] @MirrorDht@ gossiping peer: {:?}", peer);
                 let gossip_evt = GossipToData {
                     peer_address_list,
                     bundle: buf,
@@ -235,7 +235,7 @@ impl MirrorDht {
                     peer_gossip
                         .serialize(&mut Serializer::new(&mut buf))
                         .unwrap();
-                    println!(
+                    debug!(
                         "[t] @MirrorDht@ gossiping peer back: {:?} | to: {}",
                         peer, msg.peer_address
                     );

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -236,7 +236,8 @@ impl MirrorDht {
                         .unwrap();
                     trace!(
                         "@MirrorDht@ gossiping peer back: {:?} | to: {}",
-                        peer, msg.peer_address
+                        peer,
+                        msg.peer_address
                     );
                     let gossip_evt = GossipToData {
                         peer_address_list: vec![msg.peer_address.clone()],

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -121,7 +121,7 @@ impl Dht for MirrorDht {
 impl MirrorDht {
     /// Return true if new peer or updated peer
     fn add_peer(&mut self, peer_info: &PeerData) -> bool {
-        debug!("[t] @MirrorDht@ Adding peer: {:?}", peer_info);
+        trace!("@MirrorDht@ Adding peer: {:?}", peer_info);
         let maybe_peer = self.peer_list.get_mut(&peer_info.peer_address);
         match maybe_peer {
             None => {

--- a/crates/lib3h/src/dht/mod.rs
+++ b/crates/lib3h/src/dht/mod.rs
@@ -16,7 +16,12 @@ pub mod tests {
     // for this to actually show log entries you also have to run the tests like this:
     // RUST_LOG=lib3h=debug cargo test -- --nocapture
     fn enable_logging_for_test(enable: bool) {
-        let _ = env_logger::builder().is_test(enable).try_init();
+        std::env::set_var("RUST_LOG", "debug");
+        let _ = env_logger::builder()
+            .default_format_timestamp(false)
+            .default_format_module_path(false)
+            .is_test(enable)
+            .try_init();
     }
 
     /// CONSTS
@@ -96,6 +101,7 @@ pub mod tests {
 
     #[test]
     fn test_this_peer() {
+        enable_logging_for_test(true);
         let dht = new_dht(true, PEER_A);
         let this = dht.this_peer();
         assert_eq!(this.peer_address, PEER_A);
@@ -103,6 +109,7 @@ pub mod tests {
 
     #[test]
     fn test_own_peer_list() {
+        enable_logging_for_test(true);
         let mut dht = new_dht(true, PEER_A);
         // Should be empty
         let this = dht.get_peer(PEER_A);
@@ -151,6 +158,7 @@ pub mod tests {
 
     #[test]
     fn test_update_peer() {
+        enable_logging_for_test(true);
         let mut dht = new_dht(true, PEER_A);
         // Should be empty
         let this = dht.get_peer(PEER_A);
@@ -186,6 +194,7 @@ pub mod tests {
 
     #[test]
     fn test_mirror_broadcast_entry() {
+        enable_logging_for_test(true);
         let mut dht_a = new_dht(true, PEER_A);
         let mut dht_b = new_dht(true, PEER_B);
         // Add a peer
@@ -232,6 +241,7 @@ pub mod tests {
 
     #[test]
     fn test_mirror_gossip_peer() {
+        enable_logging_for_test(true);
         let mut dht_a = new_dht(true, PEER_A);
         let mut dht_b = new_dht(true, PEER_B);
         // Add a peer

--- a/crates/lib3h/src/dht/mod.rs
+++ b/crates/lib3h/src/dht/mod.rs
@@ -13,6 +13,12 @@ pub mod tests {
     };
     use url::Url;
 
+    // for this to actually show log entries you also have to run the tests like this:
+    // RUST_LOG=lib3h=debug cargo test -- --nocapture
+    fn enable_logging_for_test(enable: bool) {
+        let _ = env_logger::builder().is_test(enable).try_init();
+    }
+
     /// CONSTS
     lazy_static! {
         /// Entries
@@ -128,6 +134,7 @@ pub mod tests {
 
     #[test]
     fn test_get_own_entry() {
+        enable_logging_for_test(true);
         let mut dht = new_dht(true, PEER_A);
         // Should be empty
         let result = dht.get_entry(&ENTRY_ADDRESS_1);

--- a/crates/lib3h/src/dht/rrdht.rs
+++ b/crates/lib3h/src/dht/rrdht.rs
@@ -77,7 +77,7 @@ impl Dht for RrDht {
                 Some(msg) => msg,
             };
             did_work = true;
-            println!("[t] RrDht.process(): {:?}", cmd)
+            debug!("[t] RrDht.process(): {:?}", cmd)
         }
         Ok((did_work, outbox))
     }

--- a/crates/lib3h/src/dht/rrdht.rs
+++ b/crates/lib3h/src/dht/rrdht.rs
@@ -77,7 +77,7 @@ impl Dht for RrDht {
                 Some(msg) => msg,
             };
             did_work = true;
-            debug!("[t] RrDht.process(): {:?}", cmd)
+            trace!("RrDht.process(): {:?}", cmd)
         }
         Ok((did_work, outbox))
     }

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -21,7 +21,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         // Process the network gateway as a transport
         let (tranport_did_work, event_list) =
             Transport::process(&mut *self.network_gateway.borrow_mut())?;
-        println!(
+        debug!(
             "[d] {} - network_gateway Transport.process(): {} {}",
             self.name.clone(),
             tranport_did_work,
@@ -46,7 +46,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
 
     /// Handle a DhtEvent sent to us by our network gateway
     fn handle_netDhtEvent(&mut self, cmd: DhtEvent) -> Lib3hResult<Vec<Lib3hServerProtocol>> {
-        println!("[d] {} << handle_netDhtEvent: {:?}", self.name.clone(), cmd);
+        debug!("[d] {} << handle_netDhtEvent: {:?}", self.name.clone(), cmd);
         let outbox = Vec::new();
         match cmd {
             DhtEvent::GossipTo(_data) => {
@@ -79,7 +79,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         &mut self,
         evt: &TransportEvent,
     ) -> Lib3hResult<Vec<Lib3hServerProtocol>> {
-        println!(
+        debug!(
             "[d] {} << handle_netTransportEvent: {:?}",
             self.name.clone(),
             evt
@@ -89,7 +89,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         match evt {
             TransportEvent::TransportError(id, e) => {
                 self.network_connections.remove(id);
-                eprintln!(
+                error!(
                     "[e] {} Network error from {} : {:?}",
                     self.name.clone(),
                     id,
@@ -106,7 +106,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
             TransportEvent::ConnectResult(id) => {
                 let mut network_gateway = self.network_gateway.borrow_mut();
                 if let Some(uri) = network_gateway.get_uri(id) {
-                    println!("[i] Network Connection opened: {} ({})", id, uri);
+                    debug!("[i] Network Connection opened: {} ({})", id, uri);
 
                     // FIXME: Do this in next process instead
                     // Send to other node our Joined Spaces
@@ -116,19 +116,19 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                     our_joined_space_list
                         .serialize(&mut Serializer::new(&mut buf))
                         .unwrap();
-                    println!(
+                    debug!(
                         "(GatewayTransport) P2pProtocol::AllJoinedSpaceList: {:?} to {:?}",
                         our_joined_space_list, id
                     );
                     // id is connectionId but we need a transportId, so search for it in the DHT
                     let peer_list = network_gateway.get_peer_list();
-                    println!(
+                    debug!(
                         "(GatewayTransport) P2pProtocol::AllJoinedSpaceList: get_peer_list = {:?}",
                         peer_list
                     );
                     let maybe_peer_data = peer_list.iter().find(|pd| pd.peer_uri == uri);
                     if let Some(peer_data) = maybe_peer_data {
-                        println!(
+                        debug!(
                             "(GatewayTransport) P2pProtocol::AllJoinedSpaceList ; sending back to {:?}",
                             peer_data,
                         );
@@ -162,7 +162,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                 }
             }
             TransportEvent::Received(id, payload) => {
-                println!("[d] Received message from: {} | {}", id, payload.len());
+                debug!("[d] Received message from: {} | {}", id, payload.len());
                 let mut de = Deserializer::new(&payload[..]);
                 let maybe_msg: Result<P2pProtocol, rmp_serde::decode::Error> =
                     Deserialize::deserialize(&mut de);
@@ -224,14 +224,14 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
             }
             // HACK
             P2pProtocol::BroadcastJoinSpace(gateway_id, peer_data) => {
-                println!("[d] Received JoinSpace: {} {:?}", gateway_id, peer_data);
+                debug!("[d] Received JoinSpace: {} {:?}", gateway_id, peer_data);
                 for (_, space_gateway) in self.space_gateway_map.iter_mut() {
                     space_gateway.post_dht(DhtCommand::HoldPeer(peer_data.clone()))?;
                 }
             }
             // HACK
             P2pProtocol::AllJoinedSpaceList(join_list) => {
-                println!("[d] Received AllJoinedSpaceList: {:?}", join_list);
+                debug!("[d] Received AllJoinedSpaceList: {:?}", join_list);
                 for (space_address, peer_data) in join_list {
                     let maybe_space_gateway = self.get_first_space_mut(space_address);
                     if let Some(space_gateway) = maybe_space_gateway {

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -79,7 +79,8 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         &mut self,
         evt: &TransportEvent,
     ) -> Lib3hResult<Vec<Lib3hServerProtocol>> {
-        debug!("{} << handle_netTransportEvent: {:?}",
+        debug!(
+            "{} << handle_netTransportEvent: {:?}",
             self.name.clone(),
             evt
         );
@@ -88,12 +89,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         match evt {
             TransportEvent::TransportError(id, e) => {
                 self.network_connections.remove(id);
-                error!(
-                    "{} Network error from {} : {:?}",
-                    self.name.clone(),
-                    id,
-                    e
-                );
+                error!("{} Network error from {} : {:?}", self.name.clone(), id, e);
                 // Output a Lib3hServerProtocol::Disconnected if it was the connection
                 if self.network_connections.is_empty() {
                     let data = DisconnectedData {
@@ -117,7 +113,8 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                         .unwrap();
                     trace!(
                         "(GatewayTransport) P2pProtocol::AllJoinedSpaceList: {:?} to {:?}",
-                        our_joined_space_list, id
+                        our_joined_space_list,
+                        id
                     );
                     // id is connectionId but we need a transportId, so search for it in the DHT
                     let peer_list = network_gateway.get_peer_list();

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -22,7 +22,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         let (tranport_did_work, event_list) =
             Transport::process(&mut *self.network_gateway.borrow_mut())?;
         debug!(
-            "[d] {} - network_gateway Transport.process(): {} {}",
+            "{} - network_gateway Transport.process(): {} {}",
             self.name.clone(),
             tranport_did_work,
             event_list.len()
@@ -46,7 +46,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
 
     /// Handle a DhtEvent sent to us by our network gateway
     fn handle_netDhtEvent(&mut self, cmd: DhtEvent) -> Lib3hResult<Vec<Lib3hServerProtocol>> {
-        debug!("[d] {} << handle_netDhtEvent: {:?}", self.name.clone(), cmd);
+        debug!("{} << handle_netDhtEvent: {:?}", self.name.clone(), cmd);
         let outbox = Vec::new();
         match cmd {
             DhtEvent::GossipTo(_data) => {
@@ -79,8 +79,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         &mut self,
         evt: &TransportEvent,
     ) -> Lib3hResult<Vec<Lib3hServerProtocol>> {
-        debug!(
-            "[d] {} << handle_netTransportEvent: {:?}",
+        debug!("{} << handle_netTransportEvent: {:?}",
             self.name.clone(),
             evt
         );
@@ -90,7 +89,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
             TransportEvent::TransportError(id, e) => {
                 self.network_connections.remove(id);
                 error!(
-                    "[e] {} Network error from {} : {:?}",
+                    "{} Network error from {} : {:?}",
                     self.name.clone(),
                     id,
                     e
@@ -106,7 +105,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
             TransportEvent::ConnectResult(id) => {
                 let mut network_gateway = self.network_gateway.borrow_mut();
                 if let Some(uri) = network_gateway.get_uri(id) {
-                    debug!("[i] Network Connection opened: {} ({})", id, uri);
+                    info!("Network Connection opened: {} ({})", id, uri);
 
                     // FIXME: Do this in next process instead
                     // Send to other node our Joined Spaces
@@ -116,19 +115,19 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                     our_joined_space_list
                         .serialize(&mut Serializer::new(&mut buf))
                         .unwrap();
-                    debug!(
+                    trace!(
                         "(GatewayTransport) P2pProtocol::AllJoinedSpaceList: {:?} to {:?}",
                         our_joined_space_list, id
                     );
                     // id is connectionId but we need a transportId, so search for it in the DHT
                     let peer_list = network_gateway.get_peer_list();
-                    debug!(
+                    trace!(
                         "(GatewayTransport) P2pProtocol::AllJoinedSpaceList: get_peer_list = {:?}",
                         peer_list
                     );
                     let maybe_peer_data = peer_list.iter().find(|pd| pd.peer_uri == uri);
                     if let Some(peer_data) = maybe_peer_data {
-                        debug!(
+                        trace!(
                             "(GatewayTransport) P2pProtocol::AllJoinedSpaceList ; sending back to {:?}",
                             peer_data,
                         );
@@ -162,7 +161,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                 }
             }
             TransportEvent::Received(id, payload) => {
-                debug!("[d] Received message from: {} | {}", id, payload.len());
+                debug!("Received message from: {} | {}", id, payload.len());
                 let mut de = Deserializer::new(&payload[..]);
                 let maybe_msg: Result<P2pProtocol, rmp_serde::decode::Error> =
                     Deserialize::deserialize(&mut de);
@@ -224,14 +223,14 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
             }
             // HACK
             P2pProtocol::BroadcastJoinSpace(gateway_id, peer_data) => {
-                debug!("[d] Received JoinSpace: {} {:?}", gateway_id, peer_data);
+                debug!("Received JoinSpace: {} {:?}", gateway_id, peer_data);
                 for (_, space_gateway) in self.space_gateway_map.iter_mut() {
                     space_gateway.post_dht(DhtCommand::HoldPeer(peer_data.clone()))?;
                 }
             }
             // HACK
             P2pProtocol::AllJoinedSpaceList(join_list) => {
-                debug!("[d] Received AllJoinedSpaceList: {:?}", join_list);
+                debug!("Received AllJoinedSpaceList: {:?}", join_list);
                 for (space_address, peer_data) in join_list {
                     let maybe_space_gateway = self.get_first_space_mut(space_address);
                     if let Some(space_gateway) = maybe_space_gateway {

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -103,7 +103,7 @@ impl<D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<TransportMemory, D
             dht_factory,
             &dht_config,
         )));
-        println!(
+        debug!(
             "New MOCK RealEngine {} -> {:?}",
             name,
             network_gateway.borrow().this_peer()
@@ -148,7 +148,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> NetworkEngine
 
     /// Add incoming Lib3hClientProtocol message in FIFO
     fn post(&mut self, client_msg: Lib3hClientProtocol) -> Lib3hResult<()> {
-        // println!("[t] RealEngine.post(): {:?}", client_msg);
+        debug!("[t] RealEngine.post(): {:?}", client_msg);
         self.inbox.push_back(client_msg);
         Ok(())
     }
@@ -156,7 +156,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> NetworkEngine
     /// Process Lib3hClientProtocol message inbox and
     /// output a list of Lib3hServerProtocol messages for Core to handle
     fn process(&mut self) -> Lib3hResult<(DidWork, Vec<Lib3hServerProtocol>)> {
-        println!("\n[t] {} - RealEngine.process() START", self.name);
+        debug!("\n[t] {} - RealEngine.process() START", self.name);
         // Process all received Lib3hClientProtocol messages from Core
         let (inbox_did_work, mut outbox) = self.process_inbox()?;
         // Process the network layer
@@ -165,7 +165,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> NetworkEngine
         // Process the space layer
         let mut p2p_output = self.process_space_gateways()?;
         outbox.append(&mut p2p_output);
-        println!("[t] {} - RealEngine.process() END\n", self.name);
+        debug!("[t] {} - RealEngine.process() END\n", self.name);
         // Done
         Ok((inbox_did_work || net_did_work, outbox))
     }
@@ -198,7 +198,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         &mut self,
         client_msg: Lib3hClientProtocol,
     ) -> Lib3hResult<(DidWork, Vec<Lib3hServerProtocol>)> {
-        println!("[d] {} serving: {:?}", self.name.clone(), client_msg);
+        debug!("[d] {} serving: {:?}", self.name.clone(), client_msg);
         let mut outbox = Vec::new();
         let did_work = true;
         // Note: use same order as the enum
@@ -234,7 +234,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                     Ok(space_gateway) => {
                         let connection_id =
                             std::string::String::from_utf8_lossy(&msg.to_agent_id).into_owned();
-                        println!("[d] {} -- connection_id: {:?}", my_name, connection_id);
+                        debug!("[d] {} -- connection_id: {:?}", my_name, connection_id);
                         // Change into P2pProtocol
                         let net_msg = P2pProtocol::DirectMessage(msg);
                         // Serialize
@@ -243,7 +243,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                             .serialize(&mut Serializer::new(&mut payload))
                             .unwrap();
                         // Send
-                        println!(
+                        debug!(
                             "[t] {} sending payload to transport id {}",
                             my_name, connection_id
                         );
@@ -395,7 +395,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         p2p_msg
             .serialize(&mut Serializer::new(&mut payload))
             .unwrap();
-        println!(
+        debug!(
             "[t] {} - Broadcasting JoinSpace: {}, {}",
             self.name.clone(),
             space_address,

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -148,7 +148,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> NetworkEngine
 
     /// Add incoming Lib3hClientProtocol message in FIFO
     fn post(&mut self, client_msg: Lib3hClientProtocol) -> Lib3hResult<()> {
-        debug!("[t] RealEngine.post(): {:?}", client_msg);
+        trace!("RealEngine.post(): {:?}", client_msg);
         self.inbox.push_back(client_msg);
         Ok(())
     }
@@ -156,7 +156,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> NetworkEngine
     /// Process Lib3hClientProtocol message inbox and
     /// output a list of Lib3hServerProtocol messages for Core to handle
     fn process(&mut self) -> Lib3hResult<(DidWork, Vec<Lib3hServerProtocol>)> {
-        debug!("\n[t] {} - RealEngine.process() START", self.name);
+        trace!("\n{} - RealEngine.process() START", self.name);
         // Process all received Lib3hClientProtocol messages from Core
         let (inbox_did_work, mut outbox) = self.process_inbox()?;
         // Process the network layer
@@ -165,7 +165,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> NetworkEngine
         // Process the space layer
         let mut p2p_output = self.process_space_gateways()?;
         outbox.append(&mut p2p_output);
-        debug!("[t] {} - RealEngine.process() END\n", self.name);
+        trace!("{} - RealEngine.process() END\n", self.name);
         // Done
         Ok((inbox_did_work || net_did_work, outbox))
     }
@@ -198,7 +198,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         &mut self,
         client_msg: Lib3hClientProtocol,
     ) -> Lib3hResult<(DidWork, Vec<Lib3hServerProtocol>)> {
-        debug!("[d] {} serving: {:?}", self.name.clone(), client_msg);
+        debug!("{} serving: {:?}", self.name.clone(), client_msg);
         let mut outbox = Vec::new();
         let did_work = true;
         // Note: use same order as the enum
@@ -234,7 +234,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                     Ok(space_gateway) => {
                         let connection_id =
                             std::string::String::from_utf8_lossy(&msg.to_agent_id).into_owned();
-                        debug!("[d] {} -- connection_id: {:?}", my_name, connection_id);
+                        debug!("{} -- connection_id: {:?}", my_name, connection_id);
                         // Change into P2pProtocol
                         let net_msg = P2pProtocol::DirectMessage(msg);
                         // Serialize
@@ -243,8 +243,8 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                             .serialize(&mut Serializer::new(&mut payload))
                             .unwrap();
                         // Send
-                        debug!(
-                            "[t] {} sending payload to transport id {}",
+                        trace!(
+                            "{} sending payload to transport id {}",
                             my_name, connection_id
                         );
                         space_gateway.send(&[connection_id.as_str()], &payload)?;
@@ -395,8 +395,8 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         p2p_msg
             .serialize(&mut Serializer::new(&mut payload))
             .unwrap();
-        debug!(
-            "[t] {} - Broadcasting JoinSpace: {}, {}",
+        trace!(
+            "{} - Broadcasting JoinSpace: {}, {}",
             self.name.clone(),
             space_address,
             peer.peer_address

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -245,7 +245,8 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                         // Send
                         trace!(
                             "{} sending payload to transport id {}",
-                            my_name, connection_id
+                            my_name,
+                            connection_id
                         );
                         space_gateway.send(&[connection_id.as_str()], &payload)?;
                     }

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -148,7 +148,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> NetworkEngine
 
     /// Add incoming Lib3hClientProtocol message in FIFO
     fn post(&mut self, client_msg: Lib3hClientProtocol) -> Lib3hResult<()> {
-        trace!("RealEngine.post(): {:?}", client_msg);
+        // trace!("RealEngine.post(): {:?}", client_msg);
         self.inbox.push_back(client_msg);
         Ok(())
     }
@@ -156,7 +156,8 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> NetworkEngine
     /// Process Lib3hClientProtocol message inbox and
     /// output a list of Lib3hServerProtocol messages for Core to handle
     fn process(&mut self) -> Lib3hResult<(DidWork, Vec<Lib3hServerProtocol>)> {
-        trace!("\n{} - RealEngine.process() START", self.name);
+        trace!("");
+        trace!("{} - RealEngine.process() START", self.name);
         // Process all received Lib3hClientProtocol messages from Core
         let (inbox_did_work, mut outbox) = self.process_inbox()?;
         // Process the network layer

--- a/crates/lib3h/src/engine/space_layer.rs
+++ b/crates/lib3h/src/engine/space_layer.rs
@@ -66,7 +66,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         chain_id: &ChainId,
         cmd: DhtEvent,
     ) -> Lib3hResult<Vec<Lib3hServerProtocol>> {
-        println!(
+        debug!(
             "[d] {} << handle_spaceDhtEvent: [{:?}] - {:?}",
             self.name.clone(),
             chain_id,
@@ -85,7 +85,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                 // n/a - should have been handled by gateway
             }
             DhtEvent::HoldPeerRequested(peer_data) => {
-                println!(
+                debug!(
                     "[d] {} -- ({}).post() HoldPeer {:?}",
                     self.name.clone(),
                     space_gateway.identifier(),

--- a/crates/lib3h/src/engine/space_layer.rs
+++ b/crates/lib3h/src/engine/space_layer.rs
@@ -67,7 +67,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         cmd: DhtEvent,
     ) -> Lib3hResult<Vec<Lib3hServerProtocol>> {
         debug!(
-            "[d] {} << handle_spaceDhtEvent: [{:?}] - {:?}",
+            "{} << handle_spaceDhtEvent: [{:?}] - {:?}",
             self.name.clone(),
             chain_id,
             cmd
@@ -86,7 +86,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
             }
             DhtEvent::HoldPeerRequested(peer_data) => {
                 debug!(
-                    "[d] {} -- ({}).post() HoldPeer {:?}",
+                    "{} -- ({}).post() HoldPeer {:?}",
                     self.name.clone(),
                     space_gateway.identifier(),
                     peer_data

--- a/crates/lib3h/src/gateway/gateway_dht.rs
+++ b/crates/lib3h/src/gateway/gateway_dht.rs
@@ -61,11 +61,7 @@ impl<T: Transport, D: Dht> Dht for P2pGateway<T, D> {
 impl<T: Transport, D: Dht> P2pGateway<T, D> {
     /// Handle a DhtEvent sent to us by our internal DHT.
     pub(crate) fn handle_DhtEvent(&mut self, evt: DhtEvent) -> Lib3hResult<()> {
-        trace!(
-            "({}).handle_DhtEvent() {:?}",
-            self.identifier.clone(),
-            evt
-        );
+        trace!("({}).handle_DhtEvent() {:?}", self.identifier.clone(), evt);
         match evt {
             DhtEvent::GossipTo(data) => {
                 // DHT should give us the peer_transport

--- a/crates/lib3h/src/gateway/gateway_dht.rs
+++ b/crates/lib3h/src/gateway/gateway_dht.rs
@@ -34,7 +34,7 @@ impl<T: Transport, D: Dht> Dht for P2pGateway<T, D> {
     fn process(&mut self) -> Lib3hResult<(DidWork, Vec<DhtEvent>)> {
         // Process the dht
         let (did_work, dht_event_list) = self.inner_dht.process()?;
-        println!(
+        debug!(
             "[t] ({}).Dht.process() - output: {} {}",
             self.identifier.clone(),
             did_work,
@@ -61,7 +61,7 @@ impl<T: Transport, D: Dht> Dht for P2pGateway<T, D> {
 impl<T: Transport, D: Dht> P2pGateway<T, D> {
     /// Handle a DhtEvent sent to us by our internal DHT.
     pub(crate) fn handle_DhtEvent(&mut self, evt: DhtEvent) -> Lib3hResult<()> {
-        println!(
+        debug!(
             "[t] ({}).handle_DhtEvent() {:?}",
             self.identifier.clone(),
             evt
@@ -81,7 +81,7 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
                         .get_peer(&to_peer_address)
                         .expect("Should gossip to a known peer")
                         .peer_uri;
-                    println!(
+                    debug!(
                         "({}) GossipTo: {} {}",
                         self.identifier.clone(),
                         to_peer_address,

--- a/crates/lib3h/src/gateway/gateway_dht.rs
+++ b/crates/lib3h/src/gateway/gateway_dht.rs
@@ -34,8 +34,8 @@ impl<T: Transport, D: Dht> Dht for P2pGateway<T, D> {
     fn process(&mut self) -> Lib3hResult<(DidWork, Vec<DhtEvent>)> {
         // Process the dht
         let (did_work, dht_event_list) = self.inner_dht.process()?;
-        debug!(
-            "[t] ({}).Dht.process() - output: {} {}",
+        trace!(
+            "({}).Dht.process() - output: {} {}",
             self.identifier.clone(),
             did_work,
             dht_event_list.len()
@@ -61,8 +61,8 @@ impl<T: Transport, D: Dht> Dht for P2pGateway<T, D> {
 impl<T: Transport, D: Dht> P2pGateway<T, D> {
     /// Handle a DhtEvent sent to us by our internal DHT.
     pub(crate) fn handle_DhtEvent(&mut self, evt: DhtEvent) -> Lib3hResult<()> {
-        debug!(
-            "[t] ({}).handle_DhtEvent() {:?}",
+        trace!(
+            "({}).handle_DhtEvent() {:?}",
             self.identifier.clone(),
             evt
         );
@@ -81,7 +81,7 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
                         .get_peer(&to_peer_address)
                         .expect("Should gossip to a known peer")
                         .peer_uri;
-                    debug!(
+                    trace!(
                         "({}) GossipTo: {} {}",
                         self.identifier.clone(),
                         to_peer_address,

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -21,7 +21,7 @@ use url::Url;
 impl<T: Transport, D: Dht> Transport for P2pGateway<T, D> {
     /// TODO: return a higher-level uri instead
     fn connect(&mut self, uri: &Url) -> TransportResult<ConnectionId> {
-        println!("[t] ({}).connect() {}", self.identifier.clone(), uri);
+        debug!("[t] ({}).connect() {}", self.identifier.clone(), uri);
         // Connect
         let connection_id = self.inner_transport.borrow_mut().connect(&uri)?;
         // Store result in connection map
@@ -49,7 +49,7 @@ impl<T: Transport, D: Dht> Transport for P2pGateway<T, D> {
         // get connectionId from the inner dht first
         let dht_uri_list = self.connection_id_to_dht_uri_list(dht_id_list)?;
         // send
-        println!(
+        debug!(
             "[t] ({}).send() {:?} -> {:?} | {}",
             self.identifier.clone(),
             dht_id_list,
@@ -64,7 +64,7 @@ impl<T: Transport, D: Dht> Transport for P2pGateway<T, D> {
                 .get(&dht_uri)
                 .expect("unknown dht_transport");
             net_uri_list.push(net_uri);
-            println!(
+            debug!(
                 "[t] ({}).send() reversed mapped dht_uri {:?} to net_uri {:?}",
                 self.identifier.clone(),
                 dht_uri,
@@ -80,7 +80,7 @@ impl<T: Transport, D: Dht> Transport for P2pGateway<T, D> {
     fn send_all(&mut self, payload: &[u8]) -> TransportResult<()> {
         let connection_list = self.connection_id_list()?;
         let dht_id_list: Vec<&str> = connection_list.iter().map(|v| &**v).collect();
-        println!(
+        debug!(
             "[t] ({}) send_all() {:?}",
             self.identifier.clone(),
             dht_id_list
@@ -90,7 +90,7 @@ impl<T: Transport, D: Dht> Transport for P2pGateway<T, D> {
 
     /// TODO?
     fn bind(&mut self, url: &Url) -> TransportResult<Url> {
-        println!("[t] ({}) bind() {}", self.identifier.clone(), url);
+        debug!("[t] ({}) bind() {}", self.identifier.clone(), url);
         self.inner_transport.borrow_mut().bind(url)
     }
 
@@ -116,7 +116,7 @@ impl<T: Transport, D: Dht> Transport for P2pGateway<T, D> {
                 outbox.append(&mut output);
             }
         }
-        println!(
+        debug!(
             "[t] ({}).Transport.process() - output: {} {}",
             self.identifier.clone(),
             did_work,
@@ -125,7 +125,7 @@ impl<T: Transport, D: Dht> Transport for P2pGateway<T, D> {
         //// ?? Don't process inner transport because we are not the owner and are not responsable for that??
         // Process inner transport
         let (inner_did_work, mut event_list) = self.inner_transport.borrow_mut().process()?;
-        println!(
+        debug!(
             "[t] ({}).Transport.inner_process() - output: {} {}",
             self.identifier.clone(),
             inner_did_work,
@@ -185,7 +185,7 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
 
     /// Process a transportEvent received from our internal connection.
     pub(crate) fn handle_TransportEvent(&mut self, evt: &TransportEvent) -> TransportResult<()> {
-        println!(
+        debug!(
             "[d] <<< '({})' recv transport event: {:?}",
             self.identifier.clone(),
             evt
@@ -193,20 +193,20 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
         // Note: use same order as the enum
         match evt {
             TransportEvent::TransportError(id, e) => {
-                println!(
+                debug!(
                     "[e] (GatewayTransport) Connection Error for {}: {}\n Closing connection.",
                     id, e
                 );
                 self.inner_transport.borrow_mut().close(id)?;
             }
             TransportEvent::ConnectResult(id) => {
-                println!(
+                debug!(
                     "[i] ({}) Connection opened id: {}",
                     self.identifier.clone(),
                     id
                 );
                 if let Some(uri) = self.get_uri(id) {
-                    println!(
+                    debug!(
                         "[t] (GatewayTransport).ConnectResult: mapping {} -> {}",
                         uri, id
                     );
@@ -222,7 +222,7 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
                     our_peer_address
                         .serialize(&mut Serializer::new(&mut buf))
                         .unwrap();
-                    println!(
+                    debug!(
                         "(GatewayTransport) P2pProtocol::PeerAddress: {:?} to {:?}",
                         our_peer_address, id
                     );
@@ -235,19 +235,19 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
             }
             TransportEvent::Closed(id) => {
                 // FIXME
-                println!("[w] Connection closed: {}", id);
+                debug!("[w] Connection closed: {}", id);
                 self.inner_transport.borrow_mut().close(id)?;
                 //let _transport_id = self.wss_socket.wait_connect(&self.ipc_uri)?;
             }
             TransportEvent::Received(id, payload) => {
-                println!("[d] Received message from: {}", id);
-                // println!("Deserialize msg: {:?}", payload);
+                debug!("[d] Received message from: {}", id);
+                // debug!("Deserialize msg: {:?}", payload);
                 let mut de = Deserializer::new(&payload[..]);
                 let maybe_p2p_msg: Result<P2pProtocol, rmp_serde::decode::Error> =
                     Deserialize::deserialize(&mut de);
                 if let Ok(p2p_msg) = maybe_p2p_msg {
                     if let P2pProtocol::PeerAddress(gateway_id, peer_address) = p2p_msg {
-                        println!(
+                        debug!(
                             "[d] Received PeerAddress: {} | {} ({})",
                             peer_address, gateway_id, self.identifier
                         );
@@ -275,7 +275,7 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
         &mut self,
         cmd: &TransportCommand,
     ) -> TransportResult<Vec<TransportEvent>> {
-        println!(
+        debug!(
             "[t]'({})' serving transport cmd: {:?}",
             self.identifier.clone(),
             cmd

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -80,11 +80,7 @@ impl<T: Transport, D: Dht> Transport for P2pGateway<T, D> {
     fn send_all(&mut self, payload: &[u8]) -> TransportResult<()> {
         let connection_list = self.connection_id_list()?;
         let dht_id_list: Vec<&str> = connection_list.iter().map(|v| &**v).collect();
-        trace!(
-            "({}) send_all() {:?}",
-            self.identifier.clone(),
-            dht_id_list
-        );
+        trace!("({}) send_all() {:?}", self.identifier.clone(), dht_id_list);
         self.send(&dht_id_list, payload)
     }
 
@@ -200,15 +196,12 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
                 self.inner_transport.borrow_mut().close(id)?;
             }
             TransportEvent::ConnectResult(id) => {
-                info!(
-                    "({}) Connection opened id: {}",
-                    self.identifier.clone(),
-                    id
-                );
+                info!("({}) Connection opened id: {}", self.identifier.clone(), id);
                 if let Some(uri) = self.get_uri(id) {
                     trace!(
                         "(GatewayTransport).ConnectResult: mapping {} -> {}",
-                        uri, id
+                        uri,
+                        id
                     );
                     self.connection_map.insert(uri, id.clone());
                     // Ok(conn_id)
@@ -224,7 +217,8 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
                         .unwrap();
                     trace!(
                         "(GatewayTransport) P2pProtocol::PeerAddress: {:?} to {:?}",
-                        our_peer_address, id
+                        our_peer_address,
+                        id
                     );
                     self.inner_transport.borrow_mut().send(&[&id], &buf)?;
                 }

--- a/crates/lib3h/src/lib.rs
+++ b/crates/lib3h/src/lib.rs
@@ -15,6 +15,8 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 extern crate rmp_serde;
+#[macro_use]
+extern crate log;
 
 // -- mod -- //
 

--- a/crates/lib3h/src/transport/memory_mock/memory_server.rs
+++ b/crates/lib3h/src/transport/memory_mock/memory_server.rs
@@ -24,7 +24,7 @@ lazy_static! {
 
 /// Add new MemoryServer to the global server map
 pub fn set_server(uri: &Url) -> TransportResult<()> {
-    // println!("[d] MemoryServer::set_server: {}", uri);
+    debug!("[d] MemoryServer::set_server: {}", uri);
     // Create server with that name if it doesn't already exist
     let mut server_map = MEMORY_SERVER_MAP.write().unwrap();
     if server_map.contains_key(uri) {
@@ -72,7 +72,7 @@ impl MemoryServer {
     /// Create an inbox for this new sender
     /// Will connect the other way.
     pub fn connect(&mut self, requester_uri: &ConnectionIdRef) -> TransportResult<()> {
-        println!(
+        debug!(
             "[i] (MemoryServer) {} creates inbox for {}",
             self.uri, requester_uri
         );
@@ -95,7 +95,7 @@ impl MemoryServer {
 
     /// Delete this connectionId's inbox
     pub fn close(&mut self, id: &ConnectionIdRef) -> TransportResult<()> {
-        println!("[i] (MemoryServer {}).close({})", self.uri, id);
+        debug!("[i] (MemoryServer {}).close({})", self.uri, id);
         let res = self.inbox_map.remove(id);
         if res.is_none() {
             return Err(TransportError::new(format!(
@@ -123,7 +123,7 @@ impl MemoryServer {
     /// Process all inboxes.
     /// Return a TransportEvent::Received for each payload processed.
     pub fn process(&mut self) -> TransportResult<(DidWork, Vec<TransportEvent>)> {
-        println!("[t] (MemoryServer {}).process()", self.uri);
+        debug!("[t] (MemoryServer {}).process()", self.uri);
         let mut outbox = Vec::new();
         let mut did_work = false;
         // Process connexion inbox
@@ -140,7 +140,7 @@ impl MemoryServer {
                     Some(msg) => msg,
                 };
                 did_work = true;
-                println!("[t] (MemoryServer {}) received: {:?}", self.uri, payload);
+                debug!("[t] (MemoryServer {}) received: {:?}", self.uri, payload);
                 let evt = TransportEvent::Received(id.clone(), payload);
                 outbox.push(evt);
             }

--- a/crates/lib3h/src/transport/memory_mock/memory_server.rs
+++ b/crates/lib3h/src/transport/memory_mock/memory_server.rs
@@ -24,7 +24,7 @@ lazy_static! {
 
 /// Add new MemoryServer to the global server map
 pub fn set_server(uri: &Url) -> TransportResult<()> {
-    debug!("[d] MemoryServer::set_server: {}", uri);
+    debug!("MemoryServer::set_server: {}", uri);
     // Create server with that name if it doesn't already exist
     let mut server_map = MEMORY_SERVER_MAP.write().unwrap();
     if server_map.contains_key(uri) {
@@ -72,8 +72,8 @@ impl MemoryServer {
     /// Create an inbox for this new sender
     /// Will connect the other way.
     pub fn connect(&mut self, requester_uri: &ConnectionIdRef) -> TransportResult<()> {
-        debug!(
-            "[i] (MemoryServer) {} creates inbox for {}",
+        info!(
+            "(MemoryServer) {} creates inbox for {}",
             self.uri, requester_uri
         );
         if self.inbox_map.contains_key(requester_uri) {
@@ -95,7 +95,7 @@ impl MemoryServer {
 
     /// Delete this connectionId's inbox
     pub fn close(&mut self, id: &ConnectionIdRef) -> TransportResult<()> {
-        debug!("[i] (MemoryServer {}).close({})", self.uri, id);
+        info!("(MemoryServer {}).close({})", self.uri, id);
         let res = self.inbox_map.remove(id);
         if res.is_none() {
             return Err(TransportError::new(format!(
@@ -123,7 +123,7 @@ impl MemoryServer {
     /// Process all inboxes.
     /// Return a TransportEvent::Received for each payload processed.
     pub fn process(&mut self) -> TransportResult<(DidWork, Vec<TransportEvent>)> {
-        debug!("[t] (MemoryServer {}).process()", self.uri);
+        trace!("(MemoryServer {}).process()", self.uri);
         let mut outbox = Vec::new();
         let mut did_work = false;
         // Process connexion inbox
@@ -140,7 +140,7 @@ impl MemoryServer {
                     Some(msg) => msg,
                 };
                 did_work = true;
-                debug!("[t] (MemoryServer {}) received: {:?}", self.uri, payload);
+                trace!("(MemoryServer {}) received: {:?}", self.uri, payload);
                 let evt = TransportEvent::Received(id.clone(), payload);
                 outbox.push(evt);
             }

--- a/crates/lib3h/src/transport/memory_mock/transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/transport_memory.rs
@@ -69,7 +69,7 @@ impl Transport for TransportMemory {
             Some(u) => u,
         };
 
-        // println!("[d] ---- connect: {} -> {}", my_uri, uri);
+        // debug!(" ---- connect: {} -> {}", my_uri, uri);
         let server_map = memory_server::MEMORY_SERVER_MAP.read().unwrap();
         let maybe_server = server_map.get(uri);
         if let None = maybe_server {
@@ -131,7 +131,7 @@ impl Transport for TransportMemory {
         for id in id_list {
             let maybe_uri = self.connections.get(*id);
             if let None = maybe_uri {
-                println!("[w] No known connection for connectionId: {}", id);
+                warn!("No known connection for connectionId: {}", id);
                 continue;
             }
             let uri = maybe_uri.unwrap();
@@ -143,7 +143,7 @@ impl Transport for TransportMemory {
                     uri
                 )));
             }
-            println!("[t] (TransportMemory).send() {} | {}", uri, payload.len());
+            trace!("(TransportMemory).send() {} | {}", uri, payload.len());
             // let uri = self.get_uri(id).unwrap();
             let mut server = maybe_server.unwrap().lock().unwrap();
             server
@@ -179,7 +179,7 @@ impl Transport for TransportMemory {
 
     /// Process my TransportCommand inbox and all my server inboxes
     fn process(&mut self) -> TransportResult<(DidWork, Vec<TransportEvent>)> {
-        // println!("[t] (TransportMemory).process()");
+        // trace!("(TransportMemory).process()");
         let mut outbox = Vec::new();
         let mut did_work = false;
         // Process TransportCommand inbox
@@ -214,8 +214,8 @@ impl Transport for TransportMemory {
         }
         // Connect back to received connections if not already connected to them
         for uri in to_connect_list {
-            println!(
-                "[t] (TransportMemory) {} <- {}",
+            trace!(
+                "(TransportMemory) {} <- {}",
                 uri,
                 self.maybe_my_uri.clone().unwrap()
             );
@@ -247,7 +247,7 @@ impl TransportMemory {
         &mut self,
         cmd: &TransportCommand,
     ) -> TransportResult<Vec<TransportEvent>> {
-        println!("[d] >>> '(TransportMemory)' recv cmd: {:?}", cmd);
+        debug!(">>> '(TransportMemory)' recv cmd: {:?}", cmd);
         // Note: use same order as the enum
         match cmd {
             TransportCommand::Connect(url) => {

--- a/crates/lib3h/src/transport/mod.rs
+++ b/crates/lib3h/src/transport/mod.rs
@@ -37,8 +37,20 @@ pub mod tests {
     // How many times to call process before checking if work was done
     const NUM_PROCESS_LOOPS: u8 = 5;
 
+    // for this to actually show log entries you also have to run the tests like this:
+    // RUST_LOG=lib3h=debug cargo test -- --nocapture
+    fn enable_logging_for_test(enable: bool) {
+        std::env::set_var("RUST_LOG", "debug");
+        let _ = env_logger::builder()
+            .default_format_timestamp(false)
+            .default_format_module_path(false)
+            .is_test(enable)
+            .try_init();
+    }
+
     #[test]
     fn memory_send_test() {
+        enable_logging_for_test(true);
         let mut node_A = transport_memory::TransportMemory::new();
         let mut node_B = transport_memory::TransportMemory::new();
         let uri_A = Url::parse("mem://a").unwrap();

--- a/crates/lib3h/src/transport_wss/mod.rs
+++ b/crates/lib3h/src/transport_wss/mod.rs
@@ -360,7 +360,7 @@ impl<T: Read + Write + std::fmt::Debug + std::marker::Sized> TransportWss<T> {
     fn priv_process_accept(&mut self) -> DidWork {
         match &mut self.acceptor {
             Err(err) => {
-                println!("acceptor in error state: {:?}", err);
+                warn!("acceptor in error state: {:?}", err);
                 false
             }
             Ok(acceptor) => (acceptor)(self.n_id.clone())
@@ -370,7 +370,7 @@ impl<T: Read + Write + std::fmt::Debug + std::marker::Sized> TransportWss<T> {
                     true
                 })
                 .unwrap_or_else(|err| {
-                    println!("did not accept any connections: {:?}", err);
+                    warn!("did not accept any connections: {:?}", err);
                     false
                 }),
         }
@@ -422,7 +422,8 @@ impl<T: Read + Write + std::fmt::Debug + std::marker::Sized> TransportWss<T> {
         // move the socket out, to be replaced
         let socket = std::mem::replace(&mut info.stateful_socket, WebsocketStreamState::None);
 
-        println!("transport_wss: socket={:?}", socket);
+        debug!("transport_wss: socket={:?}", socket);
+        // TODO remove?
         std::io::stdout().flush().ok().expect("flush stdout");
         match socket {
             WebsocketStreamState::None => {

--- a/crates/lib3h/src/transport_wss/tcp.rs
+++ b/crates/lib3h/src/transport_wss/tcp.rs
@@ -27,14 +27,14 @@ impl TransportWss<std::net::TcpStream> {
         let host = url.host_str().expect("host name must be supplied");
         let port = url.port().unwrap_or(80);
         let formatted_url = format!("{}:{}", host, port);
-        println!("formatted url: {}", formatted_url);
+        debug!("formatted url: {}", formatted_url);
         TcpListener::bind(formatted_url)
             .map_err(|err| err.into())
             .and_then(move |listener: TcpListener| {
                 listener
                     .set_nonblocking(true)
                     .map_err(|err| {
-                        println!("transport_wss::tcp listener error: {:?}", err);
+                        error!("transport_wss::tcp listener error: {:?}", err);
                         err.into()
                     })
                     .map(|()| {
@@ -44,7 +44,7 @@ impl TransportWss<std::net::TcpStream> {
                                 listener
                                     .accept()
                                     .map_err(|err| {
-                                        println!("transport_wss::tcp accept error: {:?}", err);
+                                        error!("transport_wss::tcp accept error: {:?}", err);
                                         err.into()
                                     })
                                     .and_then(|(tcp_stream, socket_address)| {
@@ -54,13 +54,13 @@ impl TransportWss<std::net::TcpStream> {
                                             socket_address.port()
                                         );
 
-                                        println!(
+                                        debug!(
                                             "transport_wss::tcp v4 socket_address: {}",
                                             v4_socket_address
                                         );
                                         url::Url::parse(v4_socket_address.as_str())
                                             .map(|url| {
-                                                println!(
+                                                error!(
                                                     "transport_wss::tcp accepted for url {}",
                                                     url.clone()
                                                 );
@@ -71,7 +71,7 @@ impl TransportWss<std::net::TcpStream> {
                                                 )
                                             })
                                             .map_err(|err| {
-                                                println!("transport_wss::tcp url error: {:?}", err);
+                                                error!("transport_wss::tcp url error: {:?}", err);
                                                 err.into()
                                             })
                                     })

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -44,6 +44,17 @@ lazy_static! {
     ];
 }
 
+// for this to actually show log entries you also have to run the tests like this:
+// RUST_LOG=lib3h=debug cargo test -- --nocapture
+fn enable_logging_for_test(enable: bool) {
+    std::env::set_var("RUST_LOG", "trace");
+    let _ = env_logger::builder()
+        .default_format_timestamp(false)
+        .default_format_module_path(false)
+        .is_test(enable)
+        .try_init();
+}
+
 //--------------------------------------------------------------------------------------------------
 // Engine Setup
 //--------------------------------------------------------------------------------------------------
@@ -109,6 +120,7 @@ fn print_test_name(print_str: &str, test_fn: *mut std::os::raw::c_void) {
 
 #[test]
 fn basic_connect_test_mock() {
+    enable_logging_for_test(true);
     // Setup
     let mut engine_a = basic_setup_mock("basic_send_test_mock_node_a");
     let engine_b = basic_setup_mock("basic_send_test_mock_node_b");
@@ -136,6 +148,7 @@ fn basic_connect_test_mock() {
 
 #[test]
 fn basic_track_test_wss() {
+    enable_logging_for_test(true);
     // Setup
     let mut engine = basic_setup_wss();
     basic_track_test(&mut engine);
@@ -143,6 +156,7 @@ fn basic_track_test_wss() {
 
 #[test]
 fn basic_track_test_mock() {
+    enable_logging_for_test(true);
     // Setup
     let mut engine = basic_setup_mock("basic_track_test_mock");
     basic_track_test(&mut engine);
@@ -197,6 +211,7 @@ fn basic_track_test<T: Transport, D: Dht>(
 
 #[test]
 fn basic_two_nodes_mock() {
+    enable_logging_for_test(true);
     // Launch tests on each setup
     for (test_fn, can_setup) in TWO_NODES_BASIC_TEST_FNS.iter() {
         launch_two_nodes_test_with_memory_network(*test_fn, *can_setup).unwrap();


### PR DESCRIPTION
## PR summary

This PR adds the logging crate, and renames most debugging printlns to debug.  Also adds a sample function in `dht/mod.rs` for what's needed to activate logging for use during testing.

Questions during review:  
- should some of the `debug!` uses actually be `trace!`
- should some of the `error!` uses actually be `warn!`

closes #97

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
