### PR TITLE
Ghost actor typed callbacks

### DIFF
--- a/crates/ghost_actor/src/ghost_actor.rs
+++ b/crates/ghost_actor/src/ghost_actor.rs
@@ -35,12 +35,12 @@ pub struct GhostParentWrapper<
 }
 
 impl<
-        Context,
+        Context: 'static,
         RequestToParent,
         RequestToParentResponse,
         RequestToChild,
-        RequestToChildResponse,
-        Error,
+        RequestToChildResponse: 'static,
+        Error: 'static,
     >
     GhostParentWrapper<
         Context,
@@ -77,12 +77,12 @@ impl<
     }
 
     /// see GhostContextEndpoint::request
-    pub fn request(
+    pub fn request<A: Any>(
         &mut self,
         timeout: std::time::Duration,
         context: Context,
         payload: RequestToChild,
-        cb: GhostCallback<Context, RequestToChildResponse, Error>,
+        cb: GhostCallback<Context, RequestToChildResponse, Error, A>,
     ) {
         self.endpoint.request(timeout, context, payload, cb)
     }

--- a/crates/ghost_actor/src/ghost_actor.rs
+++ b/crates/ghost_actor/src/ghost_actor.rs
@@ -423,7 +423,7 @@ mod tests {
         // now lets try posting a request with a callback which just saves the response
         // value to the parent's statee
         let cb: GhostCallback<FakeParent, TestContext, TestMsgInResponse, TestError> =
-            Box::new(|dyn_parent, _context, callback_data| {
+            Box::new(|parent, _context, callback_data| {
                 if let GhostCallbackData::Response(Ok(TestMsgInResponse(payload))) = callback_data {
                     dyn_parent.state = payload;
                 }

--- a/crates/ghost_actor/src/ghost_actor.rs
+++ b/crates/ghost_actor/src/ghost_actor.rs
@@ -82,7 +82,7 @@ impl<
         timeout: std::time::Duration,
         context: Context,
         payload: RequestToChild,
-        cb: GhostCallback<Context, RequestToChildResponse, Error, A>,
+        cb: GhostCallback<A, Context, RequestToChildResponse, Error>,
     ) {
         self.endpoint.request(timeout, context, payload, cb)
     }

--- a/crates/ghost_actor/src/ghost_actor.rs
+++ b/crates/ghost_actor/src/ghost_actor.rs
@@ -425,7 +425,7 @@ mod tests {
         let cb: GhostCallback<FakeParent, TestContext, TestMsgInResponse, TestError> =
             Box::new(|parent, _context, callback_data| {
                 if let GhostCallbackData::Response(Ok(TestMsgInResponse(payload))) = callback_data {
-                    dyn_parent.state = payload;
+                    parent.state = payload;
                 }
                 Ok(())
             });

--- a/crates/ghost_actor/src/ghost_actor.rs
+++ b/crates/ghost_actor/src/ghost_actor.rs
@@ -262,7 +262,7 @@ impl<
         >,
         request_id_prefix: &str,
     ) -> Self {
-        let endpoint = actor
+        let endpoint: GhostContextEndpoint<UserData, Context, _, _, _, _, _> = actor
             .take_parent_endpoint()
             .expect("exists")
             .as_context_endpoint(request_id_prefix);

--- a/crates/ghost_actor/src/ghost_actor.rs
+++ b/crates/ghost_actor/src/ghost_actor.rs
@@ -1,7 +1,6 @@
 use crate::{
     GhostCallback, GhostContextEndpoint, GhostEndpoint, GhostMessage, GhostResult, WorkWasDone,
 };
-use std::any::Any;
 
 /// helper struct that merges (on the parent side) the actual child
 /// GhostActor instance, with the child's ghost channel endpoint.
@@ -174,10 +173,6 @@ pub trait GhostActor<
     Error,
 >
 {
-    /// get a generic reference to ourselves
-    /// will be passed into any endpoint process functions
-    fn as_any(&mut self) -> &mut dyn Any;
-
     /// our parent gets a reference to the parent side of our channel
     fn take_parent_endpoint(
         &mut self,
@@ -310,7 +305,6 @@ mod tests {
     use super::*;
     use crate::{ghost_channel::create_ghost_channel, ghost_tracker::GhostCallbackData};
     use detach::prelude::*;
-    use std::any::Any;
 
     // Any actor has messages that it exchanges with it's parent
     // These are the Out message, and it has messages that come internally
@@ -360,9 +354,6 @@ mod tests {
         for TestActor
     {
         // START BOILER PLATE--------------------------
-        fn as_any(&mut self) -> &mut dyn Any {
-            &mut *self
-        }
 
         fn take_parent_endpoint(
             &mut self,

--- a/crates/ghost_actor/src/ghost_actor.rs
+++ b/crates/ghost_actor/src/ghost_actor.rs
@@ -226,12 +226,12 @@ pub struct GhostParentWrapperDyn<
 }
 
 impl<
-        Context:'static,
+        Context: 'static,
         RequestToParent,
         RequestToParentResponse,
         RequestToChild,
-        RequestToChildResponse:'static,
-        Error:'static,
+        RequestToChildResponse: 'static,
+        Error: 'static,
     >
     GhostParentWrapperDyn<
         Context,

--- a/crates/ghost_actor/src/ghost_channel.rs
+++ b/crates/ghost_actor/src/ghost_channel.rs
@@ -422,7 +422,7 @@ mod tests {
         // state to see if the callback was run.
         fn cb_factory() -> GhostCallback<FakeActor, TestContext, TestMsgOutResponse, TestError> {
             Box::new(|me, _context, callback_data| {
-                dyn_me.0 = format!("{:?}", callback_data);
+                me.0 = format!("{:?}", callback_data);
                 Ok(())
             })
         }

--- a/crates/ghost_actor/src/ghost_channel.rs
+++ b/crates/ghost_actor/src/ghost_channel.rs
@@ -25,7 +25,7 @@ pub struct GhostMessage<MessageToSelf, MessageToOther, MessageToSelfResponse, Er
     >,
 }
 
-impl<RequestToSelf, RequestToOther, RequestToSelfResponse, Error> std::fmt::Debug
+impl<RequestToSelf, RequestToOther, RequestToSelfResponse, Error: 'static> std::fmt::Debug
     for GhostMessage<RequestToSelf, RequestToOther, RequestToSelfResponse, Error>
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -33,7 +33,7 @@ impl<RequestToSelf, RequestToOther, RequestToSelfResponse, Error> std::fmt::Debu
     }
 }
 
-impl<RequestToSelf, RequestToOther, RequestToSelfResponse, Error>
+impl<RequestToSelf, RequestToOther, RequestToSelfResponse, Error: 'static>
     GhostMessage<RequestToSelf, RequestToOther, RequestToSelfResponse, Error>
 {
     fn new(
@@ -89,7 +89,13 @@ pub struct GhostEndpoint<
     >,
 }
 
-impl<RequestToOther, RequestToOtherResponse, RequestToSelf, RequestToSelfResponse, Error>
+impl<
+        RequestToOther,
+        RequestToOtherResponse: 'static,
+        RequestToSelf,
+        RequestToSelfResponse,
+        Error: 'static,
+    >
     GhostEndpoint<
         RequestToOther,
         RequestToOtherResponse,
@@ -117,7 +123,7 @@ impl<RequestToOther, RequestToOtherResponse, RequestToSelf, RequestToSelfRespons
     /// don't need any context.
     /// request_id_prefix is a debugging hint... the request_ids generated
     /// for tracking request/response pairs will be prepended with this prefix.
-    pub fn as_context_endpoint<Context>(
+    pub fn as_context_endpoint<Context: 'static>(
         self,
         request_id_prefix: &str,
     ) -> GhostContextEndpoint<
@@ -154,12 +160,12 @@ pub struct GhostContextEndpoint<
 }
 
 impl<
-        Context,
+        Context: 'static,
         RequestToOther,
-        RequestToOtherResponse,
+        RequestToOtherResponse: 'static,
         RequestToSelf,
         RequestToSelfResponse,
-        Error,
+        Error: 'static,
     >
     GhostContextEndpoint<
         Context,
@@ -200,12 +206,12 @@ impl<
 
     /// make a request of the other side. When a response is sent back to us
     /// the callback will be invoked.
-    pub fn request(
+    pub fn request<A: Any>(
         &mut self,
         timeout: std::time::Duration,
         context: Context,
         payload: RequestToOther,
-        cb: GhostCallback<Context, RequestToOtherResponse, Error>,
+        cb: GhostCallback<Context, RequestToOtherResponse, Error, A>,
     ) {
         let request_id = self
             .pending_responses_tracker
@@ -273,10 +279,10 @@ impl<
 #[allow(clippy::complexity)]
 pub fn create_ghost_channel<
     RequestToParent,
-    RequestToParentResponse,
+    RequestToParentResponse: 'static,
     RequestToChild,
-    RequestToChildResponse,
-    Error,
+    RequestToChildResponse: 'static,
+    Error: 'static,
 >() -> (
     GhostEndpoint<
         RequestToChild,

--- a/crates/ghost_actor/src/ghost_channel.rs
+++ b/crates/ghost_actor/src/ghost_channel.rs
@@ -211,7 +211,7 @@ impl<
         timeout: std::time::Duration,
         context: Context,
         payload: RequestToOther,
-        cb: GhostCallback<Context, RequestToOtherResponse, Error, A>,
+        cb: GhostCallback<A, Context, RequestToOtherResponse, Error>,
     ) {
         let request_id = self
             .pending_responses_tracker

--- a/crates/ghost_actor/src/ghost_channel.rs
+++ b/crates/ghost_actor/src/ghost_channel.rs
@@ -421,7 +421,7 @@ mod tests {
         // the FakeActor's state String, thus for testing we can just look in the actors's
         // state to see if the callback was run.
         fn cb_factory() -> GhostCallback<FakeActor, TestContext, TestMsgOutResponse, TestError> {
-            Box::new(|dyn_me, _context, callback_data| {
+            Box::new(|me, _context, callback_data| {
                 dyn_me.0 = format!("{:?}", callback_data);
                 Ok(())
             })

--- a/crates/ghost_actor/src/ghost_tracker.rs
+++ b/crates/ghost_actor/src/ghost_tracker.rs
@@ -206,7 +206,7 @@ mod tests {
                 // when the timeout happens the callback should get
                 // the timeout enum in the callback_data
                 match callback_data {
-                    GhostCallbackData::Timeout => dyn_me.state = "timed_out".into(),
+                    GhostCallbackData::Timeout => me.state = "timed_out".into(),
                     _ => assert!(false),
                 }
                 Ok(())

--- a/crates/ghost_actor/src/ghost_tracker.rs
+++ b/crates/ghost_actor/src/ghost_tracker.rs
@@ -148,7 +148,7 @@ mod tests {
         let context = TestContext("some_context_data".into());
 
         let cb: GhostCallback<TestTrackingActor, TestContext, TestCallbackData, TestError> =
-            Box::new(|dyn_me, context, callback_data| {
+            Box::new(|me, context, callback_data| {
                 // and we'll check that we got our context back too because we
                 // might have used it to determine what to do here.
                 assert_eq!(context.0, "some_context_data");

--- a/crates/ghost_actor/src/ghost_tracker.rs
+++ b/crates/ghost_actor/src/ghost_tracker.rs
@@ -153,7 +153,7 @@ mod tests {
                 // might have used it to determine what to do here.
                 assert_eq!(context.0, "some_context_data");
                 if let GhostCallbackData::Response(Ok(TestCallbackData(payload))) = callback_data {
-                    dyn_me.state = payload;
+                    me.state = payload;
                 }
                 Ok(())
             });

--- a/crates/ghost_actor/src/ghost_tracker.rs
+++ b/crates/ghost_actor/src/ghost_tracker.rs
@@ -202,7 +202,7 @@ mod tests {
         let mut actor = TestTrackingActor::new("test_request_id_prefix");
         let context = TestContext("foo".into());
         let cb: GhostCallback<TestTrackingActor, TestContext, TestCallbackData, TestError> =
-            Box::new(|dyn_me, _context, callback_data| {
+            Box::new(|me, _context, callback_data| {
                 // when the timeout happens the callback should get
                 // the timeout enum in the callback_data
                 match callback_data {

--- a/crates/ghost_actor/src/lib.rs
+++ b/crates/ghost_actor/src/lib.rs
@@ -74,7 +74,6 @@ pub mod prelude {
 mod tests {
     use super::*;
     use detach::prelude::*;
-    use std::any::Any;
 
     type FakeError = String;
 
@@ -144,10 +143,6 @@ mod tests {
             FakeError,
         > for RrDht
     {
-        fn as_any(&mut self) -> &mut dyn Any {
-            &mut *self
-        }
-
         fn take_parent_endpoint(
             &mut self,
         ) -> Option<
@@ -294,10 +289,6 @@ mod tests {
             String,
         > for GatewayTransport
     {
-        fn as_any(&mut self) -> &mut dyn Any {
-            &mut *self
-        }
-
         fn take_parent_endpoint(
             &mut self,
         ) -> Option<

--- a/crates/ghost_actor/src/lib.rs
+++ b/crates/ghost_actor/src/lib.rs
@@ -316,7 +316,7 @@ mod tests {
                 RequestToParent::IncomingConnection {
                     address: "test".to_string(),
                 },
-                Box::new(|_m, c, r| {
+                Box::new(|_m: &mut GatewayTransport, c, r| {
                     println!(
                         "response from parent to IncomingConnection got: {:?} with context {:?}",
                         r, c
@@ -349,12 +349,7 @@ mod tests {
                             std::time::Duration::from_millis(2000),
                             GwDht::ResolveAddressForId { msg },
                             dht_protocol::RequestToChild::ResolveAddressForId { id: address },
-                            Box::new(|m, context, response| {
-                                let _m = match m.downcast_mut::<GatewayTransport>() {
-                                    None => panic!("wrong type"),
-                                    Some(m) => m,
-                                };
-
+                            Box::new(|_m:&mut GatewayTransport, context, response| {
                                 let msg = {
                                     if let GwDht::ResolveAddressForId { msg } = context {
                                         msg
@@ -459,7 +454,7 @@ mod tests {
             RequestToChild::Bind {
                 spec: "address_to_bind_to".to_string(),
             },
-            Box::new(|_, _, r| {
+            Box::new(|_: &mut (), _, r| {
                 println!("in callback 1, got: {:?}", r);
                 Ok(())
             }),
@@ -475,7 +470,7 @@ mod tests {
                 address: "agent_id_1".to_string(),
                 payload: b"some content".to_vec(),
             },
-            Box::new(|_, _, r| {
+            Box::new(|_: &mut (), _, r| {
                 println!("in callback 2, got: {:?}", r);
                 Ok(())
             }),

--- a/crates/lib3h/src/keystore.rs
+++ b/crates/lib3h/src/keystore.rs
@@ -7,7 +7,6 @@ use crate::{
 
 use detach::prelude::*;
 use lib3h_ghost_actor::prelude::*;
-use std::any::Any;
 pub mod keystore_protocol {
     #[derive(Debug)]
     pub enum RequestToChild {
@@ -122,10 +121,6 @@ impl
         Lib3hError,
     > for KeystoreStub
 {
-    fn as_any(&mut self) -> &mut dyn Any {
-        &mut *self
-    }
-
     fn take_parent_endpoint(&mut self) -> Option<KeystoreParentEndpoint> {
         std::mem::replace(&mut self.endpoint_parent, None)
     }

--- a/crates/lib3h/src/keystore.rs
+++ b/crates/lib3h/src/keystore.rs
@@ -1,10 +1,13 @@
 //! This is a stub of the keystore so we can prove out the encoding transport
 
-use crate::error::{Lib3hError, Lib3hResult};
+use crate::{
+    error::{Lib3hError, Lib3hResult},
+    transport::TransportEncoding,
+};
+
 use detach::prelude::*;
 use lib3h_ghost_actor::prelude::*;
 use std::any::Any;
-
 pub mod keystore_protocol {
     #[derive(Debug)]
     pub enum RequestToChild {
@@ -44,6 +47,7 @@ pub type KeystoreActorParentEndpoint = GhostEndpoint<
 >;
 
 pub type KeystoreActorParentWrapperDyn<Context> = GhostParentWrapperDyn<
+    TransportEncoding,
     Context,
     RequestToParent,
     RequestToParentResponse,
@@ -61,6 +65,7 @@ type KeystoreParentEndpoint = GhostEndpoint<
 >;
 
 type KeystoreSelfEndpoint = GhostContextEndpoint<
+    KeystoreStub,
     (),
     RequestToParent,
     RequestToParentResponse,
@@ -126,7 +131,7 @@ impl
     }
 
     fn process_concrete(&mut self) -> GhostResult<WorkWasDone> {
-        detach_run!(&mut self.endpoint_self, |es| es.process(self.as_any()))?;
+        detach_run!(&mut self.endpoint_self, |es| es.process(self))?;
         for msg in self.endpoint_self.as_mut().drain_messages() {
             self.handle_msg_from_parent(msg).expect("no ghost errors");
         }

--- a/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
@@ -26,6 +26,15 @@ type GhostTransportMemoryEndpointContext = GhostContextEndpoint<
     TransportError,
 >;
 
+pub type GhostTransportMemoryEndpointContextParent = GhostContextEndpoint<
+    (),
+    RequestToChild,
+    RequestToChildResponse,
+    RequestToParent,
+    RequestToParentResponse,
+    TransportError,
+>;
+
 #[allow(dead_code)]
 struct GhostTransportMemory {
     endpoint_parent: Option<GhostTransportMemoryEndpoint>,
@@ -265,7 +274,7 @@ mod tests {
              */
 
         let mut transport1 = GhostTransportMemory::new();
-        let mut t1_endpoint = transport1
+        let mut t1_endpoint: GhostTransportMemoryEndpointContextParent = transport1
             .take_parent_endpoint()
             .expect("exists")
             .as_context_endpoint::<()>("tmem_to_child1");
@@ -287,7 +296,7 @@ mod tests {
             RequestToChild::Bind {
                 spec: Url::parse("mem://_").unwrap(),
             },
-            Box::new(|_, _, r| {
+            Box::new(|_: &mut (), _, r| {
                 // parent should see the bind event
                 assert_eq!(
                     "Response(Ok(Bind(BindResultData { bound_url: \"mem://addr_1/\" })))",
@@ -303,7 +312,7 @@ mod tests {
             RequestToChild::Bind {
                 spec: Url::parse("mem://_").unwrap(),
             },
-            Box::new(|_, _, r| {
+            Box::new(|_: &mut (), _, r| {
                 // parent should see the bind event
                 assert_eq!(
                     "Response(Ok(Bind(BindResultData { bound_url: \"mem://addr_2/\" })))",
@@ -336,7 +345,7 @@ mod tests {
                 address: Url::parse("mem://addr_2").unwrap(),
                 payload: b"test message".to_vec(),
             },
-            Box::new(|_, _, r| {
+            Box::new(|_: &mut (), _, r| {
                 // parent should see that the send request was OK
                 assert_eq!("Response(Ok(SendMessage))", &format!("{:?}", r));
                 Ok(())

--- a/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
@@ -1,6 +1,6 @@
 use crate::transport::{error::TransportError, memory_mock::memory_server, protocol::*};
 use lib3h_ghost_actor::prelude::*;
-use std::{any::Any, collections::HashSet};
+use std::collections::HashSet;
 use url::Url;
 
 #[derive(Debug)]
@@ -78,10 +78,6 @@ impl
     > for GhostTransportMemory
 {
     // BOILERPLATE START----------------------------------
-
-    fn as_any(&mut self) -> &mut dyn Any {
-        &mut *self
-    }
 
     fn take_parent_endpoint(&mut self) -> Option<GhostTransportMemoryEndpoint> {
         std::mem::replace(&mut self.endpoint_parent, None)

--- a/crates/lib3h/src/transport/protocol.rs
+++ b/crates/lib3h/src/transport/protocol.rs
@@ -69,8 +69,6 @@ pub type DynTransportActor = Box<
     >,
 >;
 
-//type UserData = TransportEncoding;
-
 pub type TransportActorParentEndpoint = GhostEndpoint<
     RequestToChild,
     RequestToChildResponse,

--- a/crates/lib3h/src/transport/protocol.rs
+++ b/crates/lib3h/src/transport/protocol.rs
@@ -68,6 +68,9 @@ pub type DynTransportActor = Box<
         TransportError,
     >,
 >;
+
+//type UserData = TransportEncoding;
+
 pub type TransportActorParentEndpoint = GhostEndpoint<
     RequestToChild,
     RequestToChildResponse,
@@ -75,7 +78,8 @@ pub type TransportActorParentEndpoint = GhostEndpoint<
     RequestToParentResponse,
     TransportError,
 >;
-pub type TransportActorParentWrapper<Context, Actor> = GhostParentWrapper<
+pub type TransportActorParentWrapper<UserData, Context, Actor> = GhostParentWrapper<
+    UserData,
     Context,
     RequestToParent,
     RequestToParentResponse,
@@ -84,7 +88,8 @@ pub type TransportActorParentWrapper<Context, Actor> = GhostParentWrapper<
     TransportError,
     Actor,
 >;
-pub type TransportActorParentWrapperDyn<Context> = GhostParentWrapperDyn<
+pub type TransportActorParentWrapperDyn<UserData, Context> = GhostParentWrapperDyn<
+    UserData,
     Context,
     RequestToParent,
     RequestToParentResponse,

--- a/crates/lib3h/src/transport/transport_encoding/mod.rs
+++ b/crates/lib3h/src/transport/transport_encoding/mod.rs
@@ -5,7 +5,7 @@ use crate::{
 use detach::prelude::*;
 use lib3h_crypto_api::CryptoSystem;
 use lib3h_ghost_actor::prelude::*;
-use std::{any::Any, collections::HashMap};
+use std::collections::HashMap;
 use url::Url;
 
 enum ToParentContext {}
@@ -370,10 +370,6 @@ impl
         TransportError,
     > for TransportEncoding
 {
-    fn as_any(&mut self) -> &mut dyn Any {
-        &mut *self
-    }
-
     fn take_parent_endpoint(&mut self) -> Option<TransportActorParentEndpoint> {
         std::mem::replace(&mut self.endpoint_parent, None)
     }
@@ -445,10 +441,6 @@ mod tests {
             TransportError,
         > for TransportMock
     {
-        fn as_any(&mut self) -> &mut dyn Any {
-            &mut *self
-        }
-
         fn take_parent_endpoint(&mut self) -> Option<TransportActorParentEndpoint> {
             std::mem::replace(&mut self.endpoint_parent, None)
         }

--- a/crates/lib3h/src/transport/transport_encoding/mod.rs
+++ b/crates/lib3h/src/transport/transport_encoding/mod.rs
@@ -252,11 +252,7 @@ impl TransportEncoding {
             std::time::Duration::from_millis(2000),
             ToInnerContext::AwaitBind(msg),
             RequestToChild::Bind { spec },
-            Box::new(|m, context, response| {
-                let m = match m.downcast_mut::<TransportEncoding>() {
-                    None => panic!("wrong type"),
-                    Some(m) => m,
-                };
+            Box::new(|m: &mut TransportEncoding, context, response| {
                 let msg = {
                     match context {
                         ToInnerContext::AwaitBind(msg) => msg,
@@ -302,7 +298,7 @@ impl TransportEncoding {
             std::time::Duration::from_millis(2000),
             ToInnerContext::AwaitSend(msg),
             RequestToChild::SendMessage { address, payload },
-            Box::new(|_, context, response| {
+            Box::new(|_: &mut TransportEncoding, context, response| {
                 let msg = {
                     match context {
                         ToInnerContext::AwaitSend(msg) => msg,
@@ -522,7 +518,7 @@ mod tests {
             RequestToChild::Bind {
                 spec: Url::parse("test://1").expect("can parse url"),
             },
-            Box::new(|_, _, response| {
+            Box::new(|_: &mut (), _, response| {
                 assert_eq!(
                     &format!("{:?}", response),
                     "Response(Ok(Bind(BindResultData { bound_url: \"test://1/bound?a=HcSCJ9G64XDKYo433rIMm57wfI8Y59Udeb4hkVvQBZdm6bgbJ5Wgs79pBGBcuzz\" })))"
@@ -556,7 +552,7 @@ mod tests {
             RequestToChild::Bind {
                 spec: Url::parse("test://2").expect("can parse url"),
             },
-            Box::new(|_, _, response| {
+            Box::new(|_:&mut (), _, response| {
                 assert_eq!(
                     &format!("{:?}", response),
                     "Response(Ok(Bind(BindResultData { bound_url: \"test://2/bound?a=HcMCJ8HpYvB4zqic93d3R4DjkVQ4hhbbv9UrZmWXOcn3m7w4O3AIr56JRfrt96r\" })))"
@@ -578,11 +574,8 @@ mod tests {
                 address: addr2full.clone(),
                 payload: b"hello".to_vec(),
             },
-            Box::new(|m, _, response| {
-                match m.downcast_mut::<bool>() {
-                    None => panic!("bad downcast"),
-                    Some(b) => *b = true,
-                }
+            Box::new(|b: &mut bool, _, response| {
+                *b = true;
                 // make sure we get a success response
                 assert_eq!("Response(Ok(SendMessage))", format!("{:?}", response),);
                 Ok(())


### PR DESCRIPTION
## PR summary

This PR introduces an unconstrained type parameter `UserData` to `GhostCallback` which replaces the first parameter of the callback function from `&mut dyn Any` to `&mut UserData`. The `GhostTracker` and `GhostTrackerEntry` now maintain a map of callbacks for a specific `UserData` type.

Calls to `bookmark` and `request` now correspondingly accept `UserData` which must be the same type as the callbacks are assuming. Thus there is no need to convert the user data to the correct type using `downcast_mut`. 

Thus, in short,

```Rust
 Box::new(|u, ctx, data| { match a.downcast_mut::<UserData>() ... })
```
becomes

```Rust
 Box::new(|u:&mut UserData, ctx, data| { // no need for downcast! })
```
 
and the `GhostParentContextEndpoint` now requires a `UserData` type parameter (and thus so does `as_context_endpoint` in `GhostEndpoint`.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
