### PR TITLE
logging cleanup

### DIFF
--- a/crates/lib3h/src/dht/mod.rs
+++ b/crates/lib3h/src/dht/mod.rs
@@ -6,23 +6,15 @@ pub mod rrdht;
 #[cfg(test)]
 pub mod tests {
 
-    use crate::dht::{dht_protocol::*, dht_trait::Dht, mirror_dht::MirrorDht, rrdht::RrDht};
+    use crate::{
+        dht::{dht_protocol::*, dht_trait::Dht, mirror_dht::MirrorDht, rrdht::RrDht},
+        tests::enable_logging_for_test,
+    };
     use lib3h_protocol::{
         data_types::{EntryAspectData, EntryData},
         Address, AddressRef,
     };
     use url::Url;
-
-    // for this to actually show log entries you also have to run the tests like this:
-    // RUST_LOG=lib3h=debug cargo test -- --nocapture
-    fn enable_logging_for_test(enable: bool) {
-        std::env::set_var("RUST_LOG", "debug");
-        let _ = env_logger::builder()
-            .default_format_timestamp(false)
-            .default_format_module_path(false)
-            .is_test(enable)
-            .try_init();
-    }
 
     /// CONSTS
     lazy_static! {

--- a/crates/lib3h/src/lib.rs
+++ b/crates/lib3h/src/lib.rs
@@ -25,3 +25,17 @@ pub mod engine;
 pub mod gateway;
 pub mod transport;
 pub mod transport_wss;
+
+#[cfg(test)]
+pub mod tests {
+    // for this to actually show log entries you also have to run the tests like this:
+    // RUST_LOG=lib3h=debug cargo test -- --nocapture
+    pub fn enable_logging_for_test(enable: bool) {
+        //std::env::set_var("RUST_LOG", "debug");
+        let _ = env_logger::builder()
+            .default_format_timestamp(false)
+            .default_format_module_path(false)
+            .is_test(enable)
+            .try_init();
+    }
+}

--- a/crates/lib3h/src/transport/mod.rs
+++ b/crates/lib3h/src/transport/mod.rs
@@ -22,23 +22,13 @@ pub mod tests {
         transport_wss::{TlsConfig, TransportWss},
     };
 
+    use crate::tests::enable_logging_for_test;
     use url::Url;
 
     // How many times to call process before asserting if work was done.
     // Empirically verified to work with just 6- raise this value
     // if your transport to be tested requires more iterations.
     const NUM_PROCESS_LOOPS: u8 = 6;
-
-    // for this to actually show log entries you also have to run the tests like this:
-    // RUST_LOG=lib3h=debug cargo test -- --nocapture
-    fn enable_logging_for_test(enable: bool) {
-        std::env::set_var("RUST_LOG", "debug");
-        let _ = env_logger::builder()
-            .default_format_timestamp(false)
-            .default_format_module_path(false)
-            .is_test(enable)
-            .try_init();
-    }
 
     #[test]
     fn memory_send_test() {

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -47,7 +47,7 @@ lazy_static! {
 // for this to actually show log entries you also have to run the tests like this:
 // RUST_LOG=lib3h=debug cargo test -- --nocapture
 fn enable_logging_for_test(enable: bool) {
-    std::env::set_var("RUST_LOG", "trace");
+    //std::env::set_var("RUST_LOG", "trace");
     let _ = env_logger::builder()
         .default_format_timestamp(false)
         .default_format_module_path(false)


### PR DESCRIPTION
## PR summary
a little bit of refactor from previous merged PR,

and

commented out set::env(RUST_LOG) in code because that makes it impossible to set the log level or limit log output to specific places from the command line as it overrides anything from there.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
