### PR TITLE
Makefile env tweak

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
-.PHONY: all test fmt clean
+# Top-Level Environment Switcher
+# This will delegate to sub Makefile.* files
 
-all: test
+.PHONY: all
 
-test:
-	nix-shell --run l3h-test
-
-fmt:
-	nix-shell --run hn-rust-fmt
-
-clean:
-	nix-shell --run hn-flush
+export
+all:
+ifeq ($(MAKE_ENV),local)
+	$(MAKE) -f Makefile.local
+else
+	$(MAKE) -f Makefile.nix
+endif

--- a/Makefile.nix
+++ b/Makefile.nix
@@ -1,0 +1,12 @@
+.PHONY: all test fmt clean
+
+all: test
+
+test:
+	nix-shell --run l3h-test
+
+fmt:
+	nix-shell --run hn-rust-fmt
+
+clean:
+	nix-shell --run hn-flush


### PR DESCRIPTION
## PR summary

Tiny change. Now, instead of running `make -f Makefile.local`, I can just put `MAKE_ENV="local"` in my .bashrc and run `make`. Default without that env var is still to run the nix versions of tests / commands.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
