### PR TITLE
Use opaque in transport commands

### DIFF
--- a/crates/lib3h/src/transport/memory_mock/memory_server.rs
+++ b/crates/lib3h/src/transport/memory_mock/memory_server.rs
@@ -219,7 +219,7 @@ impl MemoryServer {
                 };
                 did_work = true;
                 trace!("(MemoryServer {}) received: {:?}", self.this_uri, payload);
-                let evt = TransportEvent::ReceivedData(id.to_string(), payload);
+                let evt = TransportEvent::ReceivedData(id.to_string(), payload.into());
                 outbox.push(evt);
             }
         }

--- a/crates/lib3h/src/transport/protocol.rs
+++ b/crates/lib3h/src/transport/protocol.rs
@@ -1,12 +1,14 @@
-use crate::transport::{error::TransportError, ConnectionId};
+use crate::{
+    lib3h_protocol::data_types::Opaque,
+    transport::{error::TransportError, ConnectionId},
+};
 use url::Url;
-
 /// Commands that can be sent to an implementor of the Transport trait and handled during `process()`
 #[derive(Debug, PartialEq, Clone)]
 pub enum TransportCommand {
     Connect(Url, /*request_id*/ String),
-    Send(Vec<ConnectionId>, Vec<u8>),
-    SendAll(Vec<u8>),
+    Send(Vec<ConnectionId>, Opaque),
+    SendAll(Opaque),
     Close(ConnectionId),
     CloseAll,
     Bind(Url),
@@ -22,7 +24,7 @@ pub enum TransportEvent {
     /// we have received an incoming connection
     IncomingConnectionEstablished(ConnectionId),
     /// We have received data from a connection
-    ReceivedData(ConnectionId, Vec<u8>),
+    ReceivedData(ConnectionId, Opaque),
     /// A connection closed for whatever reason
     ConnectionClosed(ConnectionId),
 }

--- a/crates/lib3h/src/transport_wss/mod.rs
+++ b/crates/lib3h/src/transport_wss/mod.rs
@@ -595,7 +595,7 @@ impl<T: Read + Write + std::fmt::Debug + std::marker::Sized> TransportWss<T> {
 
                         if let Some(msg) = qmsg {
                             self.event_queue
-                                .push(TransportEvent::ReceivedData(info.id.clone(), msg));
+                                .push(TransportEvent::ReceivedData(info.id.clone(), msg.into()));
                         }
                         info.stateful_socket = WebsocketStreamState::ReadyWs(socket);
                         Ok(())
@@ -634,7 +634,7 @@ impl<T: Read + Write + std::fmt::Debug + std::marker::Sized> TransportWss<T> {
 
                         if let Some(msg) = qmsg {
                             self.event_queue
-                                .push(TransportEvent::ReceivedData(info.id.clone(), msg));
+                                .push(TransportEvent::ReceivedData(info.id.clone(), msg.into()));
                         }
                         info.stateful_socket = WebsocketStreamState::ReadyWss(socket);
                         Ok(())


### PR DESCRIPTION
## PR summary

Changes `ReceivedData` and `Send*` functions to use the `Opaque` struct.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
