### PR TITLE
Mock: Hold entry

### DIFF
--- a/crates/lib3h/src/dht/dht_protocol.rs
+++ b/crates/lib3h/src/dht/dht_protocol.rs
@@ -8,7 +8,7 @@ pub enum DhtCommand {
     /// Owner received a gossip bundle from a remote peer, and asks us to handle it.
     HandleGossip(RemoteGossipBundleData),
     /// Owner wants a specific entry.
-    FetchEntry(FetchEntryData),
+    FetchEntry(FetchDhtEntryData),
     /// Owner wants us to hold a peer discovery data item.
     HoldPeer(PeerData),
     /// Owner notifies us that it is holding one or several Aspects for an Entry.
@@ -18,7 +18,7 @@ pub enum DhtCommand {
     /// Owner notifies us that is is not holding an entry anymore.
     DropEntryAddress(Address),
     /// Owner's response to ProvideEntry request
-    ProvideEntryResponse(FetchEntryResponseData),
+    EntryDataResponse(FetchDhtEntryResponseData),
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -38,9 +38,9 @@ pub enum DhtEvent {
     /// String argument is: from_peer_address
     HoldEntryRequested(FromPeerAddress, EntryData),
     /// DHT wants an entry in order to send it to someone on the network
-    ProvideEntry(FetchEntryData),
+    EntryDataRequested(FetchDhtEntryData),
     /// Response to a `FetchEntry` command.
-    FetchEntryResponse(FetchEntryResponseData),
+    FetchEntryResponse(FetchDhtEntryResponseData),
     /// Notify owner that we are no longer tracking this entry internally.
     /// Owner should purge this address from storage, but they can, of course, choose not to.
     EntryPruned(Address),
@@ -67,13 +67,13 @@ pub struct PeerData {
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
-pub struct FetchEntryData {
+pub struct FetchDhtEntryData {
     pub msg_id: String,
     pub entry_address: Address,
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
-pub struct FetchEntryResponseData {
+pub struct FetchDhtEntryResponseData {
     pub msg_id: String,
     pub entry: EntryData,
 }

--- a/crates/lib3h/src/dht/mod.rs
+++ b/crates/lib3h/src/dht/mod.rs
@@ -72,10 +72,10 @@ pub mod tests {
 
     #[allow(non_snake_case)]
     #[allow(dead_code)]
-    fn create_FetchEntry(entry_address: &AddressRef) -> FetchEntryData {
+    fn create_FetchEntry(entry_address: &AddressRef) -> FetchDhtEntryData {
         unsafe {
             FETCH_COUNT += 1;
-            FetchEntryData {
+            FetchDhtEntryData {
                 msg_id: format!("fetch_{}", FETCH_COUNT),
                 entry_address: entry_address.to_owned(),
             }
@@ -148,22 +148,21 @@ pub mod tests {
         let entry_address_list = dht.get_entry_address_list();
         assert_eq!(entry_address_list.len(), 1);
         // Fetch it
-        let fetch_entry = FetchEntryData {
+        let fetch_entry = FetchDhtEntryData {
             msg_id: "fetch_1".to_owned(),
             entry_address: ENTRY_ADDRESS_1.clone(),
         };
         dht.post(DhtCommand::FetchEntry(fetch_entry)).unwrap();
         let (_did_work, event_list) = dht.process().unwrap();
         assert_eq!(event_list.len(), 1);
-        let provide_entry = unwrap_to!(event_list[0] => DhtEvent::ProvideEntry);
+        let provide_entry = unwrap_to!(event_list[0] => DhtEvent::EntryDataRequested);
         // Make something up
         let entry = create_EntryData(&ENTRY_ADDRESS_1, &ASPECT_ADDRESS_1, &ASPECT_CONTENT_1);
-        let response = FetchEntryResponseData {
+        let response = FetchDhtEntryResponseData {
             msg_id: provide_entry.msg_id.clone(),
             entry: entry.clone(),
         };
-        dht.post(DhtCommand::ProvideEntryResponse(response))
-            .unwrap();
+        dht.post(DhtCommand::EntryDataResponse(response)).unwrap();
         let (_did_work, event_list) = dht.process().unwrap();
         // Should have it
         assert_eq!(event_list.len(), 1);

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -70,7 +70,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
             DhtEvent::EntryPruned(_address) => {
                 // FIXME
             }
-            DhtEvent::ProvideEntry(_) => {
+            DhtEvent::EntryDataRequested(_) => {
                 // FIXME
             }
         }

--- a/crates/lib3h/src/engine/space_layer.rs
+++ b/crates/lib3h/src/engine/space_layer.rs
@@ -124,21 +124,29 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                     .entry
                     .serialize(&mut Serializer::new(&mut query_result))
                     .unwrap();
-                let lib3h_msg = Lib3hServerProtocol::QueryEntryResult(QueryEntryResultData {
+                let msg_data = QueryEntryResultData {
                     space_address: chain_id.0.clone(),
                     entry_address: response.entry.entry_address.clone(),
                     request_id: response.msg_id.clone(),
                     requester_agent_id: chain_id.1.clone(), // TODO: get requester with channel from p2p protocol
                     responder_agent_id: chain_id.1.clone(),
                     query_result,
-                });
-                outbox.push(lib3h_msg)
+                };
+                outbox.push(Lib3hServerProtocol::QueryEntryResult(msg_data))
             }
             DhtEvent::EntryPruned(_address) => {
                 // FIXME
             }
-            DhtEvent::ProvideEntry(_) => {
-                // FIXME
+            // EntryDataRequested: Change it into a Lib3hServerProtocol::HandleFetchEntry.
+            DhtEvent::EntryDataRequested(fetch_entry) => {
+                let msg_data = FetchEntryData {
+                    space_address: chain_id.0.clone(),
+                    entry_address: fetch_entry.entry_address.clone(),
+                    request_id: fetch_entry.msg_id.clone(),
+                    provider_agent_id: chain_id.1.clone(),
+                    aspect_address_list: None,
+                };
+                outbox.push(Lib3hServerProtocol::HandleFetchEntry(msg_data))
             }
         }
         Ok(outbox)

--- a/crates/lib3h/src/gateway/gateway_dht.rs
+++ b/crates/lib3h/src/gateway/gateway_dht.rs
@@ -114,7 +114,7 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
             DhtEvent::EntryPruned(_address) => {
                 // FIXME
             }
-            DhtEvent::ProvideEntry(_) => {
+            DhtEvent::EntryDataRequested(_) => {
                 // FIXME
             }
         }

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -127,10 +127,10 @@ type TwoNodesTestFn = fn(alex: &mut NodeMock, billy: &mut NodeMock);
 
 lazy_static! {
     pub static ref TWO_NODES_BASIC_TEST_FNS: Vec<(TwoNodesTestFn, bool)> = vec![
-        //(setup_only, true),
-        //(two_nodes_send_message, true),
+        (setup_only, true),
+        (two_nodes_send_message, true),
         (two_nodes_dht_publish_test, true),
-        //(two_nodes_dht_hold_test, true),
+        (two_nodes_dht_hold_test, true),
     ];
 }
 


### PR DESCRIPTION
## PR summary
Solves #127 
Requires #142 

Renamed `FetchEntryData` to `FetchDhtEntryData` because of name collision between DHT and lib3h protocols.

Renamed `DhtEvent::ProvideEntry` to `DhtEvent::EntryDataRequested` because I think its clearer if DhtCommands start with a verb and DhtEvents don't, but I'm not holding this tightly. Whats your preference @neonphog ?

Renamed `dht_test` to `dht_publish_test` and added `dht_hold_test`.

### Sequence

[rendered in hackmd](https://hackmd.io/8foiDSBFTKOZgZaKaHfuqg?view)
```mermaid
sequenceDiagram
    participant ca as Core A  
    participant na as NetEngine A 
    participant da as spaceGateway A  
    ca->>na: Lib3hClientProtocol::HoldEntry(entry, spaceA)
    na->>na: get_space(spaceA, agentA)    
    na->>da: DhtCommand::HoldEntryAddress(addr)
    da->>na: DhtEvent::EntryDataRequested(addr)
    na->>ca: Lib3hServerProtocol::HandleFetchEntry(addr)
    ca->>na: Lib3hClientProtocol::HandleFetchEntryResult(entry)
    na->>da: DhtCommand::EntryDataResponse(entry)
    da->>na: DhtEvent::GossipTo(entry, all)
```


## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
