### PR TITLE
Mock: timestamp of peerData

### DIFF
--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -1,6 +1,9 @@
-use crate::dht::{
-    dht_protocol::*,
-    dht_trait::{Dht, DhtConfig},
+use crate::{
+    time,
+    dht::{
+        dht_protocol::*,
+        dht_trait::{Dht, DhtConfig},
+    }
 };
 use lib3h_protocol::{data_types::EntryData, Address, DidWork, Lib3hResult};
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -43,7 +46,7 @@ impl MirrorDht {
             this_peer: PeerData {
                 peer_address: peer_address.to_string(),
                 peer_uri: peer_transport.clone(),
-                timestamp: 0, // TODO #166
+                timestamp: time::since_epoch_ms(),
             },
             pending_fetch_request_list: HashSet::new(),
         }
@@ -137,7 +140,7 @@ impl MirrorDht {
                     trace!("@MirrorDht@ Adding peer - BAD");
                     return false;
                 }
-                trace!("@MirrorDht@ Adding peer - OK UPDATED");
+                trace!("@MirrorDht@ Adding peer - OK UPDATED: {} > {}", peer_info.timestamp, peer.timestamp);
                 peer.timestamp = peer_info.timestamp;
                 true
             }

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -1,9 +1,9 @@
 use crate::{
-    time,
     dht::{
         dht_protocol::*,
         dht_trait::{Dht, DhtConfig},
-    }
+    },
+    time,
 };
 use lib3h_protocol::{data_types::EntryData, Address, DidWork, Lib3hResult};
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -140,7 +140,11 @@ impl MirrorDht {
                     trace!("@MirrorDht@ Adding peer - BAD");
                     return false;
                 }
-                trace!("@MirrorDht@ Adding peer - OK UPDATED: {} > {}", peer_info.timestamp, peer.timestamp);
+                trace!(
+                    "@MirrorDht@ Adding peer - OK UPDATED: {} > {}",
+                    peer_info.timestamp,
+                    peer.timestamp
+                );
                 peer.timestamp = peer_info.timestamp;
                 true
             }

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -221,7 +221,10 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                     if let Some(space_gateway) = maybe_space_gateway {
                         Dht::post(space_gateway, cmd)?;
                     } else {
-                        warn!("received gossip for unjoined space_gateway: {}", msg.space_address);
+                        warn!(
+                            "received gossip for unjoined space_gateway: {}",
+                            msg.space_address
+                        );
                     }
                 }
             }

--- a/crates/lib3h/src/engine/p2p_protocol.rs
+++ b/crates/lib3h/src/engine/p2p_protocol.rs
@@ -4,6 +4,7 @@ use lib3h_protocol::{data_types::DirectMessageData, Address};
 pub type SpaceAddress = String;
 pub type PeerAddress = String;
 pub type GatewayId = String;
+pub type PeerTimestamp = u64;
 
 /// Enum holding all message types in the 'network module <-> network module' protocol.
 /// TODO #150 - replace this with the p2p-protocol crate
@@ -13,7 +14,7 @@ pub enum P2pProtocol {
     DirectMessage(DirectMessageData),
     DirectMessageResult(DirectMessageData),
     /// Notify another node's our identify in a specific gateway/dht
-    PeerAddress(GatewayId, PeerAddress),
+    PeerAddress(GatewayId, PeerAddress, PeerTimestamp),
     /// Broadcast JoinSpace to all when joining a space
     BroadcastJoinSpace(SpaceAddress, PeerData),
     /// For sending a peer's 'JoinSpace' info to a newly connected peer

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -513,11 +513,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
         let space_gateway = self.space_gateway_map.get_mut(&chain_id).unwrap();
         Dht::post(
             space_gateway,
-            DhtCommand::HoldPeer(PeerData {
-                peer_address: dht_config.this_peer_address,
-                peer_uri: dht_config.this_peer_uri,
-                timestamp: 42, // TODO #166
-            }),
+            DhtCommand::HoldPeer(space_gateway.this_peer().clone()),
         )?;
         // Send Get*Lists requests
         let mut list_data = GetListData {

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -270,7 +270,9 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
                 let maybe_p2p_msg: Result<P2pProtocol, rmp_serde::decode::Error> =
                     Deserialize::deserialize(&mut de);
                 if let Ok(p2p_msg) = maybe_p2p_msg {
-                    if let P2pProtocol::PeerAddress(gateway_id, peer_address, peer_timestamp) = p2p_msg {
+                    if let P2pProtocol::PeerAddress(gateway_id, peer_address, peer_timestamp) =
+                        p2p_msg
+                    {
                         debug!(
                             "Received PeerAddress: {} | {} ({})",
                             peer_address, gateway_id, self.identifier

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -204,9 +204,11 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
         }
 
         // Send to other node our PeerAddress
+        let this_peer = self.this_peer().clone();
         let our_peer_address = P2pProtocol::PeerAddress(
             self.identifier().to_string(),
-            self.this_peer().clone().peer_address,
+            this_peer.peer_address,
+            this_peer.timestamp,
         );
         let mut buf = Vec::new();
         our_peer_address
@@ -268,7 +270,7 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
                 let maybe_p2p_msg: Result<P2pProtocol, rmp_serde::decode::Error> =
                     Deserialize::deserialize(&mut de);
                 if let Ok(p2p_msg) = maybe_p2p_msg {
-                    if let P2pProtocol::PeerAddress(gateway_id, peer_address) = p2p_msg {
+                    if let P2pProtocol::PeerAddress(gateway_id, peer_address, peer_timestamp) = p2p_msg {
                         debug!(
                             "Received PeerAddress: {} | {} ({})",
                             peer_address, gateway_id, self.identifier
@@ -277,7 +279,7 @@ impl<T: Transport, D: Dht> P2pGateway<T, D> {
                             let peer = PeerData {
                                 peer_address: peer_address.clone(),
                                 peer_uri: transport_id_to_url(id.clone()),
-                                timestamp: 42, // TODO #166
+                                timestamp: peer_timestamp,
                             };
                             Dht::post(self, DhtCommand::HoldPeer(peer)).expect("FIXME"); // TODO #58
                                                                                          // TODO #150 - Should not call process manually

--- a/crates/lib3h/src/lib.rs
+++ b/crates/lib3h/src/lib.rs
@@ -25,6 +25,7 @@ pub mod engine;
 pub mod gateway;
 pub mod transport;
 pub mod transport_wss;
+pub mod time;
 
 #[cfg(test)]
 pub mod tests {

--- a/crates/lib3h/src/lib.rs
+++ b/crates/lib3h/src/lib.rs
@@ -23,9 +23,9 @@ extern crate log;
 pub mod dht;
 pub mod engine;
 pub mod gateway;
+pub mod time;
 pub mod transport;
 pub mod transport_wss;
-pub mod time;
 
 #[cfg(test)]
 pub mod tests {

--- a/crates/lib3h/src/time.rs
+++ b/crates/lib3h/src/time.rs
@@ -1,12 +1,12 @@
-
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub fn since_epoch_ms() -> u64 {
     let start = SystemTime::now();
-    let since_the_epoch = start.duration_since(UNIX_EPOCH)
-                               .expect("Time went backwards");
-    let in_ms = since_the_epoch.as_secs() * 1000
-        + since_the_epoch.subsec_nanos() as u64 / 1_000_000;
+    let since_the_epoch = start
+        .duration_since(UNIX_EPOCH)
+        .expect("Time went backwards");
+    let in_ms =
+        since_the_epoch.as_secs() * 1000 + since_the_epoch.subsec_nanos() as u64 / 1_000_000;
     in_ms
 }
 

--- a/crates/lib3h/src/time.rs
+++ b/crates/lib3h/src/time.rs
@@ -6,7 +6,7 @@ pub fn since_epoch_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .expect("Time went backwards");
     let in_ms =
-        since_the_epoch.as_secs() * 1000 + since_the_epoch.subsec_nanos() as u64 / 1_000_000;
+        since_the_epoch.as_secs() * 1000 + u64::from(since_the_epoch.subsec_nanos()) / 1_000_000;
     in_ms
 }
 

--- a/crates/lib3h/src/time.rs
+++ b/crates/lib3h/src/time.rs
@@ -1,0 +1,25 @@
+
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub fn since_epoch_ms() -> u64 {
+    let start = SystemTime::now();
+    let since_the_epoch = start.duration_since(UNIX_EPOCH)
+                               .expect("Time went backwards");
+    let in_ms = since_the_epoch.as_secs() * 1000
+        + since_the_epoch.subsec_nanos() as u64 / 1_000_000;
+    in_ms
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::since_epoch_ms;
+
+    #[test]
+    pub fn test_since_epoch_ms() {
+        let first = since_epoch_ms();
+        println!("first: {}", first);
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        let second = since_epoch_ms();
+        assert!(second > first);
+    }
+}

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -92,6 +92,7 @@ pub fn two_join_space(alex: &mut NodeMock, billy: &mut NodeMock, space_address: 
     let (_did_work, _srv_msg_list) = billy.process().unwrap();
 
     // Billy joins space
+    println!("\n {} joins {}\n", billy.name, space_address);
     let req_id = billy.join_space(&space_address, true).unwrap();
     let (did_work, srv_msg_list) = billy.process().unwrap();
     assert!(did_work);


### PR DESCRIPTION
## PR summary
Added `since_epoch_ms()` function in new `time.rs` file.
PeerData of this is created with proper timestamp, than gossiped around.
