### PR TITLE
remove deprecation for now

### DIFF
--- a/crates/sodium/src/aead.rs
+++ b/crates/sodium/src/aead.rs
@@ -22,7 +22,6 @@ pub const ABYTES: usize = rust_sodium_sys::crypto_aead_xchacha20poly1305_ietf_AB
 /// @param {SecBuf} nonce - sometimes called initialization vector (iv)
 ///
 /// @param {SecBuf} cipher - Empty Buffer (needed when you want to Decrypt the meassage)
-#[deprecated(note = "use CryptoSystem")]
 pub fn enc(
     message: &mut SecBuf,
     secret: &mut SecBuf,
@@ -73,7 +72,6 @@ pub fn enc(
 /// @param {Buffer} nonce - sometimes called initialization vector (iv)
 ///
 /// @param {Buffer} cipher - the cipher text
-#[deprecated(note = "use CryptoSystem")]
 pub fn dec(
     decrypted_message: &mut SecBuf,
     secret: &mut SecBuf,

--- a/crates/sodium/src/hash.rs
+++ b/crates/sodium/src/hash.rs
@@ -14,7 +14,6 @@ pub const BYTES512: usize = rust_sodium_sys::crypto_hash_sha512_BYTES as usize;
 /// @param {SecBuf} input - the data to hash
 ///
 /// @param {SecBuf} output - Empty Buffer to be used as output
-#[deprecated(note = "use CryptoSystem")]
 pub fn sha256(input: &mut SecBuf, output: &mut SecBuf) -> Result<(), CryptoError> {
     check_init();
     let input_len = input.len() as libc::c_ulonglong;
@@ -35,7 +34,6 @@ pub fn sha256(input: &mut SecBuf, output: &mut SecBuf) -> Result<(), CryptoError
 /// @param {Buffer} input - the data to hash
 ///
 /// @param {SecBuf} output - Empty Buffer to be used as output
-#[deprecated(note = "use CryptoSystem")]
 pub fn sha512(input: &mut SecBuf, output: &mut SecBuf) -> Result<(), CryptoError> {
     check_init();
     let input = input.read_lock();

--- a/crates/sodium/src/kdf.rs
+++ b/crates/sodium/src/kdf.rs
@@ -16,7 +16,6 @@ pub const MAXBYTES: usize = rust_sodium_sys::crypto_kdf_BYTES_MAX as usize;
 /// @param {Buffer} context - eight bytes context
 ///
 /// @param {SecBuf} parent - the parent key to derive from
-#[deprecated(note = "use CryptoSystem")]
 pub fn derive(
     out: &mut SecBuf,
     index: u64,

--- a/crates/sodium/src/kx.rs
+++ b/crates/sodium/src/kx.rs
@@ -12,7 +12,6 @@ pub const SESSIONKEYBYTES: usize = rust_sodium_sys::crypto_kx_SESSIONKEYBYTES as
 /// @param {SecBuf} pk - Empty Buffer to be used as publicKey return
 ///
 /// @param {SecBuf} sk - Empty Buffer to be used as secretKey return
-#[deprecated(note = "use CryptoSystem")]
 pub fn keypair(pk: &mut SecBuf, sk: &mut SecBuf) -> Result<(), CryptoError> {
     check_init();
     let mut pk = pk.write_lock();
@@ -30,7 +29,6 @@ pub fn keypair(pk: &mut SecBuf, sk: &mut SecBuf) -> Result<(), CryptoError> {
 /// @param {SecBuf} pk - Empty Buffer to be used as publicKey return
 ///
 /// @param {SecBuf} sk - Empty Buffer to be used as secretKey return
-#[deprecated(note = "use CryptoSystem")]
 pub fn seed_keypair(
     seed: &mut SecBuf,
     pk: &mut SecBuf,
@@ -61,7 +59,6 @@ pub fn seed_keypair(
 /// @param {SecBuf} rx - Empty Buffer to be used as secretKey return
 ///
 /// @param {SecBuf} tx - Empty Buffer to be used as secretKey return
-#[deprecated(note = "use CryptoSystem")]
 pub fn client_session(
     client_pk: &mut SecBuf,
     client_sk: &mut SecBuf,
@@ -98,7 +95,6 @@ pub fn client_session(
 /// @param {SecBuf} rx - Empty Buffer to be used as secretKey return
 ///
 /// @param {SecBuf} tx - Empty Buffer to be used as secretKey return
-#[deprecated(note = "use CryptoSystem")]
 pub fn server_session(
     server_pk: &mut SecBuf,
     server_sk: &mut SecBuf,

--- a/crates/sodium/src/pwhash.rs
+++ b/crates/sodium/src/pwhash.rs
@@ -30,7 +30,6 @@ pub const SALTBYTES: usize = rust_sodium_sys::crypto_pwhash_SALTBYTES as usize;
 /// @param {SecBuf} salt - predefined salt (randomized it if you dont want to generate it )
 ///
 /// @param {SecBuf} hash - the hash generated
-#[deprecated(note = "use CryptoSystem")]
 pub fn hash(
     password: &mut SecBuf,
     ops_limit: u64,

--- a/crates/sodium/src/secbuf.rs
+++ b/crates/sodium/src/secbuf.rs
@@ -7,7 +7,6 @@ use super::check_init;
 use lib3h_crypto_api::CryptoError;
 
 /// a trait for structures that can be used as a backing store for SecBuf
-#[deprecated(note = "use CryptoSystem")]
 pub trait Bufferable: Send {
     fn new(s: usize) -> Box<Bufferable>
     where
@@ -146,7 +145,6 @@ pub enum ProtectState {
 /// A SecBuf is a memory buffer for use with libsodium functions.
 /// It can be backed by insecure (raw) memory for things like public keys,
 /// or secure (mlocked / mprotected) memory for things like private keys.
-#[deprecated(note = "use CryptoSystem")]
 pub struct SecBuf {
     t: SecurityType,
     b: Box<Bufferable>,

--- a/crates/sodium/src/sign.rs
+++ b/crates/sodium/src/sign.rs
@@ -38,7 +38,6 @@ pub const SECRETKEYBYTES: usize = rust_sodium_sys::crypto_sign_SECRETKEYBYTES as
 /// @param {SecBuf} seed - the seed to derive a keypair from
 ///
 /// @UseReturn {SecBuf} - { publicKey, privateKey }
-#[deprecated(note = "use CryptoSystem")]
 pub fn seed_keypair(
     public_key: &mut SecBuf,
     secret_key: &mut SecBuf,
@@ -67,7 +66,6 @@ pub fn seed_keypair(
 /// @param {SecBuf} signature - Empty Buffer to be used as signature return
 ///
 /// @UseReturn {SecBuf} {signature}
-#[deprecated(note = "use CryptoSystem")]
 pub fn sign(
     message: &mut SecBuf,
     secret_key: &mut SecBuf,
@@ -97,7 +95,6 @@ pub fn sign(
 /// @param {Buffer} message
 ///
 /// @param {Buffer} publicKey
-#[deprecated(note = "use CryptoSystem")]
 pub fn verify(signature: &mut SecBuf, message: &mut SecBuf, public_key: &mut SecBuf) -> bool {
     check_init();
     let signature = signature.read_lock();


### PR DESCRIPTION
 -D warnings in core make deprecations useless

## PR summary

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
