### PR TITLE
Mock: cleaner api

### DIFF
--- a/crates/lib3h/src/engine/mod.rs
+++ b/crates/lib3h/src/engine/mod.rs
@@ -20,7 +20,7 @@ use url::Url;
 /// Identifier of a source chain: SpaceAddress+AgentId
 pub type ChainId = (Address, Address);
 
-pub static NETWORK_GATEWAY_ID: &'static str = "__memory_network__";
+pub static NETWORK_GATEWAY_ID: &'static str = "__network__";
 
 /// Struct holding all config settings for the RealEngine
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
@@ -54,7 +54,7 @@ pub struct RealEngine<T: Transport, D: Dht> {
     inbox: VecDeque<Lib3hClientProtocol>,
     /// Factory for building DHT's of type D
     dht_factory: DhtFactory<D>,
-    // Remove this if we have a full functioning mock without having to use it.
+    // TODO #159: Remove this if we have a full functioning mock without having to use it.
     #[allow(dead_code)]
     /// Transport used by the network gateway
     network_transport: Rc<RefCell<T>>,

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -98,7 +98,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
         let mut outbox = Vec::new();
         // Note: use same order as the enum
         match evt {
-            TransportEvent::TransportError(id, e) => {
+            TransportEvent::ErrorOccured(id, e) => {
                 self.network_connections.remove(id);
                 error!("{} Network error from {} : {:?}", self.name.clone(), id, e);
                 // Output a Lib3hServerProtocol::Disconnected if it was the connection
@@ -154,11 +154,11 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                     let _ = self.network_connections.insert(id.to_owned());
                 }
             }
-            TransportEvent::Connection(_id) => {
+            TransportEvent::IncomingConnectionEstablished(_id) => {
                 // TODO #159
                 unimplemented!();
             }
-            TransportEvent::Closed(id) => {
+            TransportEvent::ConnectionClosed(id) => {
                 self.network_connections.remove(id);
                 // Output a Lib3hServerProtocol::Disconnected if it was the connection
                 if self.network_connections.is_empty() {
@@ -168,7 +168,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                     outbox.push(Lib3hServerProtocol::Disconnected(data));
                 }
             }
-            TransportEvent::Received(id, payload) => {
+            TransportEvent::ReceivedData(id, payload) => {
                 debug!("Received message from: {} | {}", id, payload.len());
                 let mut de = Deserializer::new(&payload[..]);
                 let maybe_msg: Result<P2pProtocol, rmp_serde::decode::Error> =

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -59,7 +59,7 @@ impl<D: Dht> RealEngine<TransportWss<std::net::TcpStream>, D> {
             custom: config.dht_custom_config.clone(),
         };
         let network_gateway = Rc::new(RefCell::new(P2pGateway::new(
-            "__physical_network__",
+            NETWORK_GATEWAY_ID,
             Rc::clone(&network_transport),
             dht_factory,
             &dht_config,
@@ -131,18 +131,6 @@ impl<D: Dht> RealEngine<TransportMemory, D> {
 }
 
 impl<T: Transport, D: Dht> NetworkEngine for RealEngine<T, D> {
-    fn run(&self) -> Lib3hResult<()> {
-        // TODO #159
-        Ok(())
-    }
-    fn stop(&self) -> Lib3hResult<()> {
-        // TODO #159
-        Ok(())
-    }
-    fn terminate(&self) -> Lib3hResult<()> {
-        // TODO #159
-        Ok(())
-    }
 
     fn advertise(&self) -> Url {
         self.network_gateway
@@ -187,8 +175,26 @@ impl<T: Transport, D: Dht> NetworkEngine for RealEngine<T, D> {
     }
 }
 
+/// Drop
+impl<T: Transport, D: Dht> Drop for  RealEngine<T, D> {
+    fn drop(&mut self) {
+        let res = self.shutdown();
+        if let Err(e) = res {
+            warn!("Graceful shutdown failed: {}", e);
+        }
+    }
+}
+
 /// Private
 impl<T: Transport, D: Dht> RealEngine<T, D> {
+
+    /// Called on drop.
+    /// Close all connections gracefully
+    fn shutdown(&mut self) -> Lib3hResult<()> {
+        // TODO #159
+        Ok(())
+    }
+
     /// Progressively serve every Lib3hClientProtocol received in inbox
     fn process_inbox(&mut self) -> Lib3hResult<(DidWork, Vec<Lib3hServerProtocol>)> {
         let mut outbox = Vec::new();

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -131,7 +131,6 @@ impl<D: Dht> RealEngine<TransportMemory, D> {
 }
 
 impl<T: Transport, D: Dht> NetworkEngine for RealEngine<T, D> {
-
     fn advertise(&self) -> Url {
         self.network_gateway
             .borrow()
@@ -176,7 +175,7 @@ impl<T: Transport, D: Dht> NetworkEngine for RealEngine<T, D> {
 }
 
 /// Drop
-impl<T: Transport, D: Dht> Drop for  RealEngine<T, D> {
+impl<T: Transport, D: Dht> Drop for RealEngine<T, D> {
     fn drop(&mut self) {
         let res = self.shutdown();
         if let Err(e) = res {
@@ -187,7 +186,6 @@ impl<T: Transport, D: Dht> Drop for  RealEngine<T, D> {
 
 /// Private
 impl<T: Transport, D: Dht> RealEngine<T, D> {
-
     /// Called on drop.
     /// Close all connections gracefully
     fn shutdown(&mut self) -> Lib3hResult<()> {

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -189,7 +189,7 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
         );
         // Note: use same order as the enum
         match evt {
-            TransportEvent::TransportError(id, e) => {
+            TransportEvent::ErrorOccured(id, e) => {
                 error!(
                     "(GatewayTransport) Connection Error for {}: {}\n Closing connection.",
                     id, e
@@ -231,17 +231,17 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
                 );
                 self.inner_transport.borrow_mut().send(&[&id], &buf)?;
             }
-            TransportEvent::Connection(_id) => {
+            TransportEvent::IncomingConnectionEstablished(_id) => {
                 // TODO #176
                 unimplemented!();
             }
-            TransportEvent::Closed(id) => {
+            TransportEvent::ConnectionClosed(id) => {
                 // TODO #176
                 warn!("Connection closed: {}", id);
                 self.inner_transport.borrow_mut().close(id)?;
                 //let _transport_id = self.wss_socket.wait_connect(&self.ipc_uri)?;
             }
-            TransportEvent::Received(id, payload) => {
+            TransportEvent::ReceivedData(id, payload) => {
                 debug!("Received message from: {}", id);
                 // trace!("Deserialize msg: {:?}", payload);
                 let mut de = Deserializer::new(&payload[..]);
@@ -303,7 +303,7 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
             }
             TransportCommand::Close(id) => {
                 self.close(id)?;
-                let evt = TransportEvent::Closed(id.to_string());
+                let evt = TransportEvent::ConnectionClosed(id.to_string());
                 Ok(vec![evt])
             }
             TransportCommand::CloseAll => {

--- a/crates/lib3h/src/transport/memory_mock/memory_server.rs
+++ b/crates/lib3h/src/transport/memory_mock/memory_server.rs
@@ -149,7 +149,7 @@ impl MemoryServer {
                 };
                 did_work = true;
                 trace!("(MemoryServer {}) received: {:?}", self.uri, payload);
-                let evt = TransportEvent::Received(id.clone(), payload);
+                let evt = TransportEvent::ReceivedData(id.clone(), payload);
                 outbox.push(evt);
             }
         }

--- a/crates/lib3h/src/transport/memory_mock/transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/transport_memory.rs
@@ -304,14 +304,14 @@ impl TransportMemory {
             }
             TransportCommand::Close(id) => {
                 self.close(id)?;
-                let evt = TransportEvent::Closed(id.to_string());
+                let evt = TransportEvent::ConnectionClosed(id.to_string());
                 Ok(vec![evt])
             }
             TransportCommand::CloseAll => {
                 self.close_all()?;
                 let mut outbox = Vec::new();
                 for (id, _url) in &self.connections {
-                    let evt = TransportEvent::Closed(id.to_string());
+                    let evt = TransportEvent::ConnectionClosed(id.to_string());
                     outbox.push(evt);
                 }
                 Ok(outbox)

--- a/crates/lib3h/src/transport/mod.rs
+++ b/crates/lib3h/src/transport/mod.rs
@@ -95,7 +95,7 @@ pub mod tests {
         assert!(event_list.len() >= 1);
         let recv_event = event_list.last().unwrap().clone();
         let (recv_id, recv_payload) = match recv_event {
-            TransportEvent::Received(a, b) => (a, b),
+            TransportEvent::ReceivedData(a, b) => (a, b),
             e => panic!("Received wrong TransportEvent type: {:?}", e),
         };
         assert!(node_A.get_uri(idAB.as_str()).is_some());
@@ -134,7 +134,7 @@ pub mod tests {
         assert_eq!(event_list.len(), 1);
         let recv_event = event_list[0].clone();
         let (recv_id, recv_payload) = match recv_event {
-            TransportEvent::Received(a, b) => (a, b),
+            TransportEvent::ReceivedData(a, b) => (a, b),
             _ => panic!("Received wrong TransportEvent type"),
         };
         assert!(node_A.get_uri(recv_id.as_str()).is_some());

--- a/crates/lib3h/src/transport/protocol.rs
+++ b/crates/lib3h/src/transport/protocol.rs
@@ -15,12 +15,15 @@ pub enum TransportCommand {
 /// Events that can be generated during a `process()`
 #[derive(Debug, PartialEq, Clone)]
 pub enum TransportEvent {
-    TransportError(ConnectionId, TransportError),
+    /// Notify that some TransportError occured
+    ErrorOccured(ConnectionId, TransportError),
     /// an outgoing connection has been established
     ConnectResult(ConnectionId),
     /// we have received an incoming connection
-    Connection(ConnectionId),
+    IncomingConnectionEstablished(ConnectionId),
     /// We have received data from a connection
-    Received(ConnectionId, Vec<u8>),
-    Closed(ConnectionId),
+    ReceivedData(ConnectionId, Vec<u8>),
+    /// A connection closed for whatever reason
+    /// #159
+    ConnectionClosed(ConnectionId),
 }

--- a/crates/lib3h/src/transport_wss/mod.rs
+++ b/crates/lib3h/src/transport_wss/mod.rs
@@ -379,10 +379,10 @@ impl<T: Read + Write + std::fmt::Debug + std::marker::Sized> TransportWss<T> {
         for (id, mut info) in sockets {
             if let Err(e) = self.priv_process_socket(&mut did_work, &mut info) {
                 self.event_queue
-                    .push(TransportEvent::TransportError(info.id.clone(), e));
+                    .push(TransportEvent::ErrorOccured(info.id.clone(), e));
             }
             if let WebsocketStreamState::None = info.stateful_socket {
-                self.event_queue.push(TransportEvent::Closed(info.id));
+                self.event_queue.push(TransportEvent::ConnectionClosed(info.id));
                 continue;
             }
             if info.last_msg.elapsed().as_millis() as usize > DEFAULT_HEARTBEAT_MS {
@@ -393,7 +393,7 @@ impl<T: Read + Write + std::fmt::Debug + std::marker::Sized> TransportWss<T> {
                     socket.write_message(tungstenite::Message::Ping(vec![]))?;
                 }
             } else if info.last_msg.elapsed().as_millis() as usize > DEFAULT_HEARTBEAT_WAIT_MS {
-                self.event_queue.push(TransportEvent::Closed(info.id));
+                self.event_queue.push(TransportEvent::ConnectionClosed(info.id));
                 info.stateful_socket = WebsocketStreamState::None;
                 continue;
             }
@@ -535,7 +535,7 @@ impl<T: Read + Write + std::fmt::Debug + std::marker::Sized> TransportWss<T> {
 
                         if let Some(msg) = qmsg {
                             self.event_queue
-                                .push(TransportEvent::Received(info.id.clone(), msg));
+                                .push(TransportEvent::ReceivedData(info.id.clone(), msg));
                         }
                         info.stateful_socket = WebsocketStreamState::ReadyWs(socket);
                         Ok(())
@@ -574,7 +574,7 @@ impl<T: Read + Write + std::fmt::Debug + std::marker::Sized> TransportWss<T> {
 
                         if let Some(msg) = qmsg {
                             self.event_queue
-                                .push(TransportEvent::Received(info.id.clone(), msg));
+                                .push(TransportEvent::ReceivedData(info.id.clone(), msg));
                         }
                         info.stateful_socket = WebsocketStreamState::ReadyWss(socket);
                         Ok(())
@@ -664,7 +664,7 @@ impl<T: Read + Write + std::fmt::Debug + std::marker::Sized> TransportWss<T> {
             Err(e) => Err(e.into()),
             Ok(socket) => {
                 self.event_queue
-                    .push(TransportEvent::Connection(id.clone()));
+                    .push(TransportEvent::IncomingConnectionEstablished(id.clone()));
                 Ok(WebsocketStreamState::ReadyWs(Box::new(socket)))
             }
         }
@@ -683,7 +683,7 @@ impl<T: Read + Write + std::fmt::Debug + std::marker::Sized> TransportWss<T> {
             Err(e) => Err(e.into()),
             Ok(socket) => {
                 self.event_queue
-                    .push(TransportEvent::Connection(id.clone()));
+                    .push(TransportEvent::IncomingConnectionEstablished(id.clone()));
                 Ok(WebsocketStreamState::ReadyWss(Box::new(socket)))
             }
         }

--- a/crates/lib3h/src/transport_wss/mod.rs
+++ b/crates/lib3h/src/transport_wss/mod.rs
@@ -382,7 +382,8 @@ impl<T: Read + Write + std::fmt::Debug + std::marker::Sized> TransportWss<T> {
                     .push(TransportEvent::ErrorOccured(info.id.clone(), e));
             }
             if let WebsocketStreamState::None = info.stateful_socket {
-                self.event_queue.push(TransportEvent::ConnectionClosed(info.id));
+                self.event_queue
+                    .push(TransportEvent::ConnectionClosed(info.id));
                 continue;
             }
             if info.last_msg.elapsed().as_millis() as usize > DEFAULT_HEARTBEAT_MS {
@@ -393,7 +394,8 @@ impl<T: Read + Write + std::fmt::Debug + std::marker::Sized> TransportWss<T> {
                     socket.write_message(tungstenite::Message::Ping(vec![]))?;
                 }
             } else if info.last_msg.elapsed().as_millis() as usize > DEFAULT_HEARTBEAT_WAIT_MS {
-                self.event_queue.push(TransportEvent::ConnectionClosed(info.id));
+                self.event_queue
+                    .push(TransportEvent::ConnectionClosed(info.id));
                 info.stateful_socket = WebsocketStreamState::None;
                 continue;
             }

--- a/crates/lib3h/tests/engine_test.rs
+++ b/crates/lib3h/tests/engine_test.rs
@@ -133,8 +133,6 @@ fn basic_connect_test_mock() {
     // Setup
     let mut engine_a = basic_setup_mock("basic_send_test_mock_node_a");
     let engine_b = basic_setup_mock("basic_send_test_mock_node_b");
-    engine_a.run().unwrap();
-    engine_b.run().unwrap();
     // Get URL
     let url_b = engine_b.advertise();
     println!("url_b: {}", url_b);
@@ -151,8 +149,6 @@ fn basic_connect_test_mock() {
     let (did_work, srv_msg_list) = engine_a.process().unwrap();
     println!("engine_a: {:?}", srv_msg_list);
     assert!(did_work);
-    engine_a.terminate().unwrap();
-    engine_b.terminate().unwrap();
 }
 
 #[test]
@@ -172,9 +168,6 @@ fn basic_track_test_mock() {
 }
 
 fn basic_track_test<T: Transport, D: Dht>(engine: &mut RealEngine<T, D>) {
-    // Start
-    engine.run().unwrap();
-
     // Test
     let mut track_space = SpaceData {
         request_id: "track_a_1".into(),
@@ -214,8 +207,6 @@ fn basic_track_test<T: Transport, D: Dht>(engine: &mut RealEngine<T, D>) {
         "FailureResult info: {}",
         std::str::from_utf8(res_msg.result_info.as_slice()).unwrap()
     );
-    // Done
-    engine.terminate().unwrap();
 }
 
 #[test]
@@ -249,10 +240,8 @@ fn launch_two_nodes_test_with_memory_network(
     // Wrap-up test
     println!("==================");
     print_two_engines_test_name("IN-MEMORY TWO ENGINES TEST END: ", test_fn);
-    // Terminate nodes
-    alex.terminate().unwrap();
-    billy.terminate().unwrap();
 
+    // Done
     Ok(())
 }
 
@@ -263,10 +252,6 @@ fn setup_only(_alex: &mut Box<dyn NetworkEngine>, _billy: &mut Box<dyn NetworkEn
 
 ///
 fn basic_two_setup(alex: &mut Box<dyn NetworkEngine>, billy: &mut Box<dyn NetworkEngine>) {
-    // Start
-    alex.run().unwrap();
-    billy.run().unwrap();
-
     // Connect Alex to Billy
     let req_connect = ConnectData {
         request_id: "connect".to_string(),
@@ -374,10 +359,6 @@ fn basic_two_send_message(alex: &mut Box<dyn NetworkEngine>, billy: &mut Box<dyn
 
 //
 fn basic_two_join_first(alex: &mut Box<dyn NetworkEngine>, billy: &mut Box<dyn NetworkEngine>) {
-    // Start
-    alex.run().unwrap();
-    billy.run().unwrap();
-
     // Setup: Track before connecting
 
     // A joins space

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -180,10 +180,8 @@ fn launch_two_memory_nodes_test(test_fn: TwoNodesTestFn, can_setup: bool) -> Res
     // Wrap-up test
     println!("========================");
     print_test_name("IN-MEMORY TWO NODES TEST END: ", test_fn_ptr);
-    // Terminate nodes
-    alex.stop();
-    billy.stop();
 
+    // Done
     Ok(())
 }
 
@@ -208,10 +206,7 @@ fn launch_three_memory_nodes_test(test_fn: ThreeNodesTestFn, can_setup: bool) ->
     // Wrap-up test
     println!("==========================");
     print_test_name("IN-MEMORY THREE NODES TEST END: ", test_fn_ptr);
-    // Terminate nodes
-    alex.stop();
-    billy.stop();
-    camille.stop();
 
+    // Done
     Ok(())
 }

--- a/crates/lib3h/tests/node_mock/methods.rs
+++ b/crates/lib3h/tests/node_mock/methods.rs
@@ -628,20 +628,6 @@ impl NodeMock {
         }
     }
 
-    /// Start engine
-    pub fn run(&mut self) {
-        self.engine
-            .run()
-            .expect("Failed to start the NetworkEngine");
-    }
-
-    /// Stop engine
-    pub fn stop(&mut self) {
-        self.engine
-            .stop()
-            .expect("Failed to stop the NetworkEngine");
-    }
-
     /// handle all types of Lib3hServerProtocol message
     fn handle_lib3h(&mut self, lib3h_msg: Lib3hServerProtocol) {
         match lib3h_msg {

--- a/crates/lib3h/tests/test_suites/three_basic.rs
+++ b/crates/lib3h/tests/test_suites/three_basic.rs
@@ -19,11 +19,6 @@ lazy_static! {
 
 ///
 pub fn setup_three_nodes(alex: &mut NodeMock, billy: &mut NodeMock, camille: &mut NodeMock) {
-    // Start
-    alex.run();
-    billy.run();
-    camille.run();
-
     // Connection
     // ==========
     // Connect Alex to Billy

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -24,10 +24,6 @@ lazy_static! {
 
 ///
 pub fn setup_two_nodes(alex: &mut NodeMock, billy: &mut NodeMock) {
-    // Start
-    alex.run();
-    billy.run();
-
     // Connect Alex to Billy
     alex.connect_to(&billy.advertise()).unwrap();
 

--- a/crates/lib3h_protocol/src/network_engine.rs
+++ b/crates/lib3h_protocol/src/network_engine.rs
@@ -7,12 +7,6 @@ use url::Url;
 
 /// Common interface for all types of network modules to be used by the Lib3hWorker
 pub trait NetworkEngine {
-    /// Start network communications
-    fn run(&self) -> Lib3hResult<()>;
-    /// Stop network communications
-    fn stop(&self) -> Lib3hResult<()>;
-    /// Terminate module. Perform some cleanup.
-    fn terminate(&self) -> Lib3hResult<()>;
     /// Post a protocol message from core -> lib3h
     fn post(&mut self, data: Lib3hClientProtocol) -> Lib3hResult<()>;
     /// A single iteration of the networking process loop


### PR DESCRIPTION
## PR summary
Removed run/stop/terminate() from NetworkEngine trait.
Moved terminate() to a non-trait shutdown() function called on drop.
Renamed some TransportEvents for better clarity of what happened.
Fixed bug of Wss Engine not using NETWORK_GATEWAY_ID.
