### PR TITLE
Make dht config fields private

### DIFF
--- a/crates/lib3h/src/dht/dht_trait.rs
+++ b/crates/lib3h/src/dht/dht_trait.rs
@@ -13,17 +13,17 @@ pub const DEFAULT_TIMEOUT_THRESHOLD_MS: u64 = 60000;
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct DhtConfig {
-    pub this_peer_address: PeerAddress,
+    this_peer_address: PeerAddress,
     #[serde(with = "url_serde")]
-    pub this_peer_uri: Url,
-    pub custom: Vec<u8>,
-    pub gossip_interval: u64,
-    pub timeout_threshold: u64,
+    this_peer_uri: Url,
+    custom: Vec<u8>,
+    gossip_interval: u64,
+    timeout_threshold: u64,
 }
 
 impl DhtConfig {
     pub fn new(peer_address: &str, peer_uri: &Url) -> Self {
-        DhtConfig {
+        Self {
             this_peer_address: peer_address.to_owned(),
             this_peer_uri: peer_uri.to_owned(),
             custom: vec![],
@@ -31,7 +31,38 @@ impl DhtConfig {
             timeout_threshold: DEFAULT_TIMEOUT_THRESHOLD_MS,
         }
     }
+
+    pub fn with_real_engine_config(
+        peer_address: &str,
+        peer_uri: &Url,
+        config: &crate::engine::RealEngineConfig,
+    ) -> Self {
+        Self {
+            this_peer_address: peer_address.to_owned(),
+            this_peer_uri: peer_uri.to_owned(),
+            custom: config.clone().dht_custom_config,
+            gossip_interval: config.dht_gossip_interval,
+            timeout_threshold: config.dht_timeout_threshold,
+        }
+    }
+
+    pub fn this_peer_address(&self) -> PeerAddress {
+        self.this_peer_address.clone()
+    }
+
+    pub fn this_peer_uri(&self) -> Url {
+        self.this_peer_uri.clone()
+    }
+
+    pub fn timeout_threshold(&self) -> u64 {
+        self.timeout_threshold
+    }
+
+    pub fn gossip_interval(&self) -> u64 {
+        self.gossip_interval
+    }
 }
+
 pub type DhtFactory<D> = fn(config: &DhtConfig) -> Lib3hResult<D>;
 
 /// Allow storage and retrieval of peer & entry data.

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -61,8 +61,8 @@ impl MirrorDht {
             timed_out_map: HashMap::new(),
             entry_list: HashMap::new(),
             this_peer: PeerData {
-                peer_address: config.this_peer_address.to_owned(),
-                peer_uri: config.this_peer_uri.clone(),
+                peer_address: config.this_peer_address().to_owned(),
+                peer_uri: config.this_peer_uri().clone(),
                 timestamp,
             },
             pending_fetch_request_list: HashSet::new(),
@@ -154,7 +154,7 @@ impl Dht for MirrorDht {
                 continue;
             }
             // Check if timed-out
-            if now - peer.timestamp > self.config.timeout_threshold {
+            if now - peer.timestamp > self.config.timeout_threshold() {
                 debug!("@MirrorDht@ peer {} timed-out", peer_address);
                 outbox.push(DhtEvent::PeerTimedOut(peer_address.clone()));
                 timed_out_list.push(peer_address.clone());
@@ -170,9 +170,9 @@ impl Dht for MirrorDht {
             "@MirrorDht@ now: {} ; last_gossip: {} ({})",
             now,
             self.last_gossip_of_self,
-            self.config.gossip_interval,
+            self.config.gossip_interval(),
         );
-        if now - self.last_gossip_of_self > self.config.gossip_interval {
+        if now - self.last_gossip_of_self > self.config.gossip_interval() {
             self.last_gossip_of_self = now;
             let gossip_data = self.gossip_self(self.get_other_peer_list());
             if gossip_data.peer_address_list.len() > 0 {
@@ -239,7 +239,8 @@ impl MirrorDht {
                     peer.timestamp,
                 );
                 peer.timestamp = peer_info.timestamp;
-                if crate::time::since_epoch_ms() - peer.timestamp < self.config.timeout_threshold {
+                if crate::time::since_epoch_ms() - peer.timestamp < self.config.timeout_threshold()
+                {
                     self.timed_out_map
                         .insert(peer_info.peer_address.clone(), false);
                 }

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -57,13 +57,11 @@ impl<D: Dht> RealEngine<TransportWss<std::net::TcpStream>, D> {
         // TODO #209 - Check persistence first before generating
         let transport_keys = TransportKeys::new(crypto.as_crypto_system())?;
         // Generate DHT config and create network_gateway
-        let dht_config = DhtConfig {
-            this_peer_address: transport_keys.transport_id.clone(),
-            this_peer_uri: binding,
-            custom: config.dht_custom_config.clone(),
-            gossip_interval: config.dht_gossip_interval,
-            timeout_threshold: config.dht_timeout_threshold,
-        };
+        let dht_config = DhtConfig::with_real_engine_config(
+            transport_keys.transport_id.clone().as_str(),
+            &binding,
+            &config,
+        );
         let network_gateway = Rc::new(RefCell::new(P2pGateway::new(
             NETWORK_GATEWAY_ID,
             Rc::clone(&network_transport),
@@ -107,13 +105,8 @@ impl<D: Dht> RealEngine<TransportMemory, D> {
             .borrow_mut()
             .bind(&config.bind_url)
             .expect("TransportMemory.bind() failed. bind-url might not be unique?");
-        let dht_config = DhtConfig {
-            this_peer_address: format!("{}_tId", name),
-            this_peer_uri: binding,
-            custom: config.dht_custom_config.clone(),
-            gossip_interval: config.dht_gossip_interval,
-            timeout_threshold: config.dht_timeout_threshold,
-        };
+        let dht_config =
+            DhtConfig::with_real_engine_config(format!("{}_tId", name).as_str(), &binding, &config);
         // Create network gateway
         let network_gateway = Rc::new(RefCell::new(P2pGateway::new(
             NETWORK_GATEWAY_ID,
@@ -570,13 +563,11 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
         let this_peer_transport_id_as_uri =
             // TODO #175 - encapsulate this conversion logic
             Url::parse(format!("transportId:{}", this_net_peer.peer_address.clone()).as_str()).unwrap();
-        let dht_config = DhtConfig {
-            this_peer_address: agent_id,
-            this_peer_uri: this_peer_transport_id_as_uri,
-            custom: self.config.dht_custom_config.clone(),
-            gossip_interval: self.config.dht_gossip_interval,
-            timeout_threshold: self.config.dht_timeout_threshold,
-        };
+        let dht_config = DhtConfig::with_real_engine_config(
+            agent_id.as_str(),
+            &this_peer_transport_id_as_uri,
+            &self.config,
+        );
         // Create new space gateway for this ChainId
         let new_space_gateway = P2pGateway::new_with_space(
             Rc::clone(&self.network_gateway),


### PR DESCRIPTION
## PR summary

This PR tightens the `DhtConfig` construction and access of its fields. The motivation was to simplify analysis of how different config values could have been constructed or mutated when debugging. 

The fields are now private and there are two constructors for creating a dht config- one basic version with default dht timeout / gossip parameters and one that sources them from a `RealEngineConfig`.
  
## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
