### PR TITLE
Add P2pReady, Terminated, Shutdown to lib3h protocol

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Added
 
+ - Add P2pReady, Terminated to Lib3hServerProtocol and Shutdown to Lib3hClientProtocol.
+
 ### Changed
 
 ### Deprecated

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -215,6 +215,9 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
         let mut outbox = Vec::new();
         // Note: use same order as the enum
         match client_msg {
+            Lib3hClientProtocol::Shutdown => {
+                // TODO
+            }
             Lib3hClientProtocol::SuccessResult(_msg) => {
                 // TODO #168
             }

--- a/crates/lib3h/tests/node_mock/methods.rs
+++ b/crates/lib3h/tests/node_mock/methods.rs
@@ -714,6 +714,12 @@ impl NodeMock {
             Lib3hServerProtocol::HandleGetGossipingEntryList(_msg) => {
                 // no-op
             }
+            Lib3hServerProtocol::Terminated => {
+                // no-op
+            }
+            Lib3hServerProtocol::P2pReady => {
+                // no-op
+            }
         }
     }
 }

--- a/crates/lib3h_protocol/src/protocol_client.rs
+++ b/crates/lib3h_protocol/src/protocol_client.rs
@@ -50,4 +50,7 @@ pub enum Lib3hClientProtocol {
     // -- Entry lists -- //
     HandleGetAuthoringEntryListResult(EntryListData),
     HandleGetGossipingEntryListResult(EntryListData),
+
+    // -- N3h specific functinonality -- //
+    Shutdown,
 }

--- a/crates/lib3h_protocol/src/protocol_server.rs
+++ b/crates/lib3h_protocol/src/protocol_server.rs
@@ -47,4 +47,8 @@ pub enum Lib3hServerProtocol {
     // -- Entry lists -- //
     HandleGetAuthoringEntryList(GetListData),
     HandleGetGossipingEntryList(GetListData),
+
+    // -- N3h specific functinonality -- //
+    Terminated,
+    P2pReady,
 }


### PR DESCRIPTION
## PR summary

This PR reintroduces `Lib3hServerProtocol::{Terminated, P2pReady}` and `Lib3hClientProtocol::Shutdown` for the sake of n3h backwards compatibility only.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
