### PR TITLE
bump holochain_persistence to 0.0.7

### DIFF
--- a/CHANGELOG-UNRELEASED.md
+++ b/CHANGELOG-UNRELEASED.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Changed
 
+- bump holochain_persistence to `0.0.7`
+
 ### Deprecated
 
 ### Removed
@@ -15,4 +17,3 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### Fixed
 
 ### Security
-

--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
 hcid = "=0.0.6"
-holochain_persistence_api = "=0.0.6"
+holochain_persistence_api = "=0.0.7"
 # version on the left for release regex
 lib3h_protocol = { version = "=0.0.9", path = "../lib3h_protocol" }
 lib3h_crypto_api = { version = "=0.0.9", path = "../crypto_api" }

--- a/crates/lib3h_protocol/Cargo.toml
+++ b/crates/lib3h_protocol/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
 base64 = "=0.10.1"
-holochain_persistence_api = "=0.0.6"
+holochain_persistence_api = "=0.0.7"
 rmp-serde = "=0.13.7"
 serde = "=1.0.89"
 serde_derive = "=1.0.89"


### PR DESCRIPTION
## PR summary

bump holochain_persistence to 0.0.7, needed for futures crate update.