### PR TITLE
Gossip entries occassionally

### DIFF
--- a/crates/lib3h/src/dht/dht_protocol.rs
+++ b/crates/lib3h/src/dht/dht_protocol.rs
@@ -48,6 +48,8 @@ pub enum DhtEvent {
     /// Notify owner that we are no longer tracking this entry internally.
     /// Owner should purge this address from storage, but they can, of course, choose not to.
     EntryPruned(Address),
+    /// Request to get EntryData from core, and gossip it
+    GossipEntriesToRequest(Vec<Address>)
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]

--- a/crates/lib3h/src/dht/dht_protocol.rs
+++ b/crates/lib3h/src/dht/dht_protocol.rs
@@ -19,7 +19,7 @@ pub enum DhtCommand {
     /// Note: Need an EntryData to know the aspect addresses, but aspects' content can be empty.
     HoldEntryAspectAddress(EntryData),
     /// Owner wants us to bookkeep an entry and broadcast it to neighbors
-    BroadcastEntry(EntryData),
+    BroadcastEntry(EntryData, bool),
     /// Owner notifies us that is is not holding an entry anymore.
     DropEntryAddress(Address),
     /// Owner's response to ProvideEntry request

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -433,13 +433,13 @@ impl MirrorDht {
             }
             // Owner has some entry and wants it stored on the network
             // Bookkeep address and gossip entry to every known peer.
-            DhtCommand::BroadcastEntry(entry) => {
+            DhtCommand::BroadcastEntry(entry, force) => {
                 // Store address
-                let _received_new_content = self.add_entry_aspects(&entry);
+                let received_new_content = self.add_entry_aspects(&entry);
                 //// Bail if did not receive new content
-          //      if !received_new_content {
-          //          return Ok(vec![]);
-          //      }
+                if !force && !received_new_content {
+                    return Ok(vec![]);
+                }
                 let gossip_evt = self.gossip_entry(entry);
                 trace!(
                     "@MirrorDht@ broadcasting entry: {:?}",

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -308,7 +308,7 @@ impl MirrorDht {
     /// Return a list of DhtEvent to owner.
     #[allow(non_snake_case)]
     fn serve_DhtCommand(&mut self, cmd: &DhtCommand) -> Lib3hResult<Vec<DhtEvent>> {
-        debug!("@MirrorDht@ serving cmd: {:?}", cmd);
+        trace!("@MirrorDht@ serving cmd: {:?}", cmd);
         // Note: use same order as the enum
         match cmd {
             // Received gossip from remote node. Bundle must be a serialized MirrorGossip

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -308,7 +308,7 @@ impl MirrorDht {
     /// Return a list of DhtEvent to owner.
     #[allow(non_snake_case)]
     fn serve_DhtCommand(&mut self, cmd: &DhtCommand) -> Lib3hResult<Vec<DhtEvent>> {
-        trace!("@MirrorDht@ serving cmd: {:?}", cmd);
+        debug!("@MirrorDht@ serving cmd: {:?}", cmd);
         // Note: use same order as the enum
         match cmd {
             // Received gossip from remote node. Bundle must be a serialized MirrorGossip

--- a/crates/lib3h/src/dht/mod.rs
+++ b/crates/lib3h/src/dht/mod.rs
@@ -231,7 +231,7 @@ pub mod tests {
         // Add a data item in DHT A
         let entry_data = create_EntryData(&ENTRY_ADDRESS_1, &ASPECT_ADDRESS_1, &ASPECT_CONTENT_1);
         dht_a
-            .post(DhtCommand::BroadcastEntry(entry_data.clone()))
+            .post(DhtCommand::BroadcastEntry(entry_data.clone()), false)
             .unwrap();
         let (did_work, gossip_list) = dht_a.process().unwrap();
         assert!(did_work);

--- a/crates/lib3h/src/engine/mod.rs
+++ b/crates/lib3h/src/engine/mod.rs
@@ -59,6 +59,7 @@ enum RealEngineTrackerData {
     /// gossip has requested we store data, send a hold request to core
     /// core should respond ??
     HoldEntryRequested,
+    DataForGossipTo,
 }
 
 /// Struct holding all config settings for the RealEngine

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -47,7 +47,7 @@ impl<'engine, D: Dht> RealEngine<'engine, D> {
 
     /// Handle a DhtEvent sent to us by our network gateway
     fn handle_netDhtEvent(&mut self, cmd: DhtEvent) -> Lib3hResult<Vec<Lib3hServerProtocol>> {
-        debug!("{} << handle_netDhtEvent: {:?}", self.name, cmd);
+        trace!("{} << handle_netDhtEvent: {:?}", self.name, cmd);
         let outbox = Vec::new();
         match cmd {
             DhtEvent::GossipTo(_data) => {

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -21,7 +21,7 @@ impl<'engine, D: Dht> RealEngine<'engine, D> {
         // Process the network gateway as a Transport
         let (tranport_did_work, event_list) = self.network_gateway.as_transport_mut().process()?;
         if !event_list.is_empty() {
-            debug!(
+            trace!(
                 "{} - network_gateway Transport.process(): {} {}",
                 self.name,
                 tranport_did_work,
@@ -147,7 +147,7 @@ impl<'engine, D: Dht> RealEngine<'engine, D> {
         &mut self,
         evt: &TransportEvent,
     ) -> Lib3hResult<Vec<Lib3hServerProtocol>> {
-        debug!("{} << handle_netTransportEvent: {:?}", self.name, evt);
+        trace!("{} << handle_netTransportEvent: {:?}", self.name, evt);
         let mut outbox = Vec::new();
         // Note: use same order as the enum
         match evt {
@@ -181,7 +181,7 @@ impl<'engine, D: Dht> RealEngine<'engine, D> {
                 }
             }
             TransportEvent::ReceivedData(id, payload) => {
-                debug!("Received message from: {} | {}", id, payload.len());
+                trace!("Received message from: {} | {}", id, payload.len());
                 let mut de = Deserializer::new(&payload[..]);
                 let maybe_msg: Result<P2pProtocol, rmp_serde::decode::Error> =
                     Deserialize::deserialize(&mut de);

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -172,7 +172,6 @@ impl<'engine, D: Dht> NetworkEngine for RealEngine<'engine, D> {
     /// output a list of Lib3hServerProtocol messages for Core to handle
     fn process(&mut self) -> Lib3hProtocolResult<(DidWork, Vec<Lib3hServerProtocol>)> {
         self.process_count += 1;
-        trace!("");
         trace!("{} - process() START - {}", self.name, self.process_count);
         // Process all received Lib3hClientProtocol messages from Core
         let (inbox_did_work, mut outbox) = self.process_inbox()?;

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -316,10 +316,14 @@ impl<'engine, D: Dht> RealEngine<'engine, D> {
                     None,
                 );
                 match maybe_space {
-                    Err(res) => outbox.push(res),
+                    Err(res) => {
+                        error!("HandleFetchEntryResult: error: {:?}", res);
+                        outbox.push(res)
+                    },
                     Ok(space_gateway) => {
                         if is_data_for_author_list {
                             let cmd = DhtCommand::BroadcastEntry(msg.entry);
+                            debug!("HandleFetchEntryResult: Broadcasting: {:?}", cmd);
                             space_gateway.as_dht_mut().post(cmd)?;
                         } else {
                             let response = FetchDhtEntryResponseData {
@@ -327,6 +331,7 @@ impl<'engine, D: Dht> RealEngine<'engine, D> {
                                 entry: msg.entry.clone(),
                             };
                             let cmd = DhtCommand::EntryDataResponse(response);
+                            debug!("HandleFetchEntryResult: EntryDataResponse: {:?}", cmd);
                             space_gateway.as_dht_mut().post(cmd)?;
                         }
                     }

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -325,7 +325,7 @@ impl<'engine, D: Dht> RealEngine<'engine, D> {
                     },
                     Ok(space_gateway) => {
                         if is_data_for_author_list ||  is_data_for_gossip_to  {
-                            let cmd = DhtCommand::BroadcastEntry(msg.entry);
+                            let cmd = DhtCommand::BroadcastEntry(msg.entry,is_data_for_gossip_to);
                             debug!("HandleFetchEntryResult: Broadcasting: {:?} {:?}", cmd, is_data_for_gossip_to);
                             space_gateway.as_dht_mut().post(cmd)?;
                         } else {
@@ -367,7 +367,7 @@ impl<'engine, D: Dht> RealEngine<'engine, D> {
                     Err(res) => outbox.push(res),
                     Ok(space_gateway) => {
                         // send to other dht nodes
-                        let cmd = DhtCommand::BroadcastEntry(msg.entry);
+                        let cmd = DhtCommand::BroadcastEntry(msg.entry,false);
                         space_gateway.as_dht_mut().post(cmd)?;
                     }
                 }

--- a/crates/lib3h/src/engine/space_layer.rs
+++ b/crates/lib3h/src/engine/space_layer.rs
@@ -65,7 +65,7 @@ impl<'engine, D: Dht> RealEngine<'engine, D> {
         chain_id: &ChainId,
         cmd: DhtEvent,
     ) -> Lib3hProtocolResult<Vec<Lib3hServerProtocol>> {
-        debug!(
+        trace!(
             "{} << handle_spaceDhtEvent: [{:?}] - {:?}",
             self.name, chain_id, cmd,
         );

--- a/crates/lib3h/src/engine/space_layer.rs
+++ b/crates/lib3h/src/engine/space_layer.rs
@@ -75,6 +75,24 @@ impl<'engine, D: Dht> RealEngine<'engine, D> {
             .get_mut(chain_id)
             .expect("Should have the space gateway we receive an event from.");
         match cmd {
+            DhtEvent::GossipEntriesToRequest(request_list) => {
+                let mut msg_data = FetchEntryData {
+                    space_address: chain_id.0.clone(),
+                    entry_address: "".into(),
+                    request_id: "".into(),
+                    provider_agent_id: "".into(), //???
+                    aspect_address_list: None,
+                };
+                for address in request_list {
+                    msg_data.request_id = self.request_track.reserve();
+                    msg_data.entry_address = address;
+                    self.request_track.set(
+                        &msg_data.request_id,
+                        Some(RealEngineTrackerData::DataForGossipTo),
+                    );
+                    outbox.push(Lib3hServerProtocol::HandleFetchEntry(msg_data.clone()));
+                }
+            }
             DhtEvent::GossipTo(_gossip_data) => {
                 // n/a - should have been handled by gateway
             }

--- a/crates/lib3h/src/gateway/gateway_dht.rs
+++ b/crates/lib3h/src/gateway/gateway_dht.rs
@@ -85,6 +85,9 @@ impl<'gateway, D: Dht> P2pGateway<'gateway, D> {
     pub(crate) fn handle_DhtEvent(&mut self, evt: DhtEvent) -> Lib3hResult<()> {
         trace!("({}).handle_DhtEvent() {:?}", self.identifier, evt);
         match evt {
+            DhtEvent::GossipEntriesToRequest(_) => {
+                // handled in space
+            }
             DhtEvent::GossipTo(data) => {
                 // DHT should give us the peer_transport
                 for to_peer_address in data.peer_address_list {
@@ -93,6 +96,7 @@ impl<'gateway, D: Dht> P2pGateway<'gateway, D> {
                     if &to_peer_address == me {
                         continue;
                     }
+
                     // TODO END
                     // Convert DHT Gossip to P2P Gossip
                     let p2p_gossip = P2pProtocol::Gossip(GossipData {
@@ -109,6 +113,7 @@ impl<'gateway, D: Dht> P2pGateway<'gateway, D> {
                         .get_connection_id(&to_peer_address)
                         .expect("Should gossip to a known peer");
                     // Forward gossip to the inner_transport
+                    trace!("Creating P2pProtocolGossip: {:?}", p2p_gossip.clone());
                     self.inner_transport
                         .as_mut()
                         .send(&[&to_conn_id], &payload)?;

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -214,7 +214,7 @@ impl<'gateway, D: Dht> P2pGateway<'gateway, D> {
     /// Process a transportEvent received from our internal connection.
     pub(crate) fn handle_TransportEvent(&mut self, evt: &TransportEvent) -> TransportResult<()> {
         debug!(
-            "<<< '({})' recv transport event: {:?}",
+            "FISH <<< '({})' recv transport event: {:?}",
             self.identifier, evt
         );
         // Note: use same order as the enum
@@ -238,7 +238,7 @@ impl<'gateway, D: Dht> P2pGateway<'gateway, D> {
                 // TODO #176
             }
             TransportEvent::ReceivedData(connection_id, payload) => {
-                debug!("Received message from: {}", connection_id);
+//                debug!("Received message from: {}", connection_id);
                 // trace!("Deserialize msg: {:?}", payload);
                 let mut de = Deserializer::new(&payload[..]);
                 let maybe_p2p_msg: Result<P2pProtocol, rmp_serde::decode::Error> =

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -213,8 +213,8 @@ impl<'gateway, D: Dht> P2pGateway<'gateway, D> {
 
     /// Process a transportEvent received from our internal connection.
     pub(crate) fn handle_TransportEvent(&mut self, evt: &TransportEvent) -> TransportResult<()> {
-        debug!(
-            "FISH <<< '({})' recv transport event: {:?}",
+        trace!(
+            "<<< '({})' recv transport event: {:?}",
             self.identifier, evt
         );
         // Note: use same order as the enum

--- a/crates/lib3h/src/transport/memory_mock/transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/transport_memory.rs
@@ -196,7 +196,7 @@ impl Transport for TransportMemory {
             // Get the other node's uri on that connection
             let maybe_uri = self.outbound_connection_map.get(*id);
             if let None = maybe_uri {
-//                warn!("No known connection for connectionId: {}", id);
+                warn!("No known connection for connectionId: {}", id);
                 continue;
             }
             let uri = maybe_uri.unwrap();

--- a/crates/lib3h/src/transport/memory_mock/transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/transport_memory.rs
@@ -196,7 +196,7 @@ impl Transport for TransportMemory {
             // Get the other node's uri on that connection
             let maybe_uri = self.outbound_connection_map.get(*id);
             if let None = maybe_uri {
-                warn!("No known connection for connectionId: {}", id);
+//                warn!("No known connection for connectionId: {}", id);
                 continue;
             }
             let uri = maybe_uri.unwrap();


### PR DESCRIPTION
## PR summary

Adds gossiping of entries as well as peer data into the Mirror DHT.
Implemented by adding a GossipEntriesToRequest to the DHT protocol, and adding a `force` boolean to the BroadcastEntry command which is used to force the pushing of an entry that's allready in the book-keeping list and thus would otherwise be ignored by the usual BoradcastEntry path.

Adding this change makes the `agent_id_gets_gossiped_on_startup` scenario in the `lib3h-client-protocal-integration-transport-memory` branch in core pass.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
