### PR TITLE
Ghost actor transport tests

### DIFF
--- a/crates/lib3h/tests/transport.rs
+++ b/crates/lib3h/tests/transport.rs
@@ -204,11 +204,21 @@ impl TestTransport {
                 msg.respond(response);
             }
             RequestToChild::SendMessage { address, payload } => {
-                let mut mockernet = MOCKERNET.write().unwrap();
-                // return error if not bound.
-                let _ =
-                    mockernet.send_to(address, self.bound_url.as_ref().unwrap().clone(), payload);
-                //                msg.respond(response);
+                if self.bound_url.is_none() {
+                    msg.respond(Err(TransportError::new(format!("{} not bound", self.name))));
+                } else {
+                    let mut mockernet = MOCKERNET.write().unwrap();
+                    // return error if not bound.
+                    let response = match mockernet.send_to(
+                        address,
+                        self.bound_url.as_ref().unwrap().clone(),
+                        payload,
+                    ) {
+                        Err(err) => Err(TransportError::new(err)),
+                        Ok(()) => Ok(RequestToChildResponse::SendMessage),
+                    };
+                    msg.respond(response);
+                }
             }
         }
         Ok(())
@@ -251,6 +261,7 @@ impl TestTransportOwner {
 
 #[test]
 fn ghost_transport() {
+    // create an object that can be used to hold state data in callbacks to the transports
     let mut owner = TestTransportOwner::new();
 
     let mut t1: TransportActorParentWrapper<(), TestTransport> = GhostParentWrapper::new(
@@ -286,6 +297,31 @@ fn ghost_transport() {
         format!("{:?}", owner.log[0])
     );
 
+    // lets do some things to test out returning of error messages, i.e. sending messages
+    // to someone not bount to the network
+    t1.request(
+        std::time::Duration::from_millis(2000),
+        (),
+        RequestToChild::SendMessage {
+            address: Url::parse("mocknet://t2").expect("can parse url"),
+            payload: b"won't be received!".to_vec(),
+        },
+        // callback should simply log the response
+        Box::new(|dyn_owner, _, response| {
+            let owner = dyn_owner
+                .downcast_mut::<TestTransportOwner>()
+                .expect("a TestTransportOwner");
+            owner.log.push(format!("{:?}", response));
+            Ok(())
+        }),
+    );
+
+    t1.process(&mut owner).expect("should process");
+    assert_eq!(
+        "\"Response(Err(TransportError(\\\"mocknet://t2/ not bound\\\")))\"",
+        format!("{:?}", owner.log[1])
+    );
+
     // bind t2 to the network
     t2.request(
         std::time::Duration::from_millis(2000),
@@ -305,7 +341,7 @@ fn ghost_transport() {
     t2.process(&mut owner).expect("should process");
     assert_eq!(
         "\"Response(Ok(Bind(BindResultData { bound_url: \\\"mocknet://t2/\\\" })))\"",
-        format!("{:?}", owner.log[1])
+        format!("{:?}", owner.log[2])
     );
 
     t1.request(
@@ -324,13 +360,19 @@ fn ghost_transport() {
             Ok(())
         }),
     );
+
+    // we should get back an Ok on having sent the message when t1 gets processed
     t1.process(&mut owner).expect("should process");
+    assert_eq!(
+        "\"Response(Ok(SendMessage))\"",
+        format!("{:?}", owner.log[3])
+    );
+
+    // and when we drain messages from t2 we should see both the incoming connection from t1
+    // and the message itself
     t2.process(&mut owner).expect("should process");
     let mut messages = t2.drain_messages();
     assert_eq!(messages.len(), 2);
-
-    // because this is the first incoming message, the low level
-    // transport should also send an IncomingConnection event
     assert_eq!(
         "IncomingConnection { address: \"mocknet://t1/\" }",
         format!("{:?}", messages[0].take_message().expect("exists"))

--- a/crates/lib3h/tests/transport.rs
+++ b/crates/lib3h/tests/transport.rs
@@ -186,6 +186,7 @@ impl
     fn take_parent_endpoint(&mut self) -> Option<TransportActorParentEndpoint> {
         std::mem::replace(&mut self.endpoint_parent, None)
     }
+    // END BOILER PLATE--------------------------
 
     fn process_concrete(&mut self) -> GhostResult<WorkWasDone> {
         detach_run!(&mut self.endpoint_self, |es| es.process(self.as_any()))?;
@@ -195,7 +196,6 @@ impl
         self.handle_events_from_mockernet();
         Ok(false.into())
     }
-    // END BOILER PLATE--------------------------
 }
 
 impl TestTransport {

--- a/crates/lib3h/tests/transport.rs
+++ b/crates/lib3h/tests/transport.rs
@@ -1,0 +1,146 @@
+#[macro_use]
+extern crate detach;
+
+use lib3h::transport::{error::*, protocol::*};
+use lib3h_ghost_actor::prelude::*;
+use detach::prelude::*;
+use std::any::Any;
+use url::Url;
+
+enum ToParentContext {}
+struct TestTransport {
+    // instance name of this transport
+    name: String,
+    // our parent channel endpoint
+    endpoint_parent: Option<TransportActorParentEndpoint>,
+    // our self channel endpoint
+    endpoint_self: Detach<
+            GhostContextEndpoint<
+                    ToParentContext,
+                RequestToParent,
+                RequestToParentResponse,
+                RequestToChild,
+                RequestToChildResponse,
+                TransportError,
+                >,
+        >,
+}
+
+impl
+    GhostActor<
+        RequestToParent,
+        RequestToParentResponse,
+        RequestToChild,
+        RequestToChildResponse,
+        TransportError,
+    > for TestTransport
+{
+    // START BOILER PLATE--------------------------
+    fn as_any(&mut self) -> &mut dyn Any {
+        &mut *self
+    }
+
+    fn take_parent_endpoint(&mut self) -> Option<TransportActorParentEndpoint> {
+        std::mem::replace(&mut self.endpoint_parent, None)
+    }
+
+    fn process_concrete(&mut self) -> GhostResult<WorkWasDone> {
+        detach_run!(&mut self.endpoint_self, |es| es.process(self.as_any()))?;
+        for msg in self.endpoint_self.as_mut().drain_messages() {
+            self.handle_msg_from_parent(msg)?;
+        }
+        Ok(false.into())
+    }
+    // END BOILER PLATE--------------------------
+}
+
+
+impl TestTransport {
+    pub fn new(name: &str) -> Self {
+        let (endpoint_parent, endpoint_self) = create_ghost_channel();
+        let endpoint_parent = Some(endpoint_parent);
+        let endpoint_self = Detach::new(endpoint_self.as_context_endpoint(&format!("{}_to_parent_",name)));
+        TestTransport {
+            name: name.to_string(),
+            endpoint_parent,
+            endpoint_self,
+        }
+    }
+
+    /// private dispatcher for messages coming from our parent
+    fn handle_msg_from_parent(
+        &mut self,
+        mut msg: GhostMessage<
+                RequestToChild,
+            RequestToParent,
+            RequestToChildResponse,
+            TransportError,
+            >,
+    ) -> TransportResult<()> {
+        match msg.take_message().expect("exists") {
+            RequestToChild::Bind { spec: _ } => {
+                panic!("BOM")
+            },
+            RequestToChild::SendMessage { address:_, payload:_ } => {
+                panic!("BAM")
+            }
+        }
+    }
+
+}
+
+
+// owner object for the transport tests with a log into which
+// results can go for testing purposes
+struct TestTransportOwner {
+    log: Vec<String>
+}
+impl TestTransportOwner {
+    fn new() -> Self {
+        TestTransportOwner {
+            log: Vec::new()
+        }
+    }
+}
+
+
+#[test]
+fn ghost_transport() {
+    let mut owner = TestTransportOwner::new();
+
+    let mut t1: TransportActorParentWrapper<(),TestTransport> = GhostParentWrapper::new(
+            TestTransport::new("t1"),
+            "t1_requests", // prefix for request ids in the tracker
+        );
+    assert_eq!(t1.as_ref().name,"t1");
+/*    let t2: TransportActorParentWrapper<(),TestTransport> = GhostParentWrapper::new(
+        TestTransport::new("t2"),
+        "t2_requests", // prefix for request ids in the tracker
+    );
+    assert_eq!(t1.as_ref().name,"t2");
+     */
+
+    // bind t1 to the network
+    t1.request(
+        std::time::Duration::from_millis(2000),
+        (),
+        RequestToChild::Bind {
+            spec: Url::parse("mocknet://t1").expect("can parse url"),
+        },
+
+        // callback should simply log the response
+        Box::new(|dyn_owner, _, response| {
+            let owner = dyn_owner
+                .downcast_mut::<TestTransportOwner>()
+                .expect("a TestTransportOwner");
+            owner.log.push(format!("{:?}", response));
+            Ok(())
+        })
+    );
+    t1.process(&mut owner).expect("should process");
+    assert_eq!(
+        "\"event from parent\"",
+        format!("{:?}", owner.log[0])
+    )
+
+}

--- a/crates/lib3h/tests/transport.rs
+++ b/crates/lib3h/tests/transport.rs
@@ -263,23 +263,19 @@ impl TestTransport {
             for e in events {
                 match e {
                     MockernetEvent::Message { from, payload } => {
-                        detach_run!(self.endpoint_self, |s| s.publish(
-                            RequestToParent::ReceivedData {
-                                address: from,
-                                payload
-                            }
-                        ));
+                        self.endpoint_self.publish(RequestToParent::ReceivedData {
+                            address: from,
+                            payload,
+                        });
                     }
                     MockernetEvent::Connection { from } => {
-                        detach_run!(self.endpoint_self, |s| s
-                            .publish(RequestToParent::IncomingConnection { address: from }));
+                        self.endpoint_self
+                            .publish(RequestToParent::IncomingConnection { address: from });
                     }
                     MockernetEvent::Error(err) => {
-                        detach_run!(self.endpoint_self, |s| s.publish(
-                            RequestToParent::TransportError {
-                                error: TransportError::new(err)
-                            }
-                        ));
+                        self.endpoint_self.publish(RequestToParent::TransportError {
+                            error: TransportError::new(err),
+                        });
                     }
                 }
             }

--- a/crates/lib3h/tests/transport.rs
+++ b/crates/lib3h/tests/transport.rs
@@ -13,7 +13,7 @@ use std::{
 };
 use url::Url;
 
-// we need an "internet" that a transport can bind to that will
+// We need an "internet" that a transport can bind to that will
 // deliver messages to bound transports, we'll call it the Mockernet
 pub struct Mockernet {
     bindings: HashMap<Url, Tube>,
@@ -21,6 +21,8 @@ pub struct Mockernet {
     errors: Vec<(Url, String)>,
 }
 
+// These are the events that the mockernet can generate that must by handled
+// by any mockernet client.
 pub enum MockernetEvent {
     Connection { from: Url },
     Message { from: Url, payload: Vec<u8> },
@@ -30,7 +32,6 @@ pub enum MockernetEvent {
 // The Mockernet is a Series-of-Tubes, which is the technical term for the
 // sets of crossbeam channels in the bindings that mockernet shuttles
 // data between.
-// The Mockernet simulates a
 pub struct Tube {
     sender: crossbeam_channel::Sender<(Url, Vec<u8>)>,
     #[allow(dead_code)]


### PR DESCRIPTION
## PR summary

Adds a sample test of how the GhostActor Transport protocol should be used.  The test is intended to be complete around using all the different arms of the Transport Protocol enums.

## Review checklist 
- [x] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
