### PR TITLE
Mock: Get*Lists

### DIFF
--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -180,12 +180,13 @@ impl MirrorDht {
                     MirrorGossip::Entry(entry) => {
                         let _is_new = self.add_entry_address(&entry.entry_address);
                         // TODO - since aspects are not tracked, act as if there is always new data
-                        //if is_new {
-                        //    return Ok(vec![DhtEvent::HoldEntryRequested(
-                        //        self.this_peer.peer_address.clone(),
-                        //        entry,
-                        //    )]);
-                        //}
+                        let is_new = true;
+                        if is_new {
+                            return Ok(vec![DhtEvent::HoldEntryRequested(
+                                self.this_peer.peer_address.clone(),
+                                entry,
+                            )]);
+                        }
                         return Ok(vec![]);
                     }
                     MirrorGossip::Peer(peer) => {

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -178,13 +178,14 @@ impl MirrorDht {
                 }
                 match maybe_gossip.unwrap() {
                     MirrorGossip::Entry(entry) => {
-                        let is_new = self.add_entry_address(&entry.entry_address);
-                        if is_new {
-                            return Ok(vec![DhtEvent::HoldEntryRequested(
-                                self.this_peer.peer_address.clone(),
-                                entry,
-                            )]);
-                        }
+                        let _is_new = self.add_entry_address(&entry.entry_address);
+                        // TODO - since aspects are not tracked, act as if there is always new data
+                        //if is_new {
+                        //    return Ok(vec![DhtEvent::HoldEntryRequested(
+                        //        self.this_peer.peer_address.clone(),
+                        //        entry,
+                        //    )]);
+                        //}
                         return Ok(vec![]);
                     }
                     MirrorGossip::Peer(peer) => {
@@ -273,11 +274,12 @@ impl MirrorDht {
             // Bookkeep address and gossip entry to every known peer.
             DhtCommand::BroadcastEntry(entry) => {
                 // Store address
-                let received_new_content = self.add_entry_address(&entry.entry_address.clone());
-                // Bail if did not receive new content
-                if !received_new_content {
-                    return Ok(vec![]);
-                }
+                let _received_new_content = self.add_entry_address(&entry.entry_address.clone());
+                // TODO - since aspects are not tracked, act as if there is always new data
+                //// Bail if did not receive new content
+                //if !received_new_content {
+                //    return Ok(vec![]);
+                //}
                 let gossip_evt = self.gossip_entry(entry);
                 // Done
                 Ok(vec![gossip_evt])

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -418,18 +418,11 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                         // let known_entries = space_gateway.get_entry_address_list();
                         let mut count = 0;
                         for (entry_address, _) in msg.address_map {
-                            //                            if known_entries.contains(entry_address) {
-                            //                                continue;
-                            //                            }
                             count += 1;
-                            // msg_data.request_id = format!("{}_{}", msg.request_id, count);
                             msg_data.entry_address = entry_address.clone();
                             outbox.push(Lib3hServerProtocol::HandleFetchEntry(msg_data.clone()));
                         }
-                        debug!(
-                            "HandleGetAuthoringEntryListResult: sent {} HandleFetchEntry",
-                            count
-                        );
+                        debug!("HandleGetAuthoringEntryListResult: {}", count);
                     }
                 }
             }

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -297,6 +297,8 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                 match maybe_space {
                     Err(res) => outbox.push(res),
                     Ok(space_gateway) => {
+                        // TODO: create a rust equivalent of
+                        // https://github.com/holochain/n3h/blob/master/lib/n3h-common/track.js
                         if msg.request_id == "__author_list" {
                             let cmd = DhtCommand::BroadcastEntry(msg.entry);
                             space_gateway.post_dht(cmd)?;
@@ -463,6 +465,8 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
             res.result_info = "Already joined space".to_string().into_bytes();
             return Ok(vec![Lib3hServerProtocol::FailureResult(res)]);
         }
+        let mut output = Vec::new();
+        output.push(Lib3hServerProtocol::SuccessResult(res));
         // First create DhtConfig for space gateway
         let agent_id = std::string::String::from_utf8_lossy(&join_msg.agent_id).into_owned();
         let this_net_peer = self.network_gateway.borrow().this_peer().clone();
@@ -514,7 +518,6 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
             }),
         )?;
         // Send Get*Lists requests
-        let mut output = Vec::new();
         let mut list_data = GetListData {
             space_address: join_msg.space_address.clone(),
             provider_agent_id: join_msg.agent_id.clone(),
@@ -526,7 +529,6 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
         list_data.request_id = "authoring".to_owned();
         output.push(Lib3hServerProtocol::HandleGetAuthoringEntryList(list_data));
         // Done
-        output.push(Lib3hServerProtocol::SuccessResult(res));
         Ok(output)
     }
 

--- a/crates/lib3h/src/lib.rs
+++ b/crates/lib3h/src/lib.rs
@@ -32,7 +32,7 @@ pub mod tests {
     // RUST_LOG=lib3h=debug cargo test -- --nocapture
     pub fn enable_logging_for_test(enable: bool) {
         if std::env::var("RUST_LOG").is_err() {
-            std::env::set_var("RUST_LOG", "trace");
+            std::env::set_var("RUST_LOG", "debug");
         }
         let _ = env_logger::builder()
             .default_format_timestamp(false)

--- a/crates/lib3h/src/lib.rs
+++ b/crates/lib3h/src/lib.rs
@@ -31,7 +31,9 @@ pub mod tests {
     // for this to actually show log entries you also have to run the tests like this:
     // RUST_LOG=lib3h=debug cargo test -- --nocapture
     pub fn enable_logging_for_test(enable: bool) {
-        //std::env::set_var("RUST_LOG", "debug");
+        if std::env::var("RUST_LOG").is_err() {
+            std::env::set_var("RUST_LOG", "trace");
+        }
         let _ = env_logger::builder()
             .default_format_timestamp(false)
             .default_format_module_path(false)

--- a/crates/lib3h/tests/engine_test.rs
+++ b/crates/lib3h/tests/engine_test.rs
@@ -181,9 +181,7 @@ fn basic_track_test<T: Transport, D: Dht>(
     let (did_work, srv_msg_list) = engine.process().unwrap();
     assert!(did_work);
     assert_eq!(srv_msg_list.len(), 3);
-    let _ = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::HandleGetGossipingEntryList);
-    let _ = unwrap_to!(srv_msg_list[1] => Lib3hServerProtocol::HandleGetAuthoringEntryList);
-    let res_msg = unwrap_to!(srv_msg_list[2] => Lib3hServerProtocol::SuccessResult);
+    let res_msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::SuccessResult);
     assert_eq!(res_msg.request_id, "track_a_1".to_string());
     assert_eq!(res_msg.space_address, SPACE_ADDRESS_A.as_slice());
     assert_eq!(res_msg.to_agent_id, ALEX_AGENT_ID.as_slice());
@@ -191,6 +189,8 @@ fn basic_track_test<T: Transport, D: Dht>(
         "SuccessResult info: {}",
         std::str::from_utf8(res_msg.result_info.as_slice()).unwrap()
     );
+    let _ = unwrap_to!(srv_msg_list[1] => Lib3hServerProtocol::HandleGetGossipingEntryList);
+    let _ = unwrap_to!(srv_msg_list[2] => Lib3hServerProtocol::HandleGetAuthoringEntryList);
     // Track same again, should fail
     track_space.request_id = "track_a_2".into();
     engine

--- a/crates/lib3h/tests/engine_test.rs
+++ b/crates/lib3h/tests/engine_test.rs
@@ -180,8 +180,10 @@ fn basic_track_test<T: Transport, D: Dht>(
         .unwrap();
     let (did_work, srv_msg_list) = engine.process().unwrap();
     assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 1);
-    let res_msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::SuccessResult);
+    assert_eq!(srv_msg_list.len(), 3);
+    let _ = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::HandleGetGossipingEntryList);
+    let _ = unwrap_to!(srv_msg_list[1] => Lib3hServerProtocol::HandleGetAuthoringEntryList);
+    let res_msg = unwrap_to!(srv_msg_list[2] => Lib3hServerProtocol::SuccessResult);
     assert_eq!(res_msg.request_id, "track_a_1".to_string());
     assert_eq!(res_msg.space_address, SPACE_ADDRESS_A.as_slice());
     assert_eq!(res_msg.to_agent_id, ALEX_AGENT_ID.as_slice());

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -26,7 +26,7 @@ use lib3h::{
 use lib3h_crypto_api::{FakeCryptoSystem, InsecureBuffer};
 use lib3h_protocol::{network_engine::NetworkEngine, Address, Lib3hResult};
 use node_mock::NodeMock;
-use test_suites::two_basic::*;
+use test_suites::{two_basic::*, two_get_lists::*};
 use url::Url;
 use utils::constants::*;
 
@@ -110,7 +110,8 @@ fn print_two_nodes_test_name(print_str: &str, test_fn: TwoNodesTestFn) {
 fn print_test_name(print_str: &str, test_fn: *mut std::os::raw::c_void) {
     backtrace::resolve(test_fn, |symbol| {
         let mut full_name = symbol.name().unwrap().as_str().unwrap().to_string();
-        let mut test_name = full_name.split_off("integration_test::".to_string().len());
+        let mut test_name =
+            full_name.split_off("integration_test::test_suites::".to_string().len());
         test_name.push_str("()");
         println!("{}{}", print_str, test_name);
     });
@@ -121,9 +122,17 @@ fn print_test_name(print_str: &str, test_fn: *mut std::os::raw::c_void) {
 //--------------------------------------------------------------------------------------------------
 
 #[test]
-fn test_two_memory_nodes_suite() {
+fn test_two_memory_nodes_basic_suite() {
     enable_logging_for_test(true);
     for (test_fn, can_setup) in TWO_NODES_BASIC_TEST_FNS.iter() {
+        launch_two_memory_nodes_test(*test_fn, *can_setup).unwrap();
+    }
+}
+
+#[test]
+fn test_two_memory_nodes_get_lists_suite() {
+    enable_logging_for_test(true);
+    for (test_fn, can_setup) in TWO_NODES_GET_LISTS_TEST_FNS.iter() {
         launch_two_memory_nodes_test(*test_fn, *can_setup).unwrap();
     }
 }
@@ -132,7 +141,7 @@ fn test_two_memory_nodes_suite() {
 fn launch_two_memory_nodes_test(test_fn: TwoNodesTestFn, can_setup: bool) -> Result<(), ()> {
     println!("");
     print_two_nodes_test_name("IN-MEMORY TWO NODES TEST: ", test_fn);
-    println!("=======================");
+    println!("========================");
 
     // Setup
     let mut alex = setup_memory_node("alex", ALEX_AGENT_ID.clone());

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -15,6 +15,7 @@ extern crate lib3h_protocol;
 extern crate multihash;
 
 mod node_mock;
+mod test_suites;
 
 use lib3h::{
     dht::mirror_dht::MirrorDht,
@@ -23,13 +24,9 @@ use lib3h::{
     transport_wss::TlsConfig,
 };
 use lib3h_crypto_api::{FakeCryptoSystem, InsecureBuffer};
-use lib3h_protocol::{
-    data_types::*, network_engine::NetworkEngine, protocol_server::Lib3hServerProtocol, Address,
-    Lib3hResult,
-};
+use lib3h_protocol::{network_engine::NetworkEngine, Address, Lib3hResult};
 use node_mock::NodeMock;
-use rmp_serde::Deserializer;
-use serde::Deserialize;
+use test_suites::two_basic::*;
 use url::Url;
 use utils::constants::*;
 
@@ -120,21 +117,6 @@ fn print_test_name(print_str: &str, test_fn: *mut std::os::raw::c_void) {
 }
 
 //--------------------------------------------------------------------------------------------------
-// Test Suites
-//--------------------------------------------------------------------------------------------------
-
-type TwoNodesTestFn = fn(alex: &mut NodeMock, billy: &mut NodeMock);
-
-lazy_static! {
-    pub static ref TWO_NODES_BASIC_TEST_FNS: Vec<(TwoNodesTestFn, bool)> = vec![
-        (setup_only, true),
-        (two_nodes_send_message, true),
-        (two_nodes_dht_publish_test, true),
-        (two_nodes_dht_hold_test, true),
-    ];
-}
-
-//--------------------------------------------------------------------------------------------------
 // Test launchers
 //--------------------------------------------------------------------------------------------------
 
@@ -170,200 +152,4 @@ fn launch_two_memory_nodes_test(test_fn: TwoNodesTestFn, can_setup: bool) -> Res
     billy.stop();
 
     Ok(())
-}
-
-//--------------------------------------------------------------------------------------------------
-// Test setup
-//--------------------------------------------------------------------------------------------------
-
-///
-fn setup_two_nodes(alex: &mut NodeMock, billy: &mut NodeMock) {
-    // Start
-    alex.run();
-    billy.run();
-
-    // Connect Alex to Billy
-    alex.connect_to(&billy.advertise()).unwrap();
-
-    let (did_work, srv_msg_list) = alex.process().unwrap();
-    assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 1);
-    let connected_msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::Connected);
-    println!("connected_msg = {:?}", connected_msg);
-    assert_eq!(&connected_msg.uri, &billy.advertise());
-    // More process: Have Billy process P2p::PeerAddress of alex
-    let (_did_work, _srv_msg_list) = billy.process().unwrap();
-    let (_did_work, _srv_msg_list) = alex.process().unwrap();
-
-    // Alex joins space A
-    alex.join_space(&SPACE_ADDRESS_A.clone(), true).unwrap();
-    let (_did_work, _srv_msg_list) = alex.process().unwrap();
-    let (_did_work, _srv_msg_list) = billy.process().unwrap();
-
-    // Billy joins space A
-    billy.join_space(&SPACE_ADDRESS_A.clone(), true).unwrap();
-    let (_did_work, _srv_msg_list) = billy.process().unwrap();
-    let (_did_work, _srv_msg_list) = alex.process().unwrap();
-
-    let (_did_work, _srv_msg_list) = billy.process().unwrap();
-
-    println!("DONE setup_two_nodes() DONE \n\n\n");
-}
-
-//--------------------------------------------------------------------------------------------------
-// Tests
-//--------------------------------------------------------------------------------------------------
-
-/// Empty function that triggers the test suite
-fn setup_only(_alex: &mut NodeMock, _billy: &mut NodeMock) {
-    // n/a
-}
-
-/// Test SendDirectMessage and response
-fn two_nodes_send_message(alex: &mut NodeMock, billy: &mut NodeMock) {
-    // Send DM
-    let req_id = alex.send_direct_message(&BILLY_AGENT_ID, "wah".as_bytes().to_vec());
-    let (did_work, srv_msg_list) = alex.process().unwrap();
-    assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 0);
-    // Receive
-    let (did_work, srv_msg_list) = billy.process().unwrap();
-    assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 1);
-    let msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::HandleSendDirectMessage);
-    assert_eq!(msg.request_id, req_id);
-    let content = std::str::from_utf8(msg.content.as_slice()).unwrap();
-    println!("HandleSendDirectMessage: {}", content);
-
-    // Send response
-    let response_content = format!("echo: {}", content).as_bytes().to_vec();
-    billy.send_response(&req_id, &alex.agent_id, response_content.clone());
-    let (did_work, srv_msg_list) = billy.process().unwrap();
-    assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 0);
-    // Receive response
-    let (did_work, srv_msg_list) = alex.process().unwrap();
-    assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 1);
-    let msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::SendDirectMessageResult);
-    let content = std::str::from_utf8(msg.content.as_slice()).unwrap();
-    println!("SendDirectMessageResult: {}", content);
-    assert_eq!(msg.content, response_content);
-}
-
-/// Test publish, Store, Query
-fn two_nodes_dht_publish_test(alex: &mut NodeMock, billy: &mut NodeMock) {
-    // Alex publish data on the network
-    alex.author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
-        .unwrap();
-    let (did_work, srv_msg_list) = alex.process().unwrap();
-    assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 0);
-
-    // #fullsync
-    // Alex or Billy should receive the entry store request
-    let store_result = billy.wait(Box::new(one_is!(
-        Lib3hServerProtocol::HandleStoreEntryAspect(_)
-    )));
-    assert!(store_result.is_some());
-    println!("\n got HandleStoreEntryAspect: {:?}", store_result);
-    // Process the HoldEntry generated from receiving the HandleStoreEntryAspect
-    let (did_work, _srv_msg_list) = billy.process().unwrap();
-    assert!(did_work);
-
-    // Billy asks for that entry
-    // ==========================
-    println!("\nBilly requesting entry: ENTRY_ADDRESS_1\n");
-    let query_data = billy.request_entry(ENTRY_ADDRESS_1.clone());
-    let (_did_work, _srv_msg_list) = billy.process().unwrap();
-    assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 0);
-
-    println!("\nBilly reply to own request:\n");
-
-    // #fullsync
-    // Billy sends that data back to the network
-    let _ = billy.reply_to_HandleQueryEntry(&query_data).unwrap();
-    let (did_work, srv_msg_list) = billy.process().unwrap();
-    println!("\nBilly gets own response {:?}\n", srv_msg_list);
-    assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 1);
-    let msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::QueryEntryResult);
-    assert_eq!(&msg.entry_address, &*ENTRY_ADDRESS_1);
-    let mut de = Deserializer::new(&msg.query_result[..]);
-    let maybe_entry: Result<EntryData, rmp_serde::decode::Error> =
-        Deserialize::deserialize(&mut de);
-    assert_eq!(
-        &maybe_entry.unwrap().aspect_list[0].aspect,
-        &*ASPECT_CONTENT_1
-    );
-
-    // Billy asks for unknown entry
-    // ============================
-    let query_data = billy.request_entry(ENTRY_ADDRESS_2.clone());
-    let res = alex.reply_to_HandleQueryEntry(&query_data);
-    println!("\nAlex gives response {:?}\n", res);
-    assert!(res.is_err());
-    let res_data: GenericResultData = res.err().unwrap();
-    let res_info = std::str::from_utf8(res_data.result_info.as_slice()).unwrap();
-    assert_eq!(res_info, "No entry found");
-}
-
-/// Test Hold & Query
-fn two_nodes_dht_hold_test(alex: &mut NodeMock, billy: &mut NodeMock) {
-    // Alex holds an entry
-    alex.hold_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
-        .unwrap();
-    let (did_work, srv_msg_list) = alex.process().unwrap();
-    assert!(did_work);
-
-    // #fullsync
-    // mirrorDht wants the entry to broadcast it
-    assert_eq!(srv_msg_list.len(), 1);
-    let msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::HandleFetchEntry);
-    assert_eq!(&msg.entry_address, &*ENTRY_ADDRESS_1);
-    alex.reply_to_HandleFetchEntry(msg).unwrap();
-    let (did_work, srv_msg_list) = alex.process().unwrap();
-    assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 0);
-    // Process the HoldEntry generated from receiving HandleStoreEntryAspect
-    let (did_work, _srv_msg_list) = billy.process().unwrap();
-    assert!(did_work);
-
-    // Billy asks for that entry
-    // =========================
-    println!("\nBilly requesting entry: ENTRY_ADDRESS_1\n");
-    let query_data = billy.request_entry(ENTRY_ADDRESS_1.clone());
-    let (_did_work, _srv_msg_list) = billy.process().unwrap();
-    assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 0);
-
-    // #fullsync
-    // Billy sends that data back to the network
-    println!("\nBilly reply to own request\n",);
-    let _ = billy.reply_to_HandleQueryEntry(&query_data).unwrap();
-    let (did_work, srv_msg_list) = billy.process().unwrap();
-    println!("\nBilly gets own response {:?}\n", srv_msg_list);
-    assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 1);
-    let msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::QueryEntryResult);
-    assert_eq!(&msg.entry_address, &*ENTRY_ADDRESS_1);
-    let mut de = Deserializer::new(&msg.query_result[..]);
-    let maybe_entry: Result<EntryData, rmp_serde::decode::Error> =
-        Deserialize::deserialize(&mut de);
-    assert_eq!(
-        &maybe_entry.unwrap().aspect_list[0].aspect,
-        &*ASPECT_CONTENT_1
-    );
-
-    // Billy asks for unknown entry
-    // ============================
-    println!("\nBilly requesting unknown entry:\n");
-    let query_data = billy.request_entry(ENTRY_ADDRESS_2.clone());
-    let res = alex.reply_to_HandleQueryEntry(&query_data);
-    println!("\nAlex gives response {:?}\n", res);
-    assert!(res.is_err());
-    let res_data: GenericResultData = res.err().unwrap();
-    let res_info = std::str::from_utf8(res_data.result_info.as_slice()).unwrap();
-    assert_eq!(res_info, "No entry found");
 }

--- a/crates/lib3h/tests/node_mock/chain_store.rs
+++ b/crates/lib3h/tests/node_mock/chain_store.rs
@@ -30,12 +30,14 @@ impl ChainStore {
         // Append what we have in `authored_entry_store`
         let maybe_entry_store = self.authored_entry_store.get(&entry_address);
         if let Some(mut local_entry) = maybe_entry_store {
+            // println!("ChainStore.get_entry: authored_entry_store has {}", local_entry.aspect_list.len());
             entry.aspect_list.append(&mut local_entry.aspect_list);
             has_aspects = true;
         }
         // Append what we have in `stored_entry_store`
         let maybe_entry_store = self.stored_entry_store.get(&entry_address);
         if let Some(mut local_entry) = maybe_entry_store {
+            // println!("ChainStore.get_entry: stored_entry_store has {}", local_entry.aspect_list.len());
             entry.aspect_list.append(&mut local_entry.aspect_list);
             has_aspects = true;
         }

--- a/crates/lib3h/tests/node_mock/methods.rs
+++ b/crates/lib3h/tests/node_mock/methods.rs
@@ -485,8 +485,11 @@ impl NodeMock {
             .expect("Reply to HandleGetAuthoringEntryList failed.");
     }
 
-    /// Reply to a HandleGetHoldingEntryList request
-    pub fn reply_to_HandleGetHoldingEntryList(&mut self, request: &GetListData) -> Lib3hResult<()> {
+    /// Reply to a HandleGetGossipingEntryList request
+    pub fn reply_to_HandleGetGossipingEntryList(
+        &mut self,
+        request: &GetListData,
+    ) -> Lib3hResult<()> {
         assert!(self.current_space.is_some());
         let current_space = self.current_space.clone().unwrap();
         assert_eq!(request.space_address, current_space);
@@ -515,8 +518,8 @@ impl NodeMock {
         self.engine
             .post(Lib3hClientProtocol::HandleGetGossipingEntryListResult(msg).into())
     }
-    /// Look for the first HandleGetHoldingEntryList request received from network module and reply
-    pub fn reply_to_first_HandleGetHoldingEntryList(&mut self) {
+    /// Look for the first HandleGetGossipingEntryList request received from network module and reply
+    pub fn reply_to_first_HandleGetGossipingEntryList(&mut self) {
         let request = self
             .find_recv_msg(
                 0,
@@ -526,7 +529,7 @@ impl NodeMock {
         // extract request data
         let get_list_data = unwrap_to!(request => Lib3hServerProtocol::HandleGetGossipingEntryList);
         // reply
-        self.reply_to_HandleGetHoldingEntryList(&get_list_data)
+        self.reply_to_HandleGetGossipingEntryList(&get_list_data)
             .expect("Reply to HandleGetHoldingEntryList failed.");
     }
 }

--- a/crates/lib3h/tests/node_mock/methods.rs
+++ b/crates/lib3h/tests/node_mock/methods.rs
@@ -381,12 +381,14 @@ impl NodeMock {
             };
             return Err(msg_data);
         }
+        let entry = maybe_entry.unwrap();
+        // println!("\n reply_to_HandleFetchEntry_inner({}) = {:?}\n", entry.aspect_list.len(), entry.clone());
         // Send EntryData as binary
         let fetch_result_data = FetchEntryResultData {
             space_address: fetch.space_address.clone(),
             provider_agent_id: fetch.provider_agent_id.clone(),
             request_id: fetch.request_id.clone(),
-            entry: maybe_entry.unwrap(),
+            entry,
         };
         Ok(fetch_result_data)
     }

--- a/crates/lib3h/tests/node_mock/mod.rs
+++ b/crates/lib3h/tests/node_mock/mod.rs
@@ -29,6 +29,7 @@ pub struct NodeMock {
     pub agent_id: Address,
     /// The node's uri
     my_advertise: Url,
+    pub name: String,
 
     /// Sent messages logs
     request_log: Vec<String>,
@@ -72,6 +73,7 @@ impl NodeMock {
             joined_space_list: HashSet::new(),
             current_space: None,
             my_advertise,
+            name: name.to_string(),
         }
     }
 }

--- a/crates/lib3h/tests/test_suites/mod.rs
+++ b/crates/lib3h/tests/test_suites/mod.rs
@@ -1,1 +1,2 @@
 pub mod two_basic;
+pub mod two_get_lists;

--- a/crates/lib3h/tests/test_suites/mod.rs
+++ b/crates/lib3h/tests/test_suites/mod.rs
@@ -1,0 +1,1 @@
+pub mod two_basic;

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -1,5 +1,5 @@
 use crate::{node_mock::NodeMock, utils::constants::*};
-use lib3h_protocol::{data_types::*, protocol_server::Lib3hServerProtocol, Lib3hResult};
+use lib3h_protocol::{data_types::*, protocol_server::Lib3hServerProtocol};
 use rmp_serde::Deserializer;
 use serde::Deserialize;
 
@@ -70,7 +70,7 @@ pub fn request_entry_1(node: &mut NodeMock) {
     let (did_work, srv_msg_list) = node.process().unwrap();
     println!("\n{} gets own response {:?}\n", node.name, srv_msg_list);
     assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 1);
+    assert_eq!(srv_msg_list.len(), 1, "{:?}", srv_msg_list);
     let msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::QueryEntryResult);
     assert_eq!(&msg.entry_address, &*ENTRY_ADDRESS_1);
     let mut de = Deserializer::new(&msg.query_result[..]);

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -1,0 +1,211 @@
+use super::super::{node_mock::NodeMock, utils::constants::*};
+use lib3h_protocol::{data_types::*, protocol_server::Lib3hServerProtocol};
+use rmp_serde::Deserializer;
+use serde::Deserialize;
+
+pub type TwoNodesTestFn = fn(alex: &mut NodeMock, billy: &mut NodeMock);
+
+lazy_static! {
+    pub static ref TWO_NODES_BASIC_TEST_FNS: Vec<(TwoNodesTestFn, bool)> = vec![
+        (setup_only, true),
+        (two_nodes_send_message, true),
+        (two_nodes_dht_publish_test, true),
+        (two_nodes_dht_hold_test, true),
+    ];
+}
+
+//--------------------------------------------------------------------------------------------------
+// Test setup
+//--------------------------------------------------------------------------------------------------
+
+///
+pub fn setup_two_nodes(alex: &mut NodeMock, billy: &mut NodeMock) {
+    // Start
+    alex.run();
+    billy.run();
+
+    // Connect Alex to Billy
+    alex.connect_to(&billy.advertise()).unwrap();
+
+    let (did_work, srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 1);
+    let connected_msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::Connected);
+    println!("connected_msg = {:?}", connected_msg);
+    assert_eq!(&connected_msg.uri, &billy.advertise());
+    // More process: Have Billy process P2p::PeerAddress of alex
+    let (_did_work, _srv_msg_list) = billy.process().unwrap();
+    let (_did_work, _srv_msg_list) = alex.process().unwrap();
+
+    // Alex joins space A
+    alex.join_space(&SPACE_ADDRESS_A.clone(), true).unwrap();
+    let (_did_work, _srv_msg_list) = alex.process().unwrap();
+    let (_did_work, _srv_msg_list) = billy.process().unwrap();
+
+    // Billy joins space A
+    billy.join_space(&SPACE_ADDRESS_A.clone(), true).unwrap();
+    let (_did_work, _srv_msg_list) = billy.process().unwrap();
+    let (_did_work, _srv_msg_list) = alex.process().unwrap();
+
+    let (_did_work, _srv_msg_list) = billy.process().unwrap();
+
+    println!("DONE setup_two_nodes() DONE \n\n\n");
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+/// Empty function that triggers the test suite
+fn setup_only(_alex: &mut NodeMock, _billy: &mut NodeMock) {
+    // n/a
+}
+
+/// Test SendDirectMessage and response
+fn two_nodes_send_message(alex: &mut NodeMock, billy: &mut NodeMock) {
+    // Send DM
+    let req_id = alex.send_direct_message(&BILLY_AGENT_ID, "wah".as_bytes().to_vec());
+    let (did_work, srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 0);
+    // Receive
+    let (did_work, srv_msg_list) = billy.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 1);
+    let msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::HandleSendDirectMessage);
+    assert_eq!(msg.request_id, req_id);
+    let content = std::str::from_utf8(msg.content.as_slice()).unwrap();
+    println!("HandleSendDirectMessage: {}", content);
+
+    // Send response
+    let response_content = format!("echo: {}", content).as_bytes().to_vec();
+    billy.send_response(&req_id, &alex.agent_id, response_content.clone());
+    let (did_work, srv_msg_list) = billy.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 0);
+    // Receive response
+    let (did_work, srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 1);
+    let msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::SendDirectMessageResult);
+    let content = std::str::from_utf8(msg.content.as_slice()).unwrap();
+    println!("SendDirectMessageResult: {}", content);
+    assert_eq!(msg.content, response_content);
+}
+
+/// Test publish, Store, Query
+fn two_nodes_dht_publish_test(alex: &mut NodeMock, billy: &mut NodeMock) {
+    // Alex publish data on the network
+    alex.author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
+        .unwrap();
+    let (did_work, srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 0);
+
+    // #fullsync
+    // Alex or Billy should receive the entry store request
+    let store_result = billy.wait(Box::new(one_is!(
+        Lib3hServerProtocol::HandleStoreEntryAspect(_)
+    )));
+    assert!(store_result.is_some());
+    println!("\n got HandleStoreEntryAspect: {:?}", store_result);
+    // Process the HoldEntry generated from receiving the HandleStoreEntryAspect
+    let (did_work, _srv_msg_list) = billy.process().unwrap();
+    assert!(did_work);
+
+    // Billy asks for that entry
+    // ==========================
+    println!("\nBilly requesting entry: ENTRY_ADDRESS_1\n");
+    let query_data = billy.request_entry(ENTRY_ADDRESS_1.clone());
+    let (_did_work, _srv_msg_list) = billy.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 0);
+
+    println!("\nBilly reply to own request:\n");
+
+    // #fullsync
+    // Billy sends that data back to the network
+    let _ = billy.reply_to_HandleQueryEntry(&query_data).unwrap();
+    let (did_work, srv_msg_list) = billy.process().unwrap();
+    println!("\nBilly gets own response {:?}\n", srv_msg_list);
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 1);
+    let msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::QueryEntryResult);
+    assert_eq!(&msg.entry_address, &*ENTRY_ADDRESS_1);
+    let mut de = Deserializer::new(&msg.query_result[..]);
+    let maybe_entry: Result<EntryData, rmp_serde::decode::Error> =
+        Deserialize::deserialize(&mut de);
+    assert_eq!(
+        &maybe_entry.unwrap().aspect_list[0].aspect,
+        &*ASPECT_CONTENT_1
+    );
+
+    // Billy asks for unknown entry
+    // ============================
+    let query_data = billy.request_entry(ENTRY_ADDRESS_2.clone());
+    let res = alex.reply_to_HandleQueryEntry(&query_data);
+    println!("\nAlex gives response {:?}\n", res);
+    assert!(res.is_err());
+    let res_data: GenericResultData = res.err().unwrap();
+    let res_info = std::str::from_utf8(res_data.result_info.as_slice()).unwrap();
+    assert_eq!(res_info, "No entry found");
+}
+
+/// Test Hold & Query
+fn two_nodes_dht_hold_test(alex: &mut NodeMock, billy: &mut NodeMock) {
+    // Alex holds an entry
+    alex.hold_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
+        .unwrap();
+    let (did_work, srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+
+    // #fullsync
+    // mirrorDht wants the entry to broadcast it
+    assert_eq!(srv_msg_list.len(), 1);
+    let msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::HandleFetchEntry);
+    assert_eq!(&msg.entry_address, &*ENTRY_ADDRESS_1);
+    alex.reply_to_HandleFetchEntry(msg).unwrap();
+    let (did_work, srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 0);
+    // Process the HoldEntry generated from receiving HandleStoreEntryAspect
+    let (did_work, _srv_msg_list) = billy.process().unwrap();
+    assert!(did_work);
+
+    // Billy asks for that entry
+    // =========================
+    println!("\nBilly requesting entry: ENTRY_ADDRESS_1\n");
+    let query_data = billy.request_entry(ENTRY_ADDRESS_1.clone());
+    let (_did_work, _srv_msg_list) = billy.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 0);
+
+    // #fullsync
+    // Billy sends that data back to the network
+    println!("\nBilly reply to own request\n",);
+    let _ = billy.reply_to_HandleQueryEntry(&query_data).unwrap();
+    let (did_work, srv_msg_list) = billy.process().unwrap();
+    println!("\nBilly gets own response {:?}\n", srv_msg_list);
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 1);
+    let msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::QueryEntryResult);
+    assert_eq!(&msg.entry_address, &*ENTRY_ADDRESS_1);
+    let mut de = Deserializer::new(&msg.query_result[..]);
+    let maybe_entry: Result<EntryData, rmp_serde::decode::Error> =
+        Deserialize::deserialize(&mut de);
+    assert_eq!(
+        &maybe_entry.unwrap().aspect_list[0].aspect,
+        &*ASPECT_CONTENT_1
+    );
+
+    // Billy asks for unknown entry
+    // ============================
+    println!("\nBilly requesting unknown entry:\n");
+    let query_data = billy.request_entry(ENTRY_ADDRESS_2.clone());
+    let res = alex.reply_to_HandleQueryEntry(&query_data);
+    println!("\nAlex gives response {:?}\n", res);
+    assert!(res.is_err());
+    let res_data: GenericResultData = res.err().unwrap();
+    let res_info = std::str::from_utf8(res_data.result_info.as_slice()).unwrap();
+    assert_eq!(res_info, "No entry found");
+}

--- a/crates/lib3h/tests/test_suites/two_get_lists.rs
+++ b/crates/lib3h/tests/test_suites/two_get_lists.rs
@@ -3,7 +3,9 @@ use crate::{
     test_suites::two_basic::{request_entry_1, TwoNodesTestFn},
     utils::constants::*,
 };
-use lib3h_protocol::protocol_server::Lib3hServerProtocol;
+use lib3h_protocol::{data_types::EntryData, protocol_server::Lib3hServerProtocol};
+use rmp_serde::Deserializer;
+use serde::Deserialize;
 
 lazy_static! {
     pub static ref TWO_NODES_GET_LISTS_TEST_FNS: Vec<(TwoNodesTestFn, bool)> = vec![
@@ -11,6 +13,7 @@ lazy_static! {
         (hold_list_test, true),
         (empty_author_list_test, true),
         (author_list_known_entry_test, true),
+        (many_aspects_test, true),
     ];
 }
 
@@ -100,21 +103,121 @@ pub fn empty_author_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
     assert_eq!(info, "No entry found");
 }
 
-/// Return some data in publish_list request
+/// Return author_list with already known entry
 pub fn author_list_known_entry_test(alex: &mut NodeMock, billy: &mut NodeMock) {
     alex.author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
         .unwrap();
     let (did_work, srv_msg_list) = alex.process().unwrap();
     assert!(did_work);
     assert_eq!(srv_msg_list.len(), 0);
+
     alex.reply_to_first_HandleGetAuthoringEntryList();
     let (did_work, _srv_msg_list) = alex.process().unwrap();
     assert!(did_work);
-
     // Process the HoldEntry generated from receiving the HandleStoreEntryAspect
     let (did_work, _srv_msg_list) = billy.process().unwrap();
     assert!(did_work);
 
     // Billy asks for that entry
     request_entry_1(billy);
+}
+
+/// Return lots of entries
+pub fn many_aspects_test(alex: &mut NodeMock, billy: &mut NodeMock) {
+    // Author & hold several aspects on same address
+    alex.author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
+        .unwrap();
+    alex.author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_2.clone()], false)
+        .unwrap();
+    alex.hold_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_3.clone()], false)
+        .unwrap();
+    println!("\nAlex authored and stored Aspects \n");
+    let (did_work, srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 0);
+
+    // Process the HoldEntry generated from receiving the HandleStoreEntryAspect
+    println!("\nBilly should receive first aspect \n");
+    let (did_work, srv_msg_list) = billy.process().unwrap();
+    println!("\nBilly srv_msg_list = {:?}\n", srv_msg_list);
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 1);
+    let _ = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::HandleStoreEntryAspect);
+
+    // Send AuthoringList
+    // ==================
+    println!("\nAlex sends AuthoringEntryList\n");
+    alex.reply_to_first_HandleGetAuthoringEntryList();
+    let (did_work, srv_msg_list) = alex.process().unwrap();
+    println!("\nAlex srv_msg_list = {:?}\n", srv_msg_list);
+    assert!(did_work);
+    // #fullsync
+    // mirrorDht wants the entry to broadcast it
+    assert_eq!(srv_msg_list.len(), 1);
+    let msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::HandleFetchEntry);
+    assert_eq!(&msg.entry_address, &*ENTRY_ADDRESS_1);
+    alex.reply_to_HandleFetchEntry(msg).unwrap();
+    let (did_work, srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 0);
+
+    // Process the HoldEntry generated from receiving the HandleStoreEntryAspect
+    let (did_work, srv_msg_list) = billy.process().unwrap();
+    println!("\nBilly srv_msg_list = {:?}\n", srv_msg_list);
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 4);
+    //let _ = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::HandleFetchEntry); // #fullsync
+    let _ = unwrap_to!(srv_msg_list[1] => Lib3hServerProtocol::HandleStoreEntryAspect);
+    let _ = unwrap_to!(srv_msg_list[2] => Lib3hServerProtocol::HandleStoreEntryAspect);
+    let _ = unwrap_to!(srv_msg_list[3] => Lib3hServerProtocol::HandleStoreEntryAspect);
+
+    // Send GossipingList
+    // ==================
+    // Send HoldingEntryList and should receive a HandleFetchEntry request from network module
+    println!("\nAlex sends GossipingEntryList\n");
+    alex.reply_to_first_HandleGetGossipingEntryList();
+    let (did_work, _srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+    // Process the HoldEntry generated from receiving the HandleStoreEntryAspect
+    let (did_work, _srv_msg_list) = billy.process().unwrap();
+    assert!(did_work);
+    println!("\nBilly srv_msg_list = {:?}\n", srv_msg_list);
+
+    // Billy asks for the entry
+    // ========================
+    println!("\n{} requesting entry: ENTRY_ADDRESS_1\n", billy.name);
+    let query_data = billy.request_entry(ENTRY_ADDRESS_1.clone());
+    let (did_work, _srv_msg_list) = billy.process().unwrap();
+    assert!(did_work);
+
+    // #fullsync
+    // Billy sends that data back to the network
+    println!("\n{} reply to own request:\n", billy.name);
+    let _ = billy.reply_to_HandleQueryEntry(&query_data).unwrap();
+    let (did_work, srv_msg_list) = billy.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 1, "{:?}", srv_msg_list);
+    let msg = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::QueryEntryResult);
+    assert_eq!(&msg.entry_address, &*ENTRY_ADDRESS_1);
+    let mut de = Deserializer::new(&msg.query_result[..]);
+    let maybe_entry: Result<EntryData, rmp_serde::decode::Error> =
+        Deserialize::deserialize(&mut de);
+    let query_result = maybe_entry.unwrap();
+    assert_eq!(query_result.entry_address, ENTRY_ADDRESS_1.clone());
+    assert_eq!(query_result.aspect_list.len(), 3);
+    assert!(
+        query_result.aspect_list[0].aspect_address.clone() == *ASPECT_ADDRESS_1
+            || query_result.aspect_list[0].aspect_address.clone() == *ASPECT_ADDRESS_2
+            || query_result.aspect_list[0].aspect_address.clone() == *ASPECT_ADDRESS_3
+    );
+    assert!(
+        query_result.aspect_list[1].aspect_address.clone() == *ASPECT_ADDRESS_1
+            || query_result.aspect_list[1].aspect_address.clone() == *ASPECT_ADDRESS_2
+            || query_result.aspect_list[1].aspect_address.clone() == *ASPECT_ADDRESS_3
+    );
+    assert!(
+        query_result.aspect_list[2].aspect_address.clone() == *ASPECT_ADDRESS_1
+            || query_result.aspect_list[2].aspect_address.clone() == *ASPECT_ADDRESS_2
+            || query_result.aspect_list[2].aspect_address.clone() == *ASPECT_ADDRESS_3
+    );
 }

--- a/crates/lib3h/tests/test_suites/two_get_lists.rs
+++ b/crates/lib3h/tests/test_suites/two_get_lists.rs
@@ -10,6 +10,7 @@ lazy_static! {
         (author_list_test, true),
         (hold_list_test, true),
         (empty_author_list_test, true),
+        (author_list_known_entry_test, true),
     ];
 }
 
@@ -97,4 +98,23 @@ pub fn empty_author_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
     let result_data = res.err().unwrap();
     let info = std::string::String::from_utf8_lossy(&result_data.result_info).to_string();
     assert_eq!(info, "No entry found");
+}
+
+/// Return some data in publish_list request
+pub fn author_list_known_entry_test(alex: &mut NodeMock, billy: &mut NodeMock) {
+    alex.author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
+        .unwrap();
+    let (did_work, srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 0);
+    alex.reply_to_first_HandleGetAuthoringEntryList();
+    let (did_work, _srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+
+    // Process the HoldEntry generated from receiving the HandleStoreEntryAspect
+    let (did_work, _srv_msg_list) = billy.process().unwrap();
+    assert!(did_work);
+
+    // Billy asks for that entry
+    request_entry_1(billy);
 }

--- a/crates/lib3h/tests/test_suites/two_get_lists.rs
+++ b/crates/lib3h/tests/test_suites/two_get_lists.rs
@@ -1,0 +1,46 @@
+use crate::{
+    node_mock::NodeMock,
+    test_suites::two_basic::{request_entry_1, TwoNodesTestFn},
+    utils::constants::*,
+};
+use lib3h_protocol::{data_types::*, protocol_server::Lib3hServerProtocol};
+use rmp_serde::Deserializer;
+use serde::Deserialize;
+
+lazy_static! {
+    pub static ref TWO_NODES_GET_LISTS_TEST_FNS: Vec<(TwoNodesTestFn, bool)> =
+        vec![(publish_entry_list_test, true),];
+}
+
+//--------------------------------------------------------------------------------------------------
+// Tests
+//--------------------------------------------------------------------------------------------------
+
+/// Return some data in publish_list request
+pub fn publish_entry_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
+    // author an entry without publishing it
+    alex.author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], false)
+        .unwrap();
+    // Reply to the publish_list request received from network module
+    alex.reply_to_first_HandleGetAuthoringEntryList();
+    let (did_work, srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+
+    // Should receive a HandleFetchEntry request from network module after receiving list
+    assert_eq!(srv_msg_list.len(), 1);
+    // extract msg data
+    let fetch_data = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::HandleFetchEntry);
+    // Respond
+    alex.reply_to_HandleFetchEntry(&fetch_data)
+        .expect("Reply to HandleFetchEntry should work");
+    let (did_work, srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+
+    // Billy should receive storeAspect
+    let (did_work, srv_msg_list) = billy.process().unwrap();
+    assert!(did_work);
+    assert_eq!(srv_msg_list.len(), 1, "{:?}", srv_msg_list);
+
+    // Billy asks for that entry
+    request_entry_1(billy);
+}

--- a/crates/lib3h/tests/test_suites/two_get_lists.rs
+++ b/crates/lib3h/tests/test_suites/two_get_lists.rs
@@ -3,20 +3,18 @@ use crate::{
     test_suites::two_basic::{request_entry_1, TwoNodesTestFn},
     utils::constants::*,
 };
-use lib3h_protocol::{data_types::*, protocol_server::Lib3hServerProtocol};
-use rmp_serde::Deserializer;
-use serde::Deserialize;
+use lib3h_protocol::protocol_server::Lib3hServerProtocol;
 
 lazy_static! {
     pub static ref TWO_NODES_GET_LISTS_TEST_FNS: Vec<(TwoNodesTestFn, bool)> =
-        vec![(publish_entry_list_test, true),];
+        vec![(publish_entry_list_test, true), (hold_list_test, true),];
 }
 
 //--------------------------------------------------------------------------------------------------
 // Tests
 //--------------------------------------------------------------------------------------------------
 
-/// Return some data in publish_list request
+/// Return some entry in authoring_list request
 pub fn publish_entry_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
     // author an entry without publishing it
     alex.author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], false)
@@ -33,13 +31,42 @@ pub fn publish_entry_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
     // Respond
     alex.reply_to_HandleFetchEntry(&fetch_data)
         .expect("Reply to HandleFetchEntry should work");
-    let (did_work, srv_msg_list) = alex.process().unwrap();
+    let (did_work, _srv_msg_list) = alex.process().unwrap();
     assert!(did_work);
 
-    // Billy should receive storeAspect
+    // Process the HoldEntry generated from receiving the HandleStoreEntryAspect
     let (did_work, srv_msg_list) = billy.process().unwrap();
     assert!(did_work);
     assert_eq!(srv_msg_list.len(), 1, "{:?}", srv_msg_list);
+
+    // Billy asks for that entry
+    request_entry_1(billy);
+}
+
+/// Return some entry in gossiping_list request
+pub fn hold_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
+    // Have alex hold some data
+    alex.hold_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], false)
+        .unwrap();
+    // Alex: Look for the hold_list request received from network module and reply
+    alex.reply_to_first_HandleGetGossipingEntryList();
+    let (did_work, srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+
+    // #fullsync
+    // Should receive a HandleFetchEntry request from network module after receiving list
+    assert_eq!(srv_msg_list.len(), 1);
+    // extract msg data
+    let fetch_data = unwrap_to!(srv_msg_list[0] => Lib3hServerProtocol::HandleFetchEntry);
+    // Respond
+    alex.reply_to_HandleFetchEntry(&fetch_data)
+        .expect("Reply to HandleFetchEntry should work");
+    let (did_work, _srv_msg_list) = alex.process().unwrap();
+    assert!(did_work);
+
+    // Process the HoldEntry generated from receiving the HandleStoreEntryAspect
+    let (did_work, _srv_msg_list) = billy.process().unwrap();
+    assert!(did_work);
 
     // Billy asks for that entry
     request_entry_1(billy);


### PR DESCRIPTION
## PR summary
Solves #126

Send Get*Lists requests on JoinSpace.
On receiving authoring-list, ask Core for each entry and broadcast each response.
On receiving gossiping-list, send a HoldEntryAddress command to the DHT for each entry.

Added Get*lists test suite. Imported from `test_bin`.

### Follow-up

Handling  multiple aspects per entry will be done in follow-up PRs.

### PR Details

Added the test function's name to a node's binding url when testing in-memory transport.
Otherwise we would get conflicts because `cargo test` will run test suites in parallel and the in-memory transport server can't manage multiple clients with the same url.

Refactored testing succesful get of `ENTRY_ADDRESS_1` from a node as the function `request_entry_1()`, because it is used by multiple tests.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
