### PR TITLE
Release 0.0.3 alpha1

### DIFF
--- a/crates/crypto_api/Cargo.toml
+++ b/crates/crypto_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib3h_crypto_api"
-version = "0.0.2-alpha1"
+version = "0.0.3-alpha1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "lib3h abstract cryptography traits and data types"

--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib3h"
-version = "0.0.2-alpha1"
+version = "0.0.3-alpha1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 # crates.io stuff

--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
 hcid = "=0.0.6"
-lib3h_protocol = { path = "../lib3h_protocol", version = "=0.0.2-alpha1" }
+lib3h_protocol = { path = "../lib3h_protocol", version = "=0.0.3-alpha1" }
 lib3h_crypto_api = { path = "../crypto_api", version = "=0.0.2-alpha1" }
 tungstenite = "=0.6.1"
 url = "=1.7.2"

--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/holochain/lib3h"
 [dependencies]
 hcid = "=0.0.6"
 lib3h_protocol = { path = "../lib3h_protocol", version = "=0.0.3-alpha1" }
-lib3h_crypto_api = { path = "../crypto_api", version = "=0.0.2-alpha1" }
+lib3h_crypto_api = { path = "../crypto_api", version = "=0.0.3-alpha1" }
 tungstenite = "=0.6.1"
 url = "=1.7.2"
 url_serde = "=0.2.0"

--- a/crates/lib3h_protocol/Cargo.toml
+++ b/crates/lib3h_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib3h_protocol"
-version = "0.0.2-alpha1"
+version = "0.0.3-alpha1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 # crates.io stuff

--- a/crates/sodium/Cargo.toml
+++ b/crates/sodium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib3h_sodium"
-version = "0.0.2-alpha1"
+version = "0.0.3-alpha1"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "lib3h libsodium wrapper providing memory secure api access"
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/lib3h_sodium"
 repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
-lib3h_crypto_api = { path = "../crypto_api", version = "=0.0.2-alpha1" }
+lib3h_crypto_api = { path = "../crypto_api", version = "=0.0.3-alpha1" }
 lazy_static = "=1.2.0"
 libc = "=0.2.50"
 rust_sodium = "=0.10.2"


### PR DESCRIPTION
## PR summary

This PR just bumps the already published crate versions to `0.0.3-alpha1`, as is used by https://github.com/holochain/holochain-rust/pull/1566.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
