### PR TITLE
add generic hash

### DIFF
--- a/crates/crypto_api/src/crypto_system/mod.rs
+++ b/crates/crypto_api/src/crypto_system/mod.rs
@@ -128,6 +128,27 @@ pub trait CryptoSystem: Sync {
     /// compute a sha512 hash for `data`, storing it in `hash`
     fn hash_sha512(&self, hash: &mut Box<dyn Buffer>, data: &Box<dyn Buffer>) -> CryptoResult<()>;
 
+    /// min bytelength of generic hash output
+    fn generic_hash_min_bytes(&self) -> usize;
+
+    /// max bytelength of generic hash output
+    fn generic_hash_max_bytes(&self) -> usize;
+
+    /// min bytelength of generic hash key
+    fn generic_hash_key_min_bytes(&self) -> usize;
+
+    /// max bytelength of generic hash key
+    fn generic_hash_key_max_bytes(&self) -> usize;
+
+    /// compute a deterministic (BLAKE2b) generic hash for given data
+    /// key can be `None`
+    fn generic_hash(
+        &self,
+        hash: &mut Box<dyn Buffer>,
+        data: &Box<dyn Buffer>,
+        key: Option<&Box<dyn Buffer>>,
+    ) -> CryptoResult<()>;
+
     /// bytelength of pwhash salt
     fn pwhash_salt_bytes(&self) -> usize;
 

--- a/crates/crypto_api/src/error/mod.rs
+++ b/crates/crypto_api/src/error/mod.rs
@@ -13,6 +13,7 @@ pub enum CryptoError {
     BadParentSize,
     BadContextSize,
     BadSeedSize,
+    BadKeySize,
     BadPublicKeySize,
     BadSecretKeySize,
     BadSignatureSize,


### PR DESCRIPTION
## PR summary

adds `generic_hash` function to lib3h_crypto_api and lib3h_sodium.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
