### PR TITLE
more info on internal lib3h errors upgraded to lib3h_protocol errors

### DIFF
--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/lib3h"
 repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
+backtrace = "=0.3.26"
 hcid = "=0.0.6"
 holochain_persistence_api = "=0.0.7"
 # version on the left for release regex
@@ -33,7 +34,6 @@ lazy_static = "=1.2.0"
 [dev-dependencies]
 lib3h_sodium = { version = "=0.0.10", path = "../sodium" }
 unwrap_to = "=0.1.0"
-backtrace = "=0.3.14"
 env_logger = "=0.6.1"
 bincode = "=1.1.4"
 multihash = "=0.8.0"

--- a/crates/lib3h/src/error.rs
+++ b/crates/lib3h/src/error.rs
@@ -139,9 +139,25 @@ impl From<CryptoError> for Lib3hError {
 
 // I'm not so sure about this...
 impl From<Lib3hError> for Lib3hProtocolError {
-    fn from(_err: Lib3hError) -> Self {
-        Lib3hProtocolError::new(Lib3hProtocolErrorKind::Other(String::from(
-            "Lib3hProtocolError occuring in Lib3h.",
-        )))
+    fn from(err: Lib3hError) -> Self {
+        let bt = backtrace::Backtrace::new();
+        Lib3hProtocolError::new(Lib3hProtocolErrorKind::Lib3hError(
+            format!("lib3h internal: {:?}", err),
+            Some(bt),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_should_upgrade_and_backtrace_lib3h_protocol_errors() {
+        let e: Lib3hProtocolError =
+            Lib3hError::new(ErrorKind::Other("test-str-abcdefg".to_string())).into();
+        let res = format!("{:?}", e);
+        assert!(res.contains("test-str-abcdefg"));
+        assert!(res.contains("it_should_upgrade_and_backtrace_lib3h_protocol_errors"));
     }
 }

--- a/crates/lib3h/src/lib.rs
+++ b/crates/lib3h/src/lib.rs
@@ -1,3 +1,4 @@
+extern crate backtrace;
 extern crate hcid;
 extern crate lib3h_crypto_api;
 extern crate lib3h_protocol;

--- a/crates/lib3h_protocol/Cargo.toml
+++ b/crates/lib3h_protocol/Cargo.toml
@@ -13,6 +13,7 @@ documentation = "https://docs.rs/lib3h_protocol"
 repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
+backtrace = "=0.3.26"
 base64 = "=0.10.1"
 holochain_persistence_api = "=0.0.7"
 rmp-serde = "=0.13.7"

--- a/crates/lib3h_protocol/src/lib.rs
+++ b/crates/lib3h_protocol/src/lib.rs
@@ -1,5 +1,6 @@
 //! This module provides the api definition for working with lib3h
 
+extern crate backtrace;
 extern crate holochain_persistence_api;
 extern crate serde;
 #[macro_use]


### PR DESCRIPTION
## PR summary

Lib3hProtocol doesn't know about our internal Lib3hErrors, so we can't get explicit details, but we *can* get the error debug as a string, and a backtrace of the actual error:

What used to be:

```
Lib3hProtocolError(Other("Lib3hProtocolError occuring in Lib3h."))
```

Will now be:

```
Lib3hProtocolError(Lib3hError("lib3h internal: Lib3hError(Other(\"testing\"))", Some(stack backtrace:
   0: lib3h::error::<impl core::convert::From<lib3h::error::Lib3hError> for lib3h_protocol::error::Lib3hProtocolError>::from::he55e108631d1f68a (0x55959f32b78e)
             at crates/lib3h/src/error.rs:143
   1: <T as core::convert::Into<U>>::into::h93a4efe7f342dc5c (0x55959f415a82)
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/libcore/convert.rs:543
   2: lib3h::error::tests::it_should_upgrade_and_backtrace_lib3h_protocol_errors::he7dce85c88422b41 (0x55959f377820)
             at crates/lib3h/src/error.rs:155
   3: lib3h::error::tests::it_should_upgrade_and_backtrace_lib3h_protocol_errors::{{closure}}::h59a6cd0243ed64ae (0x55959f373c09)
             at crates/lib3h/src/error.rs:154
   4: core::ops::function::FnOnce::call_once::h065d685d9958d605 (0x55959f35bf0d)
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/libcore/ops/function.rs:231
   5: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::h8213151db36f7c78 (0x55959f4a4d8e)
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/liballoc/boxed.rs:766
   6: __rust_maybe_catch_panic (0x55959f858d99)
             at src/libpanic_unwind/lib.rs:82
   7: std::panicking::try::h62c09aea7a175505 (0x55959f4bf697)
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/libstd/panicking.rs:275
      std::panic::catch_unwind::hdb7380ae87e0dd2f
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/libstd/panic.rs:394
      test::run_test::run_test_inner::{{closure}}::hd5e7b883ed5b9366
             at src/libtest/lib.rs:1466
   8: std::sys_common::backtrace::__rust_begin_short_backtrace::h6c5263a534f308d2 (0x55959f49a1a4)
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/libstd/sys_common/backtrace.rs:77
   9: std::thread::Builder::spawn_unchecked::{{closure}}::{{closure}}::h7fa080bdba74ad0c (0x55959f49e324)
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/libstd/thread/mod.rs:470
      <std::panic::AssertUnwindSafe<F> as core::ops::function::FnOnce<()>>::call_once::h7f0c12531079582e
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/libstd/panic.rs:315
      std::panicking::try::do_call::hbd1167afd02ee581
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/libstd/panicking.rs:296
  10: __rust_maybe_catch_panic (0x55959f858d99)
             at src/libpanic_unwind/lib.rs:82
  11: std::panicking::try::hb0559a308ff2a87b (0x55959f49e861)
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/libstd/panicking.rs:275
      std::panic::catch_unwind::he22bde7c1444c1db
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/libstd/panic.rs:394
      std::thread::Builder::spawn_unchecked::{{closure}}::h09315946bcda801c
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/libstd/thread/mod.rs:469
      core::ops::function::FnOnce::call_once{{vtable.shim}}::h4a2b819320ecd4f6
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/libcore/ops/function.rs:231
  12: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::h56322f6b657cd33d (0x55959f84713e)
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/liballoc/boxed.rs:766
  13: <alloc::boxed::Box<F> as core::ops::function::FnOnce<A>>::call_once::h2cbeedc59f1a5bf0 (0x55959f8581cf)
             at /rustc/69656fa4cbafc378fd63f9186d93b0df3cdd9320/src/liballoc/boxed.rs:766
      std::sys_common::thread::start_thread::h780c24dc0e8bc388
             at src/libstd/sys_common/thread.rs:13
      std::sys::unix::thread::Thread::new::thread_start::h588aedefb535eac7
             at src/libstd/sys/unix/thread.rs:79
  14: start_thread (0x7f0eecf054a3)
  15: __clone (0x7f0eeca30d0e)
  16: <unknown> (0x0))))
```

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
