### PR TITLE
Make gossip data opaque

### DIFF
--- a/crates/lib3h/src/dht/dht_protocol.rs
+++ b/crates/lib3h/src/dht/dht_protocol.rs
@@ -1,5 +1,8 @@
 use crate::dht::PeerAddress;
-use lib3h_protocol::{data_types::EntryData, Address};
+use lib3h_protocol::{
+    data_types::{EntryData, Opaque},
+    Address,
+};
 use url::Url;
 
 pub type FromPeerAddress = PeerAddress;
@@ -50,13 +53,13 @@ pub enum DhtEvent {
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 pub struct RemoteGossipBundleData {
     pub from_peer_address: PeerAddress,
-    pub bundle: Vec<u8>,
+    pub bundle: Opaque,
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 pub struct GossipToData {
     pub peer_address_list: Vec<PeerAddress>,
-    pub bundle: Vec<u8>,
+    pub bundle: Opaque,
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -211,7 +211,7 @@ impl MirrorDht {
         );
         GossipToData {
             peer_address_list,
-            bundle: buf,
+            bundle: buf.into(),
         }
     }
 
@@ -221,7 +221,7 @@ impl MirrorDht {
         let maybe_peer = self.peer_map.get_mut(&peer_info.peer_address);
         match maybe_peer {
             None => {
-                trace!("@MirrorDht@ Adding peer - OK NEW");
+                debug!("@MirrorDht@ Adding peer - OK NEW");
                 self.peer_map
                     .insert(peer_info.peer_address.clone(), peer_info.clone());
                 self.timed_out_map
@@ -230,13 +230,12 @@ impl MirrorDht {
             }
             Some(mut peer) => {
                 if peer_info.timestamp <= peer.timestamp {
-                    trace!("@MirrorDht@ Adding peer - BAD");
+                    debug!("@MirrorDht@ Adding peer - BAD");
                     return false;
                 }
-                trace!(
+                debug!(
                     "@MirrorDht@ Adding peer - OK UPDATED: {} > {}",
-                    peer_info.timestamp,
-                    peer.timestamp,
+                    peer_info.timestamp, peer.timestamp,
                 );
                 peer.timestamp = peer_info.timestamp;
                 if crate::time::since_epoch_ms() - peer.timestamp < self.config.timeout_threshold()
@@ -300,7 +299,7 @@ impl MirrorDht {
             .unwrap();
         let gossip_evt = GossipToData {
             peer_address_list: self.get_other_peer_list(),
-            bundle: buf,
+            bundle: buf.into(),
         };
         DhtEvent::GossipTo(gossip_evt)
     }
@@ -382,7 +381,7 @@ impl MirrorDht {
                 );
                 let gossip_evt = GossipToData {
                     peer_address_list: others_list,
-                    bundle: buf,
+                    bundle: buf.into(),
                 };
                 event_list.push(DhtEvent::GossipTo(gossip_evt));
 

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -211,7 +211,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                 // Prepare remoteGossipTo to post to dht
                 let cmd = DhtCommand::HandleGossip(RemoteGossipBundleData {
                     from_peer_address: msg.from_peer_address.clone().into(),
-                    bundle: msg.bundle.clone().into(),
+                    bundle: msg.bundle.clone(),
                 });
                 // Check if its for the network_gateway
                 if msg.space_address.to_string() == NETWORK_GATEWAY_ID {

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -211,7 +211,7 @@ impl<T: Transport, D: Dht> RealEngine<T, D> {
                 // Prepare remoteGossipTo to post to dht
                 let cmd = DhtCommand::HandleGossip(RemoteGossipBundleData {
                     from_peer_address: msg.from_peer_address.clone().into(),
-                    bundle: msg.bundle.clone(),
+                    bundle: msg.bundle.clone().into(),
                 });
                 // Check if its for the network_gateway
                 if msg.space_address.to_string() == NETWORK_GATEWAY_ID {

--- a/crates/lib3h/src/engine/p2p_protocol.rs
+++ b/crates/lib3h/src/engine/p2p_protocol.rs
@@ -1,5 +1,8 @@
 use crate::dht::{dht_protocol::PeerData, PeerAddress};
-use lib3h_protocol::{data_types::DirectMessageData, Address};
+use lib3h_protocol::{
+    data_types::{DirectMessageData, Opaque},
+    Address,
+};
 
 pub type SpaceAddress = String;
 pub type GatewayId = String;
@@ -26,5 +29,5 @@ pub struct GossipData {
     pub space_address: Address,
     pub to_peer_address: Address,
     pub from_peer_address: Address,
-    pub bundle: Vec<u8>,
+    pub bundle: Opaque,
 }

--- a/crates/lib3h_protocol/src/data_types.rs
+++ b/crates/lib3h_protocol/src/data_types.rs
@@ -124,7 +124,7 @@ pub struct GenericResultData {
 
 impl std::fmt::Debug for Opaque {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let bytes = std::str::from_utf8(self.0.as_ref());
+        let bytes = String::from_utf8_lossy(self.0.as_ref());
         write!(f, "{:?}", bytes)
     }
 }


### PR DESCRIPTION
## PR summary

This PR makes gossip data related structures have an `Opaque` rather than a `Vec<u8>`. It also changes the debug formatter to lossy utf8 so we can handle encodings that gossip data requires (via msg pack?).

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
