### PR TITLE
use trait-objects for transports in real_engine

### DIFF
--- a/crates/lib3h/src/engine/mod.rs
+++ b/crates/lib3h/src/engine/mod.rs
@@ -7,7 +7,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 
 use crate::{
     dht::dht_trait::{Dht, DhtFactory},
-    gateway::P2pGateway,
+    gateway::GatewayWrapper,
     transport::{transport_trait::Transport, ConnectionId},
     transport_wss::TlsConfig,
 };
@@ -47,7 +47,7 @@ pub struct TransportKeys {
 }
 
 /// Lib3h's 'real mode' as a NetworkEngine
-pub struct RealEngine<T: Transport, D: Dht> {
+pub struct RealEngine<D: Dht + 'static> {
     /// Identifier
     name: String,
     /// Config settings
@@ -59,13 +59,13 @@ pub struct RealEngine<T: Transport, D: Dht> {
     // TODO #176: Remove this if we resolve #176 without it.
     #[allow(dead_code)]
     /// Transport used by the network gateway
-    network_transport: Rc<RefCell<T>>,
+    network_transport: Rc<RefCell<dyn Transport>>,
     /// P2p gateway for the network layer
-    network_gateway: Rc<RefCell<P2pGateway<T, D>>>,
+    network_gateway: GatewayWrapper,
     /// Store active connections?
     network_connections: HashSet<ConnectionId>,
     /// Map of P2p gateway per Space+Agent
-    space_gateway_map: HashMap<ChainId, P2pGateway<P2pGateway<T, D>, D>>,
+    space_gateway_map: HashMap<ChainId, GatewayWrapper>,
     #[allow(dead_code)]
     /// crypto system to use
     crypto: Box<dyn CryptoSystem>,

--- a/crates/lib3h/src/engine/mod.rs
+++ b/crates/lib3h/src/engine/mod.rs
@@ -9,13 +9,12 @@ use crate::{
     dht::dht_trait::{Dht, DhtFactory},
     gateway::GatewayWrapper,
     track::Tracker,
-    transport::{transport_trait::Transport, ConnectionId},
+    transport::{ConnectionId, TransportWrapper},
     transport_wss::TlsConfig,
 };
 
 use lib3h_crypto_api::{Buffer, CryptoSystem};
 use lib3h_protocol::{protocol_client::Lib3hClientProtocol, Address};
-use std::{cell::RefCell, rc::Rc};
 use url::Url;
 
 /// Identifier of a source chain: SpaceAddress+AgentId
@@ -61,7 +60,7 @@ pub struct TransportKeys {
 }
 
 /// Lib3h's 'real mode' as a NetworkEngine
-pub struct RealEngine<D: Dht + 'static> {
+pub struct RealEngine<'engine, D: Dht + 'engine> {
     /// Identifier
     name: String,
     /// Config settings
@@ -75,13 +74,13 @@ pub struct RealEngine<D: Dht + 'static> {
     // TODO #176: Remove this if we resolve #176 without it.
     #[allow(dead_code)]
     /// Transport used by the network gateway
-    network_transport: Rc<RefCell<dyn Transport>>,
+    network_transport: TransportWrapper<'engine>,
     /// P2p gateway for the network layer
-    network_gateway: GatewayWrapper,
+    network_gateway: GatewayWrapper<'engine>,
     /// Store active connections?
     network_connections: HashSet<ConnectionId>,
     /// Map of P2p gateway per Space+Agent
-    space_gateway_map: HashMap<ChainId, GatewayWrapper>,
+    space_gateway_map: HashMap<ChainId, GatewayWrapper<'engine>>,
     #[allow(dead_code)]
     /// crypto system to use
     crypto: Box<dyn CryptoSystem>,

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -12,7 +12,7 @@ use rmp_serde::{Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
 
 /// Network layer related private methods
-impl<D: Dht> RealEngine<D> {
+impl<'engine, D: Dht> RealEngine<'engine, D> {
     /// Process whatever the network has in for us.
     pub(crate) fn process_network_gateway(
         &mut self,

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -4,7 +4,7 @@ use crate::{
     dht::{dht_protocol::*, dht_trait::Dht},
     engine::{p2p_protocol::P2pProtocol, RealEngine, NETWORK_GATEWAY_ID},
     error::{ErrorKind, Lib3hError, Lib3hResult},
-    transport::{protocol::*, transport_trait::Transport, ConnectionIdRef},
+    transport::{protocol::*, ConnectionIdRef},
 };
 use lib3h_protocol::{data_types::*, protocol_server::Lib3hServerProtocol, DidWork};
 
@@ -12,15 +12,14 @@ use rmp_serde::{Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
 
 /// Network layer related private methods
-impl<T: Transport, D: Dht> RealEngine<T, D> {
+impl<D: Dht> RealEngine<D> {
     /// Process whatever the network has in for us.
     pub(crate) fn process_network_gateway(
         &mut self,
     ) -> Lib3hResult<(DidWork, Vec<Lib3hServerProtocol>)> {
         let mut outbox = Vec::new();
         // Process the network gateway as a Transport
-        let (tranport_did_work, event_list) =
-            Transport::process(&mut *self.network_gateway.borrow_mut())?;
+        let (tranport_did_work, event_list) = self.network_gateway.as_transport_mut().process()?;
         debug!(
             "{} - network_gateway Transport.process(): {} {}",
             self.name,
@@ -34,7 +33,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
             }
         }
         // Process the network gateway as a DHT
-        let (dht_did_work, event_list) = Dht::process(&mut *self.network_gateway.borrow_mut())?;
+        let (dht_did_work, event_list) = self.network_gateway.as_dht_mut().process()?;
         if dht_did_work {
             for evt in event_list {
                 let mut output = self.handle_netDhtEvent(evt)?;
@@ -63,22 +62,24 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                     self.name, peer_data.peer_address, peer_data.peer_uri,
                 );
                 let cmd = TransportCommand::Connect(peer_data.peer_uri.clone());
-                Transport::post(&mut *self.network_gateway.borrow_mut(), cmd)?;
+                self.network_gateway.as_transport_mut().post(cmd)?;
             }
             DhtEvent::PeerTimedOut(peer_address) => {
                 // Disconnect from that peer by calling a Close on it.
-                let mut network_gateway = self.network_gateway.borrow_mut();
-                let maybe_connection_id = network_gateway.get_connection_id(&peer_address);
+                //let mut network_gateway = self.network_gateway.borrow_mut();
+                let maybe_connection_id = self
+                    .network_gateway
+                    .as_ref()
+                    .get_connection_id(&peer_address);
                 trace!(
                     "{} -- maybe_connection_id: {:?}",
                     self.name.clone(),
                     maybe_connection_id,
                 );
                 if let Some(connection_id) = maybe_connection_id {
-                    Transport::post(
-                        &mut *network_gateway,
-                        TransportCommand::Close(connection_id),
-                    )?;
+                    self.network_gateway
+                        .as_transport_mut()
+                        .post(TransportCommand::Close(connection_id))?;
                 }
             }
             // No entries in Network DHT
@@ -103,7 +104,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
         id: &ConnectionIdRef,
     ) -> Lib3hResult<Vec<Lib3hServerProtocol>> {
         let mut outbox = Vec::new();
-        let mut network_gateway = self.network_gateway.borrow_mut();
+        let mut network_gateway = self.network_gateway.as_mut();
         if let Some(uri) = network_gateway.get_uri(id) {
             info!("Network Connection opened: {} ({})", id, uri);
             // TODO #150 - Should do this in next process instead
@@ -215,14 +216,14 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                 });
                 // Check if its for the network_gateway
                 if msg.space_address.to_string() == NETWORK_GATEWAY_ID {
-                    Dht::post(&mut *self.network_gateway.borrow_mut(), cmd)?;
+                    self.network_gateway.as_dht_mut().post(cmd)?;
                 } else {
                     // otherwise should be for one of our space
                     let maybe_space_gateway = self
                         .space_gateway_map
                         .get_mut(&(msg.space_address.to_owned(), msg.to_peer_address.to_owned()));
                     if let Some(space_gateway) = maybe_space_gateway {
-                        Dht::post(space_gateway, cmd)?;
+                        Dht::post(&mut *space_gateway.as_dht().borrow_mut(), cmd)?;
                     } else {
                         warn!("received gossip for unjoined space: {}", msg.space_address);
                     }
@@ -265,7 +266,10 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
             P2pProtocol::BroadcastJoinSpace(gateway_id, peer_data) => {
                 debug!("Received JoinSpace: {} {:?}", gateway_id, peer_data);
                 for (_, space_gateway) in self.space_gateway_map.iter_mut() {
-                    Dht::post(space_gateway, DhtCommand::HoldPeer(peer_data.clone()))?;
+                    Dht::post(
+                        &mut *space_gateway.as_dht().borrow_mut(),
+                        DhtCommand::HoldPeer(peer_data.clone()),
+                    )?;
                 }
             }
             P2pProtocol::AllJoinedSpaceList(join_list) => {
@@ -273,7 +277,10 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                 for (space_address, peer_data) in join_list {
                     let maybe_space_gateway = self.get_first_space_mut(space_address);
                     if let Some(space_gateway) = maybe_space_gateway {
-                        Dht::post(space_gateway, DhtCommand::HoldPeer(peer_data.clone()))?;
+                        Dht::post(
+                            &mut *space_gateway.as_dht().borrow_mut(),
+                            DhtCommand::HoldPeer(peer_data.clone()),
+                        )?;
                     }
                 }
             }

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -14,7 +14,7 @@ use crate::{
         p2p_protocol::P2pProtocol, RealEngine, RealEngineConfig, TransportKeys, NETWORK_GATEWAY_ID,
     },
     error::Lib3hResult,
-    gateway::P2pGateway,
+    gateway::{GatewayWrapper, P2pGateway},
     transport::{protocol::TransportCommand, transport_trait::Transport},
     transport_wss::TransportWss,
 };
@@ -41,7 +41,7 @@ impl TransportKeys {
     }
 }
 
-impl<D: Dht> RealEngine<TransportWss<std::net::TcpStream>, D> {
+impl<D: Dht> RealEngine<D> {
     /// Constructor with TransportWss
     pub fn new(
         crypto: Box<dyn CryptoSystem>,
@@ -50,9 +50,9 @@ impl<D: Dht> RealEngine<TransportWss<std::net::TcpStream>, D> {
         dht_factory: DhtFactory<D>,
     ) -> Lib3hResult<Self> {
         // Create Transport and bind
-        let network_transport = Rc::new(RefCell::new(TransportWss::with_std_tcp_stream(
-            config.tls_config.clone(),
-        )));
+        let network_transport: Rc<RefCell<dyn Transport>> = Rc::new(RefCell::new(
+            TransportWss::with_std_tcp_stream(config.tls_config.clone()),
+        ));
         let binding = network_transport.borrow_mut().bind(&config.bind_url)?;
         // Generate keys
         // TODO #209 - Check persistence first before generating
@@ -65,12 +65,12 @@ impl<D: Dht> RealEngine<TransportWss<std::net::TcpStream>, D> {
             gossip_interval: config.dht_gossip_interval,
             timeout_threshold: config.dht_timeout_threshold,
         };
-        let network_gateway = Rc::new(RefCell::new(P2pGateway::new(
+        let network_gateway = GatewayWrapper::new(&Rc::new(RefCell::new(P2pGateway::new(
             NETWORK_GATEWAY_ID,
             Rc::clone(&network_transport),
             dht_factory,
             &dht_config,
-        )));
+        ))));
         // Done
         Ok(RealEngine {
             crypto,
@@ -90,7 +90,7 @@ impl<D: Dht> RealEngine<TransportWss<std::net::TcpStream>, D> {
 
 /// Constructor
 //#[cfg(test)]
-impl<D: Dht> RealEngine<TransportMemory, D> {
+impl<D: Dht> RealEngine<D> {
     /// Constructor with TransportMemory
     pub fn new_mock(
         crypto: Box<dyn CryptoSystem>,
@@ -99,7 +99,8 @@ impl<D: Dht> RealEngine<TransportMemory, D> {
         dht_factory: DhtFactory<D>,
     ) -> Lib3hResult<Self> {
         // Create TransportMemory as the network transport
-        let network_transport = Rc::new(RefCell::new(TransportMemory::new()));
+        let network_transport: Rc<RefCell<dyn Transport>> =
+            Rc::new(RefCell::new(TransportMemory::new()));
         // Bind & create DhtConfig
         let binding = network_transport
             .borrow_mut()
@@ -113,16 +114,16 @@ impl<D: Dht> RealEngine<TransportMemory, D> {
             timeout_threshold: config.dht_timeout_threshold,
         };
         // Create network gateway
-        let network_gateway = Rc::new(RefCell::new(P2pGateway::new(
+        let network_gateway = GatewayWrapper::new(&Rc::new(RefCell::new(P2pGateway::new(
             NETWORK_GATEWAY_ID,
             Rc::clone(&network_transport),
             dht_factory,
             &dht_config,
-        )));
+        ))));
         debug!(
             "New MOCK RealEngine {} -> {:?}",
             name,
-            network_gateway.borrow().this_peer()
+            network_gateway.as_ref().this_peer()
         );
         let transport_keys = TransportKeys::new(crypto.as_crypto_system())?;
         Ok(RealEngine {
@@ -141,9 +142,10 @@ impl<D: Dht> RealEngine<TransportMemory, D> {
     }
 }
 
-impl<T: Transport, D: Dht> NetworkEngine for RealEngine<T, D> {
+impl<D: Dht> NetworkEngine for RealEngine<D> {
     fn advertise(&self) -> Url {
         self.network_gateway
+            .as_dht()
             .borrow()
             .this_peer()
             .peer_uri
@@ -182,7 +184,7 @@ impl<T: Transport, D: Dht> NetworkEngine for RealEngine<T, D> {
 }
 
 /// Drop
-impl<T: Transport, D: Dht> Drop for RealEngine<T, D> {
+impl<D: Dht> Drop for RealEngine<D> {
     fn drop(&mut self) {
         let res = self.shutdown();
         if let Err(e) = res {
@@ -192,13 +194,13 @@ impl<T: Transport, D: Dht> Drop for RealEngine<T, D> {
 }
 
 /// Private
-impl<T: Transport, D: Dht> RealEngine<T, D> {
+impl<D: Dht> RealEngine<D> {
     /// Called on drop.
     /// Close all connections gracefully
     fn shutdown(&mut self) -> Lib3hResult<()> {
         let mut result = Ok(());
         for space_gatway in self.space_gateway_map.values_mut() {
-            let res = space_gatway.close_all();
+            let res = space_gatway.as_transport().borrow_mut().close_all();
             // Continue closing connections even if some failed
             if let Err(e) = res {
                 if result.is_ok() {
@@ -207,10 +209,13 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
             }
         }
         // Done
-        self.network_gateway.borrow_mut().close_all().map_err(|e| {
-            error!("Closing of some connection failed: {:?}", e);
-            e
-        })?;
+        self.network_gateway
+            .as_transport_mut()
+            .close_all()
+            .map_err(|e| {
+                error!("Closing of some connection failed: {:?}", e);
+                e
+            })?;
         Ok(())
     }
 
@@ -252,7 +257,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
             Lib3hClientProtocol::Connect(msg) => {
                 // Convert into TransportCommand & post to network gateway
                 let cmd = TransportCommand::Connect(msg.peer_uri);
-                Transport::post(&mut *self.network_gateway.borrow_mut(), cmd)?;
+                self.network_gateway.as_transport_mut().post(cmd)?;
             }
             Lib3hClientProtocol::JoinSpace(msg) => {
                 let mut output = self.serve_JoinSpace(&msg)?;
@@ -290,14 +295,14 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                         // https://github.com/holochain/n3h/blob/master/lib/n3h-common/track.js
                         if msg.request_id == "__author_list" {
                             let cmd = DhtCommand::BroadcastEntry(msg.entry);
-                            Dht::post(space_gateway, cmd)?;
+                            Dht::post(&mut *space_gateway.as_dht().borrow_mut(), cmd)?;
                         } else {
                             let response = FetchDhtEntryResponseData {
                                 msg_id: msg.request_id.clone(),
                                 entry: msg.entry.clone(),
                             };
                             let cmd = DhtCommand::EntryDataResponse(response);
-                            Dht::post(space_gateway, cmd)?;
+                            Dht::post(&mut *space_gateway.as_dht().borrow_mut(), cmd)?;
                         }
                     }
                 }
@@ -314,7 +319,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                     Err(res) => outbox.push(res),
                     Ok(space_gateway) => {
                         let cmd = DhtCommand::BroadcastEntry(msg.entry);
-                        Dht::post(space_gateway, cmd)?;
+                        Dht::post(&mut *space_gateway.as_dht().borrow_mut(), cmd)?;
                     }
                 }
             }
@@ -330,7 +335,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                     Err(res) => outbox.push(res),
                     Ok(space_gateway) => {
                         let cmd = DhtCommand::HoldEntryAspectAddress(msg.entry);
-                        Dht::post(space_gateway, cmd)?;
+                        Dht::post(&mut *space_gateway.as_dht().borrow_mut(), cmd)?;
                     }
                 }
             }
@@ -351,7 +356,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                             entry_address: msg.entry_address,
                         };
                         let cmd = DhtCommand::FetchEntry(msg);
-                        Dht::post(space_gateway, cmd)?;
+                        Dht::post(&mut *space_gateway.as_dht().borrow_mut(), cmd)?;
                     }
                 }
             }
@@ -376,7 +381,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                             entry,
                         };
                         let cmd = DhtCommand::EntryDataResponse(msg);
-                        Dht::post(space_gateway, cmd)?;
+                        Dht::post(&mut *space_gateway.as_dht().borrow_mut(), cmd)?;
                     }
                 }
             }
@@ -402,7 +407,8 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                         let mut count = 0;
                         for (entry_address, aspect_address_list) in msg.address_map {
                             // Check aspects and only request entry with new aspects
-                            let maybe_known_aspects = space_gateway.get_aspects_of(&entry_address);
+                            let maybe_known_aspects =
+                                space_gateway.as_ref().get_aspects_of(&entry_address);
                             if let Some(known_aspects) = maybe_known_aspects {
                                 if includes(&known_aspects, &aspect_address_list) {
                                     continue;
@@ -445,7 +451,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                                 aspect_list,
                             };
                             Dht::post(
-                                space_gateway,
+                                &mut *space_gateway.as_dht().borrow_mut(),
                                 DhtCommand::HoldEntryAspectAddress(fake_entry),
                             )?;
                         }
@@ -476,7 +482,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
         output.push(Lib3hServerProtocol::SuccessResult(res));
         // First create DhtConfig for space gateway
         let agent_id: String = join_msg.agent_id.clone().into();
-        let this_net_peer = self.network_gateway.borrow().this_peer().clone();
+        let this_net_peer = self.network_gateway.as_ref().this_peer().clone();
         let this_peer_transport_id_as_uri =
             // TODO #175 - encapsulate this conversion logic
             Url::parse(format!("transportId:{}", this_net_peer.peer_address.clone()).as_str()).unwrap();
@@ -488,16 +494,17 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
             timeout_threshold: self.config.dht_timeout_threshold,
         };
         // Create new space gateway for this ChainId
-        let new_space_gateway = P2pGateway::new_with_space(
-            Rc::clone(&self.network_gateway),
-            &join_msg.space_address,
-            self.dht_factory,
-            &dht_config,
-        );
+        let new_space_gateway =
+            GatewayWrapper::new(&Rc::new(RefCell::new(P2pGateway::new_with_space(
+                self.network_gateway.as_transport().clone(),
+                &join_msg.space_address,
+                self.dht_factory,
+                &dht_config,
+            ))));
 
         // TODO #150 - Send JoinSpace to all known peers
         let space_address: String = join_msg.space_address.clone().into();
-        let peer = new_space_gateway.this_peer().to_owned();
+        let peer = new_space_gateway.as_ref().this_peer().to_owned();
         let mut payload = Vec::new();
         let p2p_msg = P2pProtocol::BroadcastJoinSpace(space_address.clone(), peer.clone());
         p2p_msg
@@ -509,7 +516,10 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
             space_address,
             peer.peer_address,
         );
-        self.network_gateway.borrow_mut().send_all(&payload).ok();
+        self.network_gateway
+            .as_transport_mut()
+            .send_all(&payload)
+            .ok();
         // TODO END
 
         // Add it to space map
@@ -517,10 +527,10 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
             .insert(chain_id.clone(), new_space_gateway);
         // Have DHT broadcast our PeerData
         let space_gateway = self.space_gateway_map.get_mut(&chain_id).unwrap();
-        Dht::post(
-            space_gateway,
-            DhtCommand::HoldPeer(space_gateway.this_peer().clone()),
-        )?;
+        let this_peer = { space_gateway.as_ref().this_peer().clone() };
+        space_gateway
+            .as_dht_mut()
+            .post(DhtCommand::HoldPeer(this_peer))?;
         // Send Get*Lists requests
         let mut list_data = GetListData {
             space_address: join_msg.space_address.clone(),
@@ -561,7 +571,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
             result_info: vec![],
         };
         // Check if messaging self
-        let peer_address = &space_gateway.this_peer().peer_address;
+        let peer_address = &space_gateway.as_ref().this_peer().peer_address.clone();
         let to_agent_id: String = msg.to_agent_id.clone().into();
         if peer_address == &to_agent_id {
             response.result_info = "Messaging self".as_bytes().to_vec();
@@ -580,7 +590,9 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
             .unwrap();
         // Send
         let peer_address: String = msg.to_agent_id.clone().into();
-        let res = space_gateway.send(&[peer_address.as_str()], &payload);
+        let res = space_gateway
+            .as_transport_mut()
+            .send(&[peer_address.as_str()], &payload);
         if let Err(e) = res {
             response.result_info = e.to_string().as_bytes().to_vec();
             return Lib3hServerProtocol::FailureResult(response);
@@ -619,12 +631,12 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
         agent_id: &Address,
         request_id: &str,
         maybe_sender_agent_id: Option<&Address>,
-    ) -> Result<&mut P2pGateway<P2pGateway<T, D>, D>, Lib3hServerProtocol> {
+    ) -> Result<GatewayWrapper, Lib3hServerProtocol> {
         let maybe_space = self
             .space_gateway_map
             .get_mut(&(space_address.to_owned(), agent_id.to_owned()));
         if let Some(space_gateway) = maybe_space {
-            return Ok(space_gateway);
+            return Ok(space_gateway.clone());
         }
         let to_agent_id = maybe_sender_agent_id.unwrap_or(agent_id);
         let res = GenericResultData {

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -27,7 +27,6 @@ use lib3h_protocol::{
 };
 use rmp_serde::{Deserializer, Serializer};
 use serde::{Deserialize, Serialize};
-use std::sync::{Arc, RwLock};
 
 impl TransportKeys {
     pub fn new(crypto: &dyn CryptoSystem) -> Lib3hResult<Self> {
@@ -66,12 +65,12 @@ impl<'engine, D: Dht> RealEngine<'engine, D> {
             gossip_interval: config.dht_gossip_interval,
             timeout_threshold: config.dht_timeout_threshold,
         };
-        let network_gateway = GatewayWrapper::new(&Arc::new(RwLock::new(P2pGateway::new(
+        let network_gateway = GatewayWrapper::new(P2pGateway::new(
             NETWORK_GATEWAY_ID,
             network_transport.clone(),
             dht_factory,
             &dht_config,
-        ))));
+        ));
         // Done
         Ok(RealEngine {
             crypto,
@@ -115,12 +114,12 @@ impl<'engine, D: Dht> RealEngine<'engine, D> {
             timeout_threshold: config.dht_timeout_threshold,
         };
         // Create network gateway
-        let network_gateway = GatewayWrapper::new(&Arc::new(RwLock::new(P2pGateway::new(
+        let network_gateway = GatewayWrapper::new(P2pGateway::new(
             NETWORK_GATEWAY_ID,
             network_transport.clone(),
             dht_factory,
             &dht_config,
-        ))));
+        ));
         debug!(
             "New MOCK RealEngine {} -> {:?}",
             name,
@@ -558,12 +557,12 @@ impl<'engine, D: Dht> RealEngine<'engine, D> {
         };
         // Create new space gateway for this ChainId
         let new_space_gateway: GatewayWrapper<'engine> =
-            GatewayWrapper::new(&Arc::new(RwLock::new(P2pGateway::new_with_space(
+            GatewayWrapper::new(P2pGateway::new_with_space(
                 self.network_gateway.as_transport(),
                 &join_msg.space_address,
                 self.dht_factory,
                 &dht_config,
-            ))));
+            ));
 
         // TODO #150 - Send JoinSpace to all known peers
         let space_address: String = join_msg.space_address.clone().into();

--- a/crates/lib3h/src/engine/space_layer.rs
+++ b/crates/lib3h/src/engine/space_layer.rs
@@ -3,8 +3,7 @@
 use crate::{
     dht::{dht_protocol::*, dht_trait::Dht},
     engine::{p2p_protocol::SpaceAddress, ChainId, RealEngine},
-    gateway::P2pGateway,
-    transport::transport_trait::Transport,
+    gateway::GatewayWrapper,
 };
 use lib3h_protocol::{
     data_types::*, error::Lib3hProtocolResult, protocol_server::Lib3hServerProtocol,
@@ -15,26 +14,23 @@ use std::collections::HashMap;
 
 /// Space layer related private methods
 /// Engine does not process a space gateway's Transport because it is shared with the network layer
-impl<T: Transport, D: Dht> RealEngine<T, D> {
+impl<D: Dht> RealEngine<D> {
     /// Return list of space+this_peer for all currently joined Spaces
     pub fn get_all_spaces(&self) -> Vec<(SpaceAddress, PeerData)> {
         let mut result = Vec::new();
         for (chainId, space_gateway) in self.space_gateway_map.iter() {
             let space_address: String = chainId.0.clone().into();
-            result.push((space_address, space_gateway.this_peer().clone()));
+            result.push((space_address, space_gateway.as_ref().this_peer().clone()));
         }
         result
     }
 
     /// Return first space gateway for a specified space_address
-    pub fn get_first_space_mut(
-        &mut self,
-        space_address: &str,
-    ) -> Option<&mut P2pGateway<P2pGateway<T, D>, D>> {
+    pub fn get_first_space_mut(&mut self, space_address: &str) -> Option<GatewayWrapper> {
         for (chainId, space_gateway) in self.space_gateway_map.iter_mut() {
             let current_space_address: String = chainId.0.clone().into();
             if current_space_address == space_address {
-                return Some(space_gateway);
+                return Some(space_gateway.clone());
             }
         }
         None
@@ -48,7 +44,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
         let mut outbox = Vec::new();
         let mut dht_outbox = HashMap::new();
         for (chain_id, space_gateway) in self.space_gateway_map.iter_mut() {
-            let (did_work, event_list) = Dht::process(space_gateway)?;
+            let (did_work, event_list) = Dht::process(&mut *space_gateway.as_dht().borrow_mut())?;
             if did_work {
                 // TODO: perf optim, don't copy chain_id
                 dht_outbox.insert(chain_id.clone(), event_list);
@@ -91,11 +87,14 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                 debug!(
                     "{} -- ({}).post() HoldPeer {:?}",
                     self.name,
-                    space_gateway.identifier(),
+                    space_gateway.as_ref().identifier(),
                     peer_data,
                 );
                 // For now accept all request
-                Dht::post(space_gateway, DhtCommand::HoldPeer(peer_data))?;
+                Dht::post(
+                    &mut *space_gateway.as_dht().borrow_mut(),
+                    DhtCommand::HoldPeer(peer_data),
+                )?;
             }
             DhtEvent::PeerTimedOut(_peer_address) => {
                 // no-op

--- a/crates/lib3h/src/gateway/gateway_dht.rs
+++ b/crates/lib3h/src/gateway/gateway_dht.rs
@@ -11,7 +11,7 @@ use rmp_serde::Serializer;
 use serde::Serialize;
 
 /// Compose DHT
-impl<D: Dht> Dht for P2pGateway<D> {
+impl<'gateway, D: Dht> Dht for P2pGateway<'gateway, D> {
     /// Peer info
     fn get_peer_list(&self) -> Vec<PeerData> {
         self.inner_dht.get_peer_list()
@@ -80,7 +80,7 @@ impl<D: Dht> Dht for P2pGateway<D> {
 }
 
 /// Private internals
-impl<D: Dht> P2pGateway<D> {
+impl<'gateway, D: Dht> P2pGateway<'gateway, D> {
     /// Handle a DhtEvent sent to us by our internal DHT.
     pub(crate) fn handle_DhtEvent(&mut self, evt: DhtEvent) -> Lib3hResult<()> {
         trace!("({}).handle_DhtEvent() {:?}", self.identifier, evt);
@@ -110,7 +110,7 @@ impl<D: Dht> P2pGateway<D> {
                         .expect("Should gossip to a known peer");
                     // Forward gossip to the inner_transport
                     self.inner_transport
-                        .borrow_mut()
+                        .as_mut()
                         .send(&[&to_conn_id], &payload)?;
                 }
             }

--- a/crates/lib3h/src/gateway/gateway_dht.rs
+++ b/crates/lib3h/src/gateway/gateway_dht.rs
@@ -4,15 +4,14 @@ use crate::{
     dht::{dht_protocol::*, dht_trait::Dht},
     engine::{p2p_protocol::*, NETWORK_GATEWAY_ID},
     error::Lib3hResult,
-    gateway::P2pGateway,
-    transport::transport_trait::Transport,
+    gateway::{Gateway, P2pGateway},
 };
 use lib3h_protocol::{Address, DidWork};
 use rmp_serde::Serializer;
 use serde::Serialize;
 
 /// Compose DHT
-impl<T: Transport, D: Dht> Dht for P2pGateway<T, D> {
+impl<D: Dht> Dht for P2pGateway<D> {
     /// Peer info
     fn get_peer_list(&self) -> Vec<PeerData> {
         self.inner_dht.get_peer_list()
@@ -81,7 +80,7 @@ impl<T: Transport, D: Dht> Dht for P2pGateway<T, D> {
 }
 
 /// Private internals
-impl<T: Transport, D: Dht> P2pGateway<T, D> {
+impl<D: Dht> P2pGateway<D> {
     /// Handle a DhtEvent sent to us by our internal DHT.
     pub(crate) fn handle_DhtEvent(&mut self, evt: DhtEvent) -> Lib3hResult<()> {
         trace!("({}).handle_DhtEvent() {:?}", self.identifier, evt);

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -17,12 +17,12 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 /// Compose Transport
-impl<D: Dht> Transport for P2pGateway<D> {
+impl<'gateway, D: Dht> Transport for P2pGateway<'gateway, D> {
     // TODO #176 - Return a higher-level uri instead?
     fn connect(&mut self, uri: &Url) -> TransportResult<ConnectionId> {
         trace!("({}).connect() {}", self.identifier, uri);
         // Connect
-        let connection_id = self.inner_transport.borrow_mut().connect(&uri)?;
+        let connection_id = self.inner_transport.as_mut().connect(&uri)?;
         // Store result in connection map
         self.connection_map
             .insert(uri.clone(), connection_id.clone());
@@ -32,12 +32,12 @@ impl<D: Dht> Transport for P2pGateway<D> {
 
     // TODO #176 - remove conn id conn_map??
     fn close(&mut self, id: &ConnectionIdRef) -> TransportResult<()> {
-        self.inner_transport.borrow_mut().close(id)
+        self.inner_transport.as_mut().close(id)
     }
 
     // TODO #176
     fn close_all(&mut self) -> TransportResult<()> {
-        self.inner_transport.borrow_mut().close_all()
+        self.inner_transport.as_mut().close_all()
     }
 
     /// id_list =
@@ -68,7 +68,7 @@ impl<D: Dht> Transport for P2pGateway<D> {
         }
         let ref_list: Vec<&str> = conn_list.iter().map(|v| v.as_str()).collect();
         // Send on the inner Transport
-        self.inner_transport.borrow_mut().send(&ref_list, payload)
+        self.inner_transport.as_mut().send(&ref_list, payload)
     }
 
     ///
@@ -82,7 +82,7 @@ impl<D: Dht> Transport for P2pGateway<D> {
     ///
     fn bind(&mut self, url: &Url) -> TransportResult<Url> {
         trace!("({}) bind() {}", self.identifier, url);
-        self.inner_transport.borrow_mut().bind(url)
+        self.inner_transport.as_mut().bind(url)
     }
 
     ///
@@ -118,7 +118,7 @@ impl<D: Dht> Transport for P2pGateway<D> {
         // Transport::process() on the network gateway,
         // otherwise remove this code and have RealEngine explicitly call the process of the
         // Network transport.
-        let (inner_did_work, mut event_list) = self.inner_transport.borrow_mut().process()?;
+        let (inner_did_work, mut event_list) = self.inner_transport.as_mut().process()?;
         trace!(
             "({}).Transport.inner_process() - output: {} {}",
             self.identifier,
@@ -148,14 +148,14 @@ impl<D: Dht> Transport for P2pGateway<D> {
 
     /// TODO: return a higher-level uri instead
     fn get_uri(&self, id: &ConnectionIdRef) -> Option<Url> {
-        self.inner_transport.borrow().get_uri(id)
+        self.inner_transport.as_ref().get_uri(id)
         //let maybe_peer_data = self.inner_dht.get_peer(id);
         //maybe_peer_data.map(|pd| pd.peer_address)
     }
 }
 
 /// Private internals
-impl<D: Dht> P2pGateway<D> {
+impl<'gateway, D: Dht> P2pGateway<'gateway, D> {
     /// Get Uris from DHT peer_address'
     pub(crate) fn dht_address_to_uri_list(
         &self,
@@ -208,7 +208,7 @@ impl<D: Dht> P2pGateway<D> {
             our_peer_address,
             id,
         );
-        return self.inner_transport.borrow_mut().send(&[&id], &buf);
+        return self.inner_transport.as_mut().send(&[&id], &buf);
     }
 
     /// Process a transportEvent received from our internal connection.
@@ -224,7 +224,7 @@ impl<D: Dht> P2pGateway<D> {
                     "({}) Connection Error for {}: {}\n Closing connection.",
                     self.identifier, id, e,
                 );
-                self.inner_transport.borrow_mut().close(id)?;
+                self.inner_transport.as_mut().close(id)?;
             }
             TransportEvent::ConnectResult(id, _) => {
                 info!("({}) Outgoing connection opened: {}", self.identifier, id);
@@ -253,7 +253,7 @@ impl<D: Dht> P2pGateway<D> {
                         );
                         let peer_uri = self
                             .inner_transport
-                            .borrow_mut()
+                            .as_mut()
                             .get_uri(connection_id)
                             .expect("FIXME"); // TODO #58
                         debug!("peer_uri of: {} = {}", connection_id, peer_uri);

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -3,7 +3,7 @@
 use crate::{
     dht::{dht_protocol::*, dht_trait::Dht},
     engine::p2p_protocol::P2pProtocol,
-    gateway::P2pGateway,
+    gateway::{Gateway, P2pGateway},
     transport::{
         error::{TransportError, TransportResult},
         protocol::{TransportCommand, TransportEvent},
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 use url::Url;
 
 /// Compose Transport
-impl<T: Transport, D: Dht> Transport for P2pGateway<T, D> {
+impl<D: Dht> Transport for P2pGateway<D> {
     // TODO #176 - Return a higher-level uri instead?
     fn connect(&mut self, uri: &Url) -> TransportResult<ConnectionId> {
         trace!("({}).connect() {}", self.identifier, uri);
@@ -155,7 +155,7 @@ impl<T: Transport, D: Dht> Transport for P2pGateway<T, D> {
 }
 
 /// Private internals
-impl<T: Transport, D: Dht> P2pGateway<T, D> {
+impl<D: Dht> P2pGateway<D> {
     /// Get Uris from DHT peer_address'
     pub(crate) fn dht_address_to_uri_list(
         &self,

--- a/crates/lib3h/src/gateway/mod.rs
+++ b/crates/lib3h/src/gateway/mod.rs
@@ -15,6 +15,8 @@ use std::{
 
 use url::Url;
 
+/// describes a super construct of a Transport and a Dht allowing
+/// Transport access via peer discovery handled by the Dht
 pub trait Gateway: Transport + Dht {
     fn identifier(&self) -> &str;
     fn get_connection_id(&self, peer_address: &str) -> Option<String>;
@@ -30,6 +32,8 @@ pub struct GatewayWrapper<'wrap> {
 }
 
 impl<'wrap> GatewayWrapper<'wrap> {
+    /// create a super-fat trait-object pointer to access concrete gateway
+    /// as a gateway, transport, or dht
     pub fn new<T: Gateway + 'wrap>(concrete: T) -> Self {
         let concrete = Arc::new(RwLock::new(concrete));
         Self {
@@ -39,40 +43,49 @@ impl<'wrap> GatewayWrapper<'wrap> {
         }
     }
 
+    /// clone a pointer to the internal TransportWrapper
     pub fn as_transport(&self) -> TransportWrapper<'wrap> {
         self.transport.clone()
     }
 
+    /// immutable ref to the dyn Transport
     pub fn as_transport_ref(&self) -> RwLockReadGuard<'_, dyn Transport + 'wrap> {
         self.transport.as_ref()
     }
 
+    /// mutable ref to the dyn Transport
     pub fn as_transport_mut(&self) -> RwLockWriteGuard<'_, dyn Transport + 'wrap> {
         self.transport.as_mut()
     }
 
+    /// clone a pointer to the internal dyn Dht
     pub fn as_dht(&self) -> Arc<RwLock<dyn Dht + 'wrap>> {
         self.dht.clone()
     }
 
+    /// immutable ref to the dyn Dht
     pub fn as_dht_ref(&self) -> RwLockReadGuard<'_, dyn Dht + 'wrap> {
-        self.dht.read().expect("can access")
+        self.dht.read().expect("failed to obtain read lock")
     }
 
+    /// mutable ref to the dyn Dht
     pub fn as_dht_mut(&self) -> RwLockWriteGuard<'_, dyn Dht + 'wrap> {
-        self.dht.write().expect("can access")
+        self.dht.write().expect("failed to obtain write lock")
     }
 
+    /// clone a pointer to the internal dyn Gateway
     pub fn as_gateway(&self) -> Arc<RwLock<dyn Gateway + 'wrap>> {
         self.gateway.clone()
     }
 
+    /// immutable ref to the dyn Gateway
     pub fn as_ref(&self) -> RwLockReadGuard<'_, dyn Gateway + 'wrap> {
-        self.gateway.read().expect("can access")
+        self.gateway.read().expect("failed to obtain read lock")
     }
 
+    /// mutable ref to the dyn Gateway
     pub fn as_mut(&self) -> RwLockWriteGuard<'_, dyn Gateway + 'wrap> {
-        self.gateway.write().expect("can access")
+        self.gateway.write().expect("failed to obtain write lock")
     }
 }
 

--- a/crates/lib3h/src/gateway/mod.rs
+++ b/crates/lib3h/src/gateway/mod.rs
@@ -14,12 +14,150 @@ use std::{
 
 use url::Url;
 
+pub trait Gateway: Transport + Dht {
+    fn identifier(&self) -> &str;
+    fn get_connection_id(&self, peer_address: &str) -> Option<String>;
+}
+
+/// since rust doesn't suport upcasting to supertraits
+/// create a super-fat-pointer in this wrapper struct
+#[derive(Clone)]
+pub struct GatewayWrapper {
+    gateway: Rc<RefCell<dyn Gateway>>,
+    transport: Rc<RefCell<dyn Transport>>,
+    dht: Rc<RefCell<dyn Dht>>,
+}
+
+impl GatewayWrapper {
+    pub fn new<T: Gateway + 'static>(concrete: &Rc<RefCell<T>>) -> Self {
+        Self {
+            gateway: concrete.clone(),
+            transport: concrete.clone(),
+            dht: concrete.clone(),
+        }
+    }
+
+    pub fn as_transport(&self) -> Rc<RefCell<dyn Transport>> {
+        self.transport.clone()
+    }
+
+    pub fn as_transport_ref(&self) -> TransportRef {
+        TransportRef(self.transport.borrow())
+    }
+
+    pub fn as_transport_mut(&self) -> TransportRefMut {
+        TransportRefMut(self.transport.borrow_mut())
+    }
+
+    pub fn as_dht(&self) -> Rc<RefCell<dyn Dht>> {
+        self.dht.clone()
+    }
+
+    pub fn as_dht_ref(&self) -> DhtRef {
+        DhtRef(self.dht.borrow())
+    }
+
+    pub fn as_dht_mut(&self) -> DhtRefMut {
+        DhtRefMut(self.dht.borrow_mut())
+    }
+
+    pub fn as_gateway(&self) -> Rc<RefCell<dyn Gateway>> {
+        self.gateway.clone()
+    }
+
+    pub fn as_ref(&self) -> GatewayRef {
+        GatewayRef(self.gateway.borrow())
+    }
+
+    pub fn as_mut(&self) -> GatewayRefMut {
+        GatewayRefMut(self.gateway.borrow_mut())
+    }
+}
+
+pub struct TransportRef<'a>(std::cell::Ref<'a, dyn Transport>);
+
+impl<'a> std::ops::Deref for TransportRef<'a> {
+    type Target = dyn Transport + 'a;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+pub struct TransportRefMut<'a>(std::cell::RefMut<'a, dyn Transport>);
+
+impl<'a> std::ops::Deref for TransportRefMut<'a> {
+    type Target = dyn Transport + 'a;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+impl std::ops::DerefMut for TransportRefMut<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.0
+    }
+}
+
+pub struct DhtRef<'a>(std::cell::Ref<'a, dyn Dht>);
+
+impl<'a> std::ops::Deref for DhtRef<'a> {
+    type Target = dyn Dht + 'a;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+pub struct DhtRefMut<'a>(std::cell::RefMut<'a, dyn Dht>);
+
+impl<'a> std::ops::Deref for DhtRefMut<'a> {
+    type Target = dyn Dht + 'a;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+impl std::ops::DerefMut for DhtRefMut<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.0
+    }
+}
+
+pub struct GatewayRef<'a>(std::cell::Ref<'a, dyn Gateway>);
+
+impl<'a> std::ops::Deref for GatewayRef<'a> {
+    type Target = dyn Gateway + 'a;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+pub struct GatewayRefMut<'a>(std::cell::RefMut<'a, dyn Gateway>);
+
+impl<'a> std::ops::Deref for GatewayRefMut<'a> {
+    type Target = dyn Gateway + 'a;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+impl std::ops::DerefMut for GatewayRefMut<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut *self.0
+    }
+}
+
 /// Gateway to a P2P network.
 /// Combines a transport and a DHT.
 /// Tracks distributed data for that P2P network in a DHT.
 /// P2pGateway should not `post() & process()` its inner transport but call it synchrounously.
-pub struct P2pGateway<T: Transport, D: Dht> {
-    inner_transport: Rc<RefCell<T>>,
+pub struct P2pGateway<D: Dht> {
+    inner_transport: Rc<RefCell<dyn Transport>>,
     inner_dht: D,
     /// Used for distinguishing gateways
     identifier: String,

--- a/crates/lib3h/src/gateway/mod.rs
+++ b/crates/lib3h/src/gateway/mod.rs
@@ -30,7 +30,8 @@ pub struct GatewayWrapper<'wrap> {
 }
 
 impl<'wrap> GatewayWrapper<'wrap> {
-    pub fn new<T: Gateway + 'wrap>(concrete: &Arc<RwLock<T>>) -> Self {
+    pub fn new<T: Gateway + 'wrap>(concrete: T) -> Self {
+        let concrete = Arc::new(RwLock::new(concrete));
         Self {
             gateway: concrete.clone(),
             transport: TransportWrapper::assume(concrete.clone()),

--- a/crates/lib3h/src/gateway/p2p_gateway.rs
+++ b/crates/lib3h/src/gateway/p2p_gateway.rs
@@ -3,26 +3,22 @@
 use crate::{
     dht::dht_trait::{Dht, DhtConfig, DhtFactory},
     gateway::{Gateway, P2pGateway},
-    transport::transport_trait::Transport,
+    transport::TransportWrapper,
 };
 use lib3h_protocol::Address;
-use std::{
-    cell::RefCell,
-    collections::{HashMap, VecDeque},
-    rc::Rc,
-};
+use std::collections::{HashMap, VecDeque};
 
 //--------------------------------------------------------------------------------------------------
 // Constructors
 //--------------------------------------------------------------------------------------------------
 
 /// any Transport Constructor
-impl<D: Dht> P2pGateway<D> {
+impl<'gateway, D: Dht> P2pGateway<'gateway, D> {
     /// Constructor
     /// Bind and set advertise on construction by using the name as URL.
     pub fn new(
         identifier: &str,
-        inner_transport: Rc<RefCell<dyn Transport>>,
+        inner_transport: TransportWrapper<'gateway>,
         dht_factory: DhtFactory<D>,
         dht_config: &DhtConfig,
     ) -> Self {
@@ -36,7 +32,7 @@ impl<D: Dht> P2pGateway<D> {
     }
 }
 
-impl<D: Dht> Gateway for P2pGateway<D> {
+impl<'gateway, D: Dht> Gateway for P2pGateway<'gateway, D> {
     /// This Gateway's identifier
     fn identifier(&self) -> &str {
         self.identifier.as_str()
@@ -74,10 +70,10 @@ impl<D: Dht> Gateway for P2pGateway<D> {
 }
 
 /// P2pGateway Constructor
-impl<D: Dht> P2pGateway<D> {
+impl<'gateway, D: Dht> P2pGateway<'gateway, D> {
     /// Constructors
     pub fn new_with_space(
-        network_gateway: Rc<RefCell<dyn Transport>>,
+        network_gateway: TransportWrapper<'gateway>,
         space_address: &Address,
         dht_factory: DhtFactory<D>,
         dht_config: &DhtConfig,

--- a/crates/lib3h/src/transport/mod.rs
+++ b/crates/lib3h/src/transport/mod.rs
@@ -14,32 +14,38 @@ pub type ConnectionIdRef = str;
 
 use transport_trait::Transport;
 
+/// Hide complexity of Arc<RwLock<dyn Transport>>
+/// making it more ergonomic to work with
 #[derive(Clone)]
 pub struct TransportWrapper<'wrap> {
     inner: Arc<RwLock<dyn Transport + 'wrap>>,
 }
 
 impl<'wrap> TransportWrapper<'wrap> {
+    /// wrap a concrete Transport into an Arc<RwLock<dyn Transport>>
     pub fn new<T: Transport + 'wrap>(concrete: T) -> Self {
         Self {
             inner: Arc::new(RwLock::new(concrete)),
         }
     }
 
+    /// if we already have an Arc<RwLock<dyn Transport>>,
+    /// us it directly as our inner
     pub fn assume(inner: Arc<RwLock<dyn Transport + 'wrap>>) -> Self {
         Self { inner }
     }
 
+    /// get an immutable ref to Transport trait object
     pub fn as_ref(&self) -> RwLockReadGuard<'_, dyn Transport + 'wrap> {
-        self.inner.read().expect("can access")
+        self.inner.read().expect("failed to obtain read lock")
     }
 
+    /// get a mutable ref to Transport trait object
     pub fn as_mut(&self) -> RwLockWriteGuard<'_, dyn Transport + 'wrap> {
-        self.inner.write().expect("can access")
+        self.inner.write().expect("failed to obtain write lock")
     }
 }
 
-///
 #[cfg(test)]
 pub mod tests {
     #![allow(non_snake_case)]

--- a/crates/lib3h/src/transport/mod.rs
+++ b/crates/lib3h/src/transport/mod.rs
@@ -1,4 +1,7 @@
 //! common types and traits for working with Transport instances
+
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
 pub mod error;
 pub mod memory_mock;
 pub mod protocol;
@@ -8,6 +11,33 @@ pub mod transport_trait;
 /// a connection identifier
 pub type ConnectionId = String;
 pub type ConnectionIdRef = str;
+
+use transport_trait::Transport;
+
+#[derive(Clone)]
+pub struct TransportWrapper<'wrap> {
+    inner: Arc<RwLock<dyn Transport + 'wrap>>,
+}
+
+impl<'wrap> TransportWrapper<'wrap> {
+    pub fn new<T: Transport + 'wrap>(concrete: T) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(concrete)),
+        }
+    }
+
+    pub fn assume(inner: Arc<RwLock<dyn Transport + 'wrap>>) -> Self {
+        Self { inner }
+    }
+
+    pub fn as_ref(&self) -> RwLockReadGuard<'_, dyn Transport + 'wrap> {
+        self.inner.read().expect("can access")
+    }
+
+    pub fn as_mut(&self) -> RwLockWriteGuard<'_, dyn Transport + 'wrap> {
+        self.inner.write().expect("can access")
+    }
+}
 
 ///
 #[cfg(test)]

--- a/crates/lib3h/src/transport/transport_crypto.rs
+++ b/crates/lib3h/src/transport/transport_crypto.rs
@@ -9,21 +9,21 @@ use lib3h_protocol::DidWork;
 use url::Url;
 
 /// Wraps any transport and adds cryptography
-pub struct TransportCrypto<T: Transport> {
-    inner_transport: T,
+pub struct TransportCrypto {
+    inner_transport: Box<dyn Transport>,
 }
 
 /// Constructor
 /// TODO #177 - Consume inner_tranport or have it be a reference?
-impl<T: Transport> TransportCrypto<T> {
-    pub fn new(inner_transport: T) -> Self {
+impl TransportCrypto {
+    pub fn new(inner_transport: Box<dyn Transport>) -> Self {
         TransportCrypto { inner_transport }
     }
 }
 
 /// Implement Transport trait by composing inner transport
 /// TODO #177 - passthrough for now
-impl<T: Transport> Transport for TransportCrypto<T> {
+impl Transport for TransportCrypto {
     fn connect(&mut self, uri: &Url) -> TransportResult<ConnectionId> {
         self.inner_transport.connect(&uri)
     }

--- a/crates/lib3h/tests/engine_test.rs
+++ b/crates/lib3h/tests/engine_test.rs
@@ -84,7 +84,7 @@ fn basic_setup_mock(name: &str) -> RealEngine<MirrorDht> {
     engine
 }
 
-fn basic_setup_wss() -> RealEngine<MirrorDht> {
+fn basic_setup_wss<'a>() -> RealEngine<'a, MirrorDht> {
     let config = RealEngineConfig {
         tls_config: TlsConfig::Unencrypted,
         socket_type: "ws".into(),

--- a/crates/lib3h/tests/engine_test.rs
+++ b/crates/lib3h/tests/engine_test.rs
@@ -12,8 +12,7 @@ extern crate lib3h_sodium;
 use lib3h::{
     dht::{dht_trait::Dht, mirror_dht::MirrorDht},
     engine::{RealEngine, RealEngineConfig},
-    transport::{memory_mock::transport_memory::TransportMemory, transport_trait::Transport},
-    transport_wss::{TlsConfig, TransportWss},
+    transport_wss::TlsConfig,
 };
 use lib3h_protocol::{
     data_types::*, network_engine::NetworkEngine, protocol_client::Lib3hClientProtocol,
@@ -58,7 +57,7 @@ fn enable_logging_for_test(enable: bool) {
 // Engine Setup
 //--------------------------------------------------------------------------------------------------
 
-fn basic_setup_mock(name: &str) -> RealEngine<TransportMemory, MirrorDht> {
+fn basic_setup_mock(name: &str) -> RealEngine<MirrorDht> {
     let config = RealEngineConfig {
         tls_config: TlsConfig::Unencrypted,
         socket_type: "mem".into(),
@@ -85,7 +84,7 @@ fn basic_setup_mock(name: &str) -> RealEngine<TransportMemory, MirrorDht> {
     engine
 }
 
-fn basic_setup_wss() -> RealEngine<TransportWss<std::net::TcpStream>, MirrorDht> {
+fn basic_setup_wss() -> RealEngine<MirrorDht> {
     let config = RealEngineConfig {
         tls_config: TlsConfig::Unencrypted,
         socket_type: "ws".into(),
@@ -171,7 +170,7 @@ fn basic_track_test_mock() {
     basic_track_test(&mut engine);
 }
 
-fn basic_track_test<T: Transport, D: Dht>(engine: &mut RealEngine<T, D>) {
+fn basic_track_test<D: Dht>(engine: &mut RealEngine<D>) {
     // Test
     let mut track_space = SpaceData {
         request_id: "track_a_1".into(),

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -19,7 +19,6 @@ use lib3h::{
     dht::mirror_dht::MirrorDht,
     engine::{RealEngine, RealEngineConfig},
     error::Lib3hResult,
-    transport::memory_mock::transport_memory::TransportMemory,
     transport_wss::TlsConfig,
 };
 use lib3h_protocol::{network_engine::NetworkEngine, Address};
@@ -59,7 +58,7 @@ fn construct_mock_engine(
     config: &RealEngineConfig,
     name: &str,
 ) -> Lib3hResult<Box<dyn NetworkEngine>> {
-    let engine: RealEngine<TransportMemory, MirrorDht> = RealEngine::new_mock(
+    let engine: RealEngine<MirrorDht> = RealEngine::new_mock(
         Box::new(lib3h_sodium::SodiumCryptoSystem::new()),
         config.clone(),
         name.into(),


### PR DESCRIPTION
## PR summary

The main impetus for this change is that, before this, we could not treat a gateway as a transport (i.e. as the sub-layer for TransportCrypto). This work was needed in order to be able to refer to a gateway as a trait-object for a transport.

Rust does not make this easy, as [upcasting to super-traits is not yet supported](https://internals.rust-lang.org/t/wheres-the-catch-with-box-read-write/6617) (there are several other internals threads that similarly peter out without coming to any conclusion)

So... we make a super-fat pointer in the form of `GatewayWrapper` that keep references to all the forms of traits we might need.

As a side effect, I think the code is actually *more* ergonomic, i.e. we got to change all those explicit method calls like:

```rust
// from
Dht::post(&mut *self.network_gateway.borrow_mut(), cmd)?;
// to
self.network_gateway.as_dht_mut().post(cmd)?;
```

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
