### PR TITLE
Mock: handle multiple aspects

### DIFF
--- a/crates/lib3h/src/dht/dht_protocol.rs
+++ b/crates/lib3h/src/dht/dht_protocol.rs
@@ -12,7 +12,8 @@ pub enum DhtCommand {
     /// Owner wants us to hold a peer discovery data item.
     HoldPeer(PeerData),
     /// Owner notifies us that it is holding one or several Aspects for an Entry.
-    HoldEntryAddress(Address),
+    /// Note: Need an EntryData to know the aspect addresses, but aspects' content can be empty.
+    HoldEntryAspectAddress(EntryData),
     /// Owner wants us to bookkeep an entry and broadcast it to neighbors
     BroadcastEntry(EntryData),
     /// Owner notifies us that is is not holding an entry anymore.

--- a/crates/lib3h/src/dht/dht_trait.rs
+++ b/crates/lib3h/src/dht/dht_trait.rs
@@ -1,5 +1,5 @@
 use crate::dht::dht_protocol::{DhtCommand, DhtEvent, PeerData};
-use lib3h_protocol::{AddressRef, DidWork, Lib3hResult};
+use lib3h_protocol::{Address, AddressRef, DidWork, Lib3hResult};
 use url::Url;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
@@ -22,6 +22,7 @@ pub trait Dht {
     fn this_peer(&self) -> &PeerData;
     /// Entry
     fn get_entry_address_list(&self) -> Vec<&AddressRef>;
+    fn get_aspects_of(&self, entry_address: &AddressRef) -> Option<Vec<Address>>;
     /// Processing
     fn post(&mut self, cmd: DhtCommand) -> Lib3hResult<()>;
     fn process(&mut self) -> Lib3hResult<(DidWork, Vec<DhtEvent>)>;

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -303,7 +303,10 @@ impl MirrorDht {
             // Owner is holding some entry. Store its address for bookkeeping.
             // Ask for its data and broadcast it because we want fullsync.
             DhtCommand::HoldEntryAspectAddress(entry) => {
-                let _received_new_content = self.add_entry_aspects(&entry);
+                let received_new_content = self.add_entry_aspects(&entry);
+                if !received_new_content {
+                    return Ok(vec![]);
+                }
                 // Use entry_address as request_id
                 let address_str = std::str::from_utf8(entry.entry_address.as_slice()).unwrap();
                 self.pending_fetch_request_list

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -144,23 +144,22 @@ impl MirrorDht {
         }
     }
 
-    /// Add aspect addresses for an entry in our local storage.
-    /// Return Diff
+    /// Return aspect addresses diff between
+    /// known aspects and aspects in the entry argument
     fn diff_aspects(&self, entry: &EntryData) -> HashSet<Address> {
-        let wtf_aspects: HashSet<_> = entry
+        let aspect_address_set: HashSet<_> = entry
             .aspect_list
             .iter()
             .map(|aspect| aspect.aspect_address.clone())
             .collect();
-        let wtf_aspects: HashSet<_> = wtf_aspects.into();
         let maybe_aspects = self.entry_list.get(&entry.entry_address);
         // Insert arg if first aspects
         if maybe_aspects.is_none() {
-            return wtf_aspects;
+            return aspect_address_set;
         }
         // Check if arg has new aspects
         let held_aspects: HashSet<_> = maybe_aspects.unwrap().clone();
-        let diff: HashSet<_> = wtf_aspects
+        let diff: HashSet<_> = aspect_address_set
             .difference(&held_aspects)
             .map(|item| item.clone())
             .collect();

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -24,13 +24,13 @@ pub struct MirrorDht {
     /// FIFO of DhtCommands send to us
     inbox: VecDeque<DhtCommand>,
     /// Storage of EntryData with empty aspect content?
-    entry_address_list: HashSet<Address>,
+    entry_list: HashMap<Address, HashSet<Address>>,
     /// Storage of PeerData
     peer_list: HashMap<String, PeerData>,
     /// PeerData of this peer
     this_peer: PeerData,
-    ///
-    pending_fetch_requests: HashSet<String>,
+    /// Keep track of fetch requests sent to Core
+    pending_fetch_request_list: HashSet<String>,
 }
 
 /// Constructors
@@ -39,13 +39,13 @@ impl MirrorDht {
         MirrorDht {
             inbox: VecDeque::new(),
             peer_list: HashMap::new(),
-            entry_address_list: HashSet::new(),
+            entry_list: HashMap::new(),
             this_peer: PeerData {
                 peer_address: peer_address.to_string(),
                 peer_uri: peer_transport.clone(),
                 timestamp: 0, // FIXME
             },
-            pending_fetch_requests: HashSet::new(),
+            pending_fetch_request_list: HashSet::new(),
         }
     }
 
@@ -77,20 +77,28 @@ impl Dht for MirrorDht {
     // -- Entry -- //
 
     fn get_entry_address_list(&self) -> Vec<&AddressRef> {
-        self.entry_address_list
-            .iter()
-            .map(|e| e.as_slice())
-            .collect()
+        self.entry_list.iter().map(|kv| kv.0.as_slice()).collect()
+    }
+
+    fn get_aspects_of(&self, entry_address: &AddressRef) -> Option<Vec<Address>> {
+        match self.entry_list.get(entry_address) {
+            None => None,
+            Some(set) => {
+                let vec = set.iter().map(|addr| addr.clone()).collect();
+                Some(vec)
+            }
+        }
     }
 
     // -- Processing -- //
 
+    /// Add to inbox
     fn post(&mut self, cmd: DhtCommand) -> Lib3hResult<()> {
         self.inbox.push_back(cmd);
         Ok(())
     }
 
-    ///
+    /// Serve each item in inbox
     fn process(&mut self) -> Lib3hResult<(DidWork, Vec<DhtEvent>)> {
         let mut outbox = Vec::new();
         let mut did_work = false;
@@ -136,10 +144,47 @@ impl MirrorDht {
         }
     }
 
-    /// Add entry to our local storage
-    /// Return true if new entry was successfully added
-    fn add_entry_address(&mut self, entry_address: &AddressRef) -> bool {
-        self.entry_address_list.insert(entry_address.to_vec())
+    /// Add aspect addresses for an entry in our local storage.
+    /// Return Diff
+    fn diff_aspects(&self, entry: &EntryData) -> HashSet<Address> {
+        let wtf_aspects: HashSet<_> = entry
+            .aspect_list
+            .iter()
+            .map(|aspect| aspect.aspect_address.clone())
+            .collect();
+        let wtf_aspects: HashSet<_> = wtf_aspects.into();
+        let maybe_aspects = self.entry_list.get(&entry.entry_address);
+        // Insert arg if first aspects
+        if maybe_aspects.is_none() {
+            return wtf_aspects;
+        }
+        // Check if arg has new aspects
+        let held_aspects: HashSet<_> = maybe_aspects.unwrap().clone();
+        let diff: HashSet<_> = wtf_aspects
+            .difference(&held_aspects)
+            .map(|item| item.clone())
+            .collect();
+        diff
+    }
+
+    /// Add aspect addresses for an entry in our local storage.
+    /// Return true if at least one new aspect address was added.
+    fn add_entry_aspects(&mut self, entry: &EntryData) -> bool {
+        let diff: HashSet<_> = self.diff_aspects(&entry);
+        if diff.len() == 0 {
+            return false;
+        }
+        let maybe_known_aspects = self.entry_list.get(&entry.entry_address);
+        let new_aspects: HashSet<_> = match maybe_known_aspects {
+            None => diff,
+            Some(known_aspects) => known_aspects
+                .union(&diff)
+                .map(|item| item.clone())
+                .collect(),
+        };
+        self.entry_list
+            .insert(entry.entry_address.to_vec(), new_aspects);
+        true
     }
 
     /// Create GossipTo event for entry to all known peers
@@ -178,10 +223,8 @@ impl MirrorDht {
                 }
                 match maybe_gossip.unwrap() {
                     MirrorGossip::Entry(entry) => {
-                        let _is_new = self.add_entry_address(&entry.entry_address);
-                        // TODO - since aspects are not tracked, act as if there is always new data
-                        let is_new = true;
-                        if is_new {
+                        let diff = self.diff_aspects(&entry);
+                        if diff.len() > 0 {
                             return Ok(vec![DhtEvent::HoldEntryRequested(
                                 self.this_peer.peer_address.clone(),
                                 entry,
@@ -200,7 +243,7 @@ impl MirrorDht {
             }
             // Ask owner to respond to self
             DhtCommand::FetchEntry(fetch_entry) => {
-                self.pending_fetch_requests
+                self.pending_fetch_request_list
                     .insert(fetch_entry.msg_id.clone());
                 return Ok(vec![DhtEvent::EntryDataRequested(fetch_entry.clone())]);
             }
@@ -260,14 +303,15 @@ impl MirrorDht {
             }
             // Owner is holding some entry. Store its address for bookkeeping.
             // Ask for its data and broadcast it because we want fullsync.
-            DhtCommand::HoldEntryAddress(entry_address) => {
-                let _received_new_content = self.add_entry_address(entry_address);
+            DhtCommand::HoldEntryAspectAddress(entry) => {
+                let _received_new_content = self.add_entry_aspects(&entry);
                 // Use entry_address as request_id
-                let address_str = std::str::from_utf8(entry_address.as_slice()).unwrap();
-                self.pending_fetch_requests.insert(address_str.to_string());
+                let address_str = std::str::from_utf8(entry.entry_address.as_slice()).unwrap();
+                self.pending_fetch_request_list
+                    .insert(address_str.to_string());
                 let fetch_entry = FetchDhtEntryData {
                     msg_id: address_str.to_string(),
-                    entry_address: entry_address.to_owned(),
+                    entry_address: entry.entry_address.to_owned(),
                 };
                 Ok(vec![DhtEvent::EntryDataRequested(fetch_entry)])
             }
@@ -275,12 +319,11 @@ impl MirrorDht {
             // Bookkeep address and gossip entry to every known peer.
             DhtCommand::BroadcastEntry(entry) => {
                 // Store address
-                let _received_new_content = self.add_entry_address(&entry.entry_address.clone());
-                // TODO - since aspects are not tracked, act as if there is always new data
+                let received_new_content = self.add_entry_aspects(&entry);
                 //// Bail if did not receive new content
-                //if !received_new_content {
-                //    return Ok(vec![]);
-                //}
+                if !received_new_content {
+                    return Ok(vec![]);
+                }
                 let gossip_evt = self.gossip_entry(entry);
                 // Done
                 Ok(vec![gossip_evt])
@@ -291,10 +334,10 @@ impl MirrorDht {
             //   - From a Publish: Forward response back to self
             //   - From a Hold   : Broadcast entry
             DhtCommand::EntryDataResponse(response) => {
-                if !self.pending_fetch_requests.remove(&response.msg_id) {
+                if !self.pending_fetch_request_list.remove(&response.msg_id) {
                     return Err(format_err!("Received response for an unknown request"));
                 }
-                // From a Hold if msg_id matches one set in HoldEntryAddress
+                // From a Hold if msg_id matches one set in HoldEntryAspectAddress
                 let address_str = std::str::from_utf8(&response.entry.entry_address).unwrap();
                 if address_str == response.msg_id {
                     let gossip_evt = self.gossip_entry(&response.entry);

--- a/crates/lib3h/src/dht/mod.rs
+++ b/crates/lib3h/src/dht/mod.rs
@@ -140,13 +140,17 @@ pub mod tests {
         let entry_address_list = dht.get_entry_address_list();
         assert_eq!(entry_address_list.len(), 0);
         // Add a data item
-        dht.post(DhtCommand::HoldEntryAddress(ENTRY_ADDRESS_1.clone()))
+        let entry = create_EntryData(&ENTRY_ADDRESS_1, &ASPECT_ADDRESS_1, &ASPECT_CONTENT_1);
+        dht.post(DhtCommand::HoldEntryAspectAddress(entry.clone()))
             .unwrap();
         let (did_work, _) = dht.process().unwrap();
         assert!(did_work);
         // Should have it
         let entry_address_list = dht.get_entry_address_list();
         assert_eq!(entry_address_list.len(), 1);
+        let maybe_aspects = dht.get_aspects_of(&ENTRY_ADDRESS_1);
+        assert!(maybe_aspects.is_some());
+        assert_eq!(maybe_aspects.unwrap().len(), 1);
         // Fetch it
         let fetch_entry = FetchDhtEntryData {
             msg_id: "fetch_1".to_owned(),
@@ -157,7 +161,6 @@ pub mod tests {
         assert_eq!(event_list.len(), 1);
         let provide_entry = unwrap_to!(event_list[0] => DhtEvent::EntryDataRequested);
         // Make something up
-        let entry = create_EntryData(&ENTRY_ADDRESS_1, &ASPECT_ADDRESS_1, &ASPECT_CONTENT_1);
         let response = FetchDhtEntryResponseData {
             msg_id: provide_entry.msg_id.clone(),
             entry: entry.clone(),
@@ -247,7 +250,7 @@ pub mod tests {
         }
         // Tell DHT B to hold it
         dht_b
-            .post(DhtCommand::HoldEntryAddress(entry_data.entry_address))
+            .post(DhtCommand::HoldEntryAspectAddress(entry_data))
             .unwrap();
         let (did_work, _) = dht_b.process().unwrap();
         assert!(did_work);

--- a/crates/lib3h/src/dht/rrdht.rs
+++ b/crates/lib3h/src/dht/rrdht.rs
@@ -1,5 +1,5 @@
 use crate::dht::{dht_protocol::*, dht_trait::Dht};
-use lib3h_protocol::{AddressRef, DidWork, Lib3hResult};
+use lib3h_protocol::{Address, AddressRef, DidWork, Lib3hResult};
 use std::collections::VecDeque;
 use url::Url;
 
@@ -51,7 +51,10 @@ impl Dht for RrDht {
         // FIXME
         vec![]
     }
-
+    fn get_aspects_of(&self, _entry_address: &AddressRef) -> Option<Vec<Address>> {
+        // FIXME
+        None
+    }
     // -- Processing -- //
 
     fn post(&mut self, cmd: DhtCommand) -> Lib3hResult<()> {

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -455,6 +455,8 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                                 };
                                 aspect_list.push(fake_aspect);
                             }
+                            // Create "fake" entry, in the sense an entry with no actual content,
+                            // but valid addresses.
                             let fake_entry = EntryData {
                                 entry_address: entry_address.clone(),
                                 aspect_list,

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -341,7 +341,7 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                 match maybe_space {
                     Err(res) => outbox.push(res),
                     Ok(space_gateway) => {
-                        let cmd = DhtCommand::HoldEntryAddress(msg.entry.entry_address);
+                        let cmd = DhtCommand::HoldEntryAspectAddress(msg.entry);
                         space_gateway.post_dht(cmd)?;
                         // Dht::post(&mut space_gateway, cmd)?;
                     }
@@ -437,8 +437,23 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
                 match maybe_space {
                     Err(res) => outbox.push(res),
                     Ok(space_gateway) => {
-                        for (entry_address, _) in msg.address_map {
-                            space_gateway.post_dht(DhtCommand::HoldEntryAddress(entry_address))?;
+                        for (entry_address, aspect_address_list) in msg.address_map {
+                            let mut aspect_list = Vec::new();
+                            for aspect_address in aspect_address_list {
+                                let fake_aspect = EntryAspectData {
+                                    aspect_address: aspect_address.clone(),
+                                    type_hint: String::new(),
+                                    aspect: vec![],
+                                    publish_ts: 0,
+                                };
+                                aspect_list.push(fake_aspect);
+                            }
+                            let fake_entry = EntryData {
+                                entry_address: entry_address.clone(),
+                                aspect_list,
+                            };
+                            space_gateway
+                                .post_dht(DhtCommand::HoldEntryAspectAddress(fake_entry))?;
                         }
                     }
                 }

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -588,6 +588,5 @@ impl<T: Transport, D: Dht, SecBuf: Buffer, Crypto: CryptoSystem> RealEngine<T, D
 fn includes(list_a: &[Address], list_b: &[Address]) -> bool {
     let set_a: HashSet<_> = list_a.iter().map(|addr| addr).collect();
     let set_b: HashSet<_> = list_b.iter().map(|addr| addr).collect();
-    let diff: HashSet<_> = set_a.difference(&set_b).map(|addr| addr).collect();
-    diff.len() > 0
+    set_b.is_subset(&set_a)
 }

--- a/crates/lib3h/src/gateway/gateway_dht.rs
+++ b/crates/lib3h/src/gateway/gateway_dht.rs
@@ -6,7 +6,7 @@ use crate::{
     gateway::{self, P2pGateway},
     transport::transport_trait::Transport,
 };
-use lib3h_protocol::{AddressRef, DidWork, Lib3hResult};
+use lib3h_protocol::{Address, AddressRef, DidWork, Lib3hResult};
 use rmp_serde::Serializer;
 use serde::Serialize;
 
@@ -25,6 +25,9 @@ impl<T: Transport, D: Dht> Dht for P2pGateway<T, D> {
     /// Entry
     fn get_entry_address_list(&self) -> Vec<&AddressRef> {
         self.inner_dht.get_entry_address_list()
+    }
+    fn get_aspects_of(&self, entry_address: &AddressRef) -> Option<Vec<Address>> {
+        self.inner_dht.get_aspects_of(entry_address)
     }
 
     /// Processing

--- a/crates/lib3h/tests/node_mock/methods.rs
+++ b/crates/lib3h/tests/node_mock/methods.rs
@@ -150,7 +150,7 @@ impl NodeMock {
 ///
 impl NodeMock {
     /// Convert an aspect_content_list into an EntryData
-    fn form_EntryData(entry_address: &Address, aspect_content_list: Vec<Vec<u8>>) -> EntryData {
+    pub fn form_EntryData(entry_address: &Address, aspect_content_list: Vec<Vec<u8>>) -> EntryData {
         let mut aspect_list = Vec::new();
         for aspect_content in aspect_content_list {
             let hash = HashString::encode_from_bytes(aspect_content.as_slice(), Hash::SHA2256);
@@ -173,7 +173,7 @@ impl NodeMock {
         entry_address: &Address,
         aspect_content_list: Vec<Vec<u8>>,
         can_broadcast: bool,
-    ) -> Lib3hResult<()> {
+    ) -> Lib3hResult<EntryData> {
         let current_space = self.current_space.clone().expect("Current Space not set");
         let entry = NodeMock::form_EntryData(entry_address, aspect_content_list);
 
@@ -204,12 +204,11 @@ impl NodeMock {
                 provider_agent_id: self.agent_id.clone(),
                 entry: entry.clone(),
             };
-            return self
-                .engine
-                .post(Lib3hClientProtocol::PublishEntry(msg_data).into());
+            self.engine
+                .post(Lib3hClientProtocol::PublishEntry(msg_data).into())?;
         }
         // Done
-        Ok(())
+        Ok(entry)
     }
 
     pub fn hold_entry(
@@ -217,7 +216,7 @@ impl NodeMock {
         entry_address: &Address,
         aspect_content_list: Vec<Vec<u8>>,
         can_tell_engine: bool,
-    ) -> Lib3hResult<()> {
+    ) -> Lib3hResult<EntryData> {
         let current_space = self.current_space.clone().expect("Current Space not set");
         let entry = NodeMock::form_EntryData(entry_address, aspect_content_list);
         let chain_store = self
@@ -244,12 +243,11 @@ impl NodeMock {
                 provider_agent_id: self.agent_id.clone(),
                 entry: entry.clone(),
             };
-            return self
-                .engine
-                .post(Lib3hClientProtocol::HoldEntry(msg_data).into());
+            self.engine
+                .post(Lib3hClientProtocol::HoldEntry(msg_data).into())?;
         }
         // Done
-        Ok(())
+        Ok(entry)
     }
 }
 

--- a/crates/lib3h/tests/node_mock/methods.rs
+++ b/crates/lib3h/tests/node_mock/methods.rs
@@ -161,6 +161,7 @@ impl NodeMock {
                 publish_ts: 42,
             });
         }
+        aspect_list.sort();
         EntryData {
             entry_address: entry_address.clone(),
             aspect_list,

--- a/crates/lib3h/tests/test_suites/two_get_lists.rs
+++ b/crates/lib3h/tests/test_suites/two_get_lists.rs
@@ -1,6 +1,6 @@
 use crate::{
     node_mock::NodeMock,
-    test_suites::two_basic::{request_entry_1, TwoNodesTestFn},
+    test_suites::two_basic::{request_entry_ok, TwoNodesTestFn},
     utils::constants::*,
 };
 use lib3h_protocol::{data_types::EntryData, protocol_server::Lib3hServerProtocol};
@@ -24,7 +24,8 @@ lazy_static! {
 /// Return some entry in authoring_list request
 pub fn author_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
     // author an entry without publishing it
-    alex.author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], false)
+    let entry = alex
+        .author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], false)
         .unwrap();
     // Reply to the publish_list request received from network module
     alex.reply_to_first_HandleGetAuthoringEntryList();
@@ -47,13 +48,14 @@ pub fn author_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
     assert_eq!(srv_msg_list.len(), 1, "{:?}", srv_msg_list);
 
     // Billy asks for that entry
-    request_entry_1(billy);
+    request_entry_ok(billy, &entry);
 }
 
 /// Return some entry in gossiping_list request
 pub fn hold_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
     // Have alex hold some data
-    alex.hold_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], false)
+    let entry = alex
+        .hold_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], false)
         .unwrap();
     // Alex: Look for the hold_list request received from network module and reply
     alex.reply_to_first_HandleGetGossipingEntryList();
@@ -76,7 +78,7 @@ pub fn hold_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
     assert!(did_work);
 
     // Billy asks for that entry
-    request_entry_1(billy);
+    request_entry_ok(billy, &entry);
 }
 
 ///
@@ -105,7 +107,8 @@ pub fn empty_author_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
 
 /// Return author_list with already known entry
 pub fn author_list_known_entry_test(alex: &mut NodeMock, billy: &mut NodeMock) {
-    alex.author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
+    let entry = alex
+        .author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
         .unwrap();
     let (did_work, srv_msg_list) = alex.process().unwrap();
     assert!(did_work);
@@ -119,7 +122,7 @@ pub fn author_list_known_entry_test(alex: &mut NodeMock, billy: &mut NodeMock) {
     assert!(did_work);
 
     // Billy asks for that entry
-    request_entry_1(billy);
+    request_entry_ok(billy, &entry);
 }
 
 /// Return lots of entries

--- a/crates/lib3h_protocol/src/data_types.rs
+++ b/crates/lib3h_protocol/src/data_types.rs
@@ -1,4 +1,5 @@
 use crate::Address;
+use std::cmp::Ordering;
 use url::Url;
 
 /// Tuple holding all the info required for identifying an Aspect.
@@ -9,12 +10,22 @@ pub type AspectKey = (Address, Address);
 // Entry (Semi-opaque Holochain entry type)
 //--------------------------------------------------------------------------------------------------
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 pub struct EntryAspectData {
     pub aspect_address: Address,
     pub type_hint: String,
     pub aspect: Vec<u8>,
     pub publish_ts: u64,
+}
+impl Ord for EntryAspectData {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.aspect_address.cmp(&other.aspect_address)
+    }
+}
+impl PartialOrd for EntryAspectData {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]


### PR DESCRIPTION
## PR summary
Solves #146

Changed: 
`DhtCommand::HoldEntryAddress(Address)` to:
`DhtCommand::HoldEntryAspectAddress(EntryData)`
since hold commands should be per aspect.

Added `get_aspects_of(entry_address)` to dht_trait.

DHT implementations should have an internal diff function to figure out if aspects are new or not.

Added some multiple aspects tests, imported from `test_bin`
Made `EntryAspectData` sortable for deterministic `EntryData` comparaisons.

#### Open question

Maybe create a type like this:
`type AspectAddressList = HashSet<Address>`
And use that in `GetListData` and `FetchEntryData`?

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
