### PR TITLE
tests for tls-optional

### DIFF
--- a/crates/lib3h/src/engine/mod.rs
+++ b/crates/lib3h/src/engine/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     dht::dht_trait::{Dht, DhtFactory},
     gateway::P2pGateway,
     transport::{transport_trait::Transport, ConnectionId},
+    transport_wss::TlsConfig,
 };
 
 use lib3h_crypto_api::{Buffer, CryptoSystem};
@@ -22,6 +23,7 @@ pub type ChainId = (Address, Address);
 /// Struct holding all config settings for the RealEngine
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct RealEngineConfig {
+    pub tls_config: TlsConfig,
     pub socket_type: String,
     pub bootstrap_nodes: Vec<String>,
     pub work_dir: String,

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -48,7 +48,9 @@ impl<D: Dht, SecBuf: Buffer, Crypto: CryptoSystem>
         name: &str,
         dht_factory: DhtFactory<D>,
     ) -> Lib3hResult<Self> {
-        let network_transport = Rc::new(RefCell::new(TransportWss::with_std_tcp_stream()));
+        let network_transport = Rc::new(RefCell::new(TransportWss::with_std_tcp_stream(
+            config.tls_config.clone(),
+        )));
         let binding = network_transport.borrow_mut().bind(&config.bind_url)?;
         let transport_keys = TransportKeys::new()?;
         let dht_config = DhtConfig {

--- a/crates/lib3h/src/transport/mod.rs
+++ b/crates/lib3h/src/transport/mod.rs
@@ -15,8 +15,11 @@ pub type ConnectionIdRef = str;
 pub mod tests {
     #![allow(non_snake_case)]
 
-    use crate::transport::{
-        memory_mock::transport_memory, protocol::TransportEvent, transport_trait::Transport,
+    use crate::{
+        transport::{
+            memory_mock::transport_memory, protocol::TransportEvent, transport_trait::Transport,
+        },
+        transport_wss::{TlsConfig, TransportWss},
     };
 
     use url::Url;
@@ -50,10 +53,20 @@ pub mod tests {
 
     #[test]
     fn wss_send_test() {
-        let mut node_A = crate::transport_wss::TransportWss::with_std_tcp_stream();
-        let mut node_B = crate::transport_wss::TransportWss::with_std_tcp_stream();
+        let mut node_A = TransportWss::with_std_tcp_stream(TlsConfig::Unencrypted);
+        let mut node_B = TransportWss::with_std_tcp_stream(TlsConfig::Unencrypted);
         let uri_A = Url::parse("wss://127.0.0.1:64529").unwrap();
         let uri_B = Url::parse("wss://127.0.0.1:64530").unwrap();
+
+        send_test(&mut node_A, &mut node_B, &uri_A, &uri_B);
+    }
+
+    #[test]
+    fn wss_send_test_tls() {
+        let mut node_A = TransportWss::with_std_tcp_stream(TlsConfig::FakeServer);
+        let mut node_B = TransportWss::with_std_tcp_stream(TlsConfig::FakeServer);
+        let uri_A = Url::parse("wss://127.0.0.1:64531").unwrap();
+        let uri_B = Url::parse("wss://127.0.0.1:64532").unwrap();
 
         send_test(&mut node_A, &mut node_B, &uri_A, &uri_B);
     }

--- a/crates/lib3h/src/transport_wss/tcp.rs
+++ b/crates/lib3h/src/transport_wss/tcp.rs
@@ -3,7 +3,9 @@
 
 use crate::{
     transport::error::TransportResult,
-    transport_wss::{Acceptor, Bind, ConnectionIdFactory, IdGenerator, TransportWss, WssInfo},
+    transport_wss::{
+        Acceptor, Bind, ConnectionIdFactory, IdGenerator, TlsConfig, TransportWss, WssInfo,
+    },
 };
 
 use std::net::{TcpListener, TcpStream};
@@ -11,7 +13,7 @@ use std::net::{TcpListener, TcpStream};
 impl TransportWss<std::net::TcpStream> {
     /// convenience constructor for creating a websocket "Transport"
     /// instance that is based of the rust std TcpStream
-    pub fn with_std_tcp_stream() -> Self {
+    pub fn with_std_tcp_stream(tls_config: TlsConfig) -> Self {
         let bind: Bind<TcpStream> = Box::new(move |url| Self::tcp_bind(url));
         TransportWss::new(
             |uri| {
@@ -20,6 +22,7 @@ impl TransportWss<std::net::TcpStream> {
                 Ok(socket)
             },
             bind,
+            tls_config,
         )
     }
 

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -10,7 +10,7 @@ use lib3h::{
     dht::{dht_trait::Dht, mirror_dht::MirrorDht},
     engine::{RealEngine, RealEngineConfig},
     transport::{memory_mock::transport_memory::TransportMemory, transport_trait::Transport},
-    transport_wss::TransportWss,
+    transport_wss::{TlsConfig, TransportWss},
 };
 use lib3h_crypto_api::{FakeCryptoSystem, InsecureBuffer};
 use lib3h_protocol::{
@@ -63,6 +63,7 @@ fn basic_setup_mock(
     name: &str,
 ) -> RealEngine<TransportMemory, MirrorDht, InsecureBuffer, FakeCryptoSystem> {
     let config = RealEngineConfig {
+        tls_config: TlsConfig::Unencrypted,
         socket_type: "mem".into(),
         bootstrap_nodes: vec![],
         work_dir: String::new(),
@@ -82,6 +83,7 @@ fn basic_setup_mock(
 fn basic_setup_wss(
 ) -> RealEngine<TransportWss<std::net::TcpStream>, MirrorDht, InsecureBuffer, FakeCryptoSystem> {
     let config = RealEngineConfig {
+        tls_config: TlsConfig::Unencrypted,
         socket_type: "ws".into(),
         bootstrap_nodes: vec![],
         work_dir: String::new(),


### PR DESCRIPTION
## PR summary

Promotes TlsConfig to RealEngine config so we can specify certificate or unencrypted. Adds unit tests excising TlsConfig.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
