### PR TITLE
Ghost Actor Default Timeouts

### DIFF
--- a/crates/ghost_actor/src/ghost_actor.rs
+++ b/crates/ghost_actor/src/ghost_actor.rs
@@ -64,7 +64,7 @@ impl<
         let endpoint = actor
             .take_parent_endpoint()
             .expect("exists")
-            .as_context_builder()
+            .as_context_endpoint_builder()
             .request_id_prefix(request_id_prefix)
             .build();
         Self { actor, endpoint }
@@ -312,7 +312,7 @@ impl<
         let endpoint: GhostContextEndpoint<UserData, Context, _, _, _, _, _> = actor
             .take_parent_endpoint()
             .expect("exists")
-            .as_context_builder()
+            .as_context_endpoint_builder()
             .request_id_prefix(request_id_prefix)
             .build();
         Self { actor, endpoint }
@@ -404,7 +404,7 @@ mod tests {
                 endpoint_for_parent: Some(endpoint_parent),
                 endpoint_as_child: Detach::new(
                     endpoint_self
-                        .as_context_builder()
+                        .as_context_endpoint_builder()
                         .request_id_prefix("child")
                         .build(),
                 ),
@@ -474,7 +474,7 @@ mod tests {
         > = child_actor
             .take_parent_endpoint()
             .unwrap()
-            .as_context_builder()
+            .as_context_endpoint_builder()
             .request_id_prefix("parent")
             .build();
 

--- a/crates/ghost_actor/src/ghost_actor.rs
+++ b/crates/ghost_actor/src/ghost_actor.rs
@@ -123,14 +123,14 @@ impl<
     }
 
     /// see GhostContextEndpoint::request
-    fn request_timeout(
+    fn request_options(
         &mut self,
         context: Context,
         payload: RequestToChild,
         cb: GhostCallback<UserData, Context, RequestToChildResponse, Error>,
-        timeout: std::time::Duration,
+        options: GhostTrackRequestOptions,
     ) {
-        self.endpoint.request_timeout(context, payload, cb, timeout)
+        self.endpoint.request_options(context, payload, cb, options)
     }
 
     /// see GhostContextEndpoint::drain_messages
@@ -333,14 +333,14 @@ impl<
         self.endpoint.request(context, payload, cb)
     }
 
-    pub fn request_timeout(
+    pub fn request_options(
         &mut self,
         context: Context,
         payload: RequestToChild,
         cb: GhostCallback<UserData, Context, RequestToChildResponse, Error>,
-        timeout: std::time::Duration,
+        options: GhostTrackRequestOptions,
     ) {
-        self.endpoint.request_timeout(context, payload, cb, timeout)
+        self.endpoint.request_options(context, payload, cb, options)
     }
 
     /// see GhostContextEndpoint::drain_messages

--- a/crates/ghost_actor/src/ghost_channel.rs
+++ b/crates/ghost_actor/src/ghost_channel.rs
@@ -103,7 +103,7 @@ impl<RequestToSelf, RequestToOther, RequestToSelfResponse, Error: 'static>
 /// a parent_endpoint, and a child_endpoint
 /// these raw endpoints are not very useful on their own. When you get them
 /// to the place they will be used, you probably want to call
-/// `as_context_endpoint()` on them.
+/// `as_context_endpoint_builder()` on them.
 pub struct GhostEndpoint<
     RequestToOther,
     RequestToOtherResponse,
@@ -149,11 +149,11 @@ impl<
     /// expand a raw endpoint into something usable.
     /// <Context> let's you store data with individual `request` calls
     /// that will be available again when the callback is invoked.
-    /// Feel free to use `as_context_endpoint::<()>("prefix")` if you
+    /// Feel free to use `as_context_endpoint_builder::<()>("prefix")` if you
     /// don't need any context.
     /// request_id_prefix is a debugging hint... the request_ids generated
     /// for tracking request/response pairs will be prepended with this prefix.
-    pub fn as_context_builder(
+    pub fn as_context_endpoint_builder(
         self,
     ) -> GhostContextEndpointBuilder<
         RequestToOther,
@@ -286,7 +286,7 @@ pub trait GhostCanTrack<
 }
 
 /// an expanded endpoint usable to send/receive requests/responses/events
-/// see `GhostEndpoint::as_context_endpoint` for additional details
+/// see `GhostEndpoint::as_context_endpoint_builder` for additional details
 pub struct GhostContextEndpoint<
     UserData,
     Context,
@@ -598,7 +598,7 @@ mod tests {
         >();
 
         // in this test the endpoint will be the child end
-        let mut endpoint = child_side.as_context_builder().build();
+        let mut endpoint = child_side.as_context_endpoint_builder().build();
 
         endpoint.publish(TestMsgOut("event to my parent".into()));
         // check to see if the event was sent to the parent

--- a/crates/ghost_actor/src/ghost_tracker.rs
+++ b/crates/ghost_actor/src/ghost_tracker.rs
@@ -2,6 +2,8 @@ use std::collections::HashMap;
 
 use crate::{ghost_error::ErrorKind, GhostError, GhostResult, RequestId};
 
+const DEFAULT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(2000);
+
 /// a ghost request callback can be invoked with a response that was injected
 /// into the system through the `handle` pathway, or to indicate a failure
 /// such as a timeout
@@ -38,7 +40,7 @@ impl Default for GhostTrackerBuilder {
     fn default() -> Self {
         Self {
             request_id_prefix: "".to_string(),
-            default_timeout: std::time::Duration::from_millis(2000),
+            default_timeout: DEFAULT_TIMEOUT,
         }
     }
 }

--- a/crates/ghost_actor/src/lib.rs
+++ b/crates/ghost_actor/src/lib.rs
@@ -55,16 +55,18 @@ mod ghost_tracker;
 pub use ghost_tracker::{GhostCallback, GhostCallbackData, GhostTracker, GhostTrackerBuilder};
 
 mod ghost_channel;
-pub use ghost_channel::{create_ghost_channel, GhostContextEndpoint, GhostEndpoint, GhostMessage};
+pub use ghost_channel::{
+    create_ghost_channel, GhostCanTrack, GhostContextEndpoint, GhostEndpoint, GhostMessage,
+};
 
 mod ghost_actor;
 pub use ghost_actor::{GhostActor, GhostParentWrapper, GhostParentWrapperDyn};
 
 pub mod prelude {
     pub use super::{
-        create_ghost_channel, GhostActor, GhostCallback, GhostCallbackData, GhostContextEndpoint,
-        GhostEndpoint, GhostError, GhostMessage, GhostParentWrapper, GhostParentWrapperDyn,
-        GhostResult, GhostTracker, WorkWasDone,
+        create_ghost_channel, GhostActor, GhostCallback, GhostCallbackData, GhostCanTrack,
+        GhostContextEndpoint, GhostEndpoint, GhostError, GhostMessage, GhostParentWrapper,
+        GhostParentWrapperDyn, GhostResult, GhostTracker, WorkWasDone,
     };
 }
 

--- a/crates/ghost_actor/src/lib.rs
+++ b/crates/ghost_actor/src/lib.rs
@@ -138,7 +138,7 @@ mod tests {
                 endpoint_parent: Some(endpoint_parent),
                 endpoint_self: Detach::new(
                     endpoint_self
-                        .as_context_builder()
+                        .as_context_endpoint_builder()
                         .request_id_prefix("dht_to_parent")
                         .build(),
                 ),
@@ -288,7 +288,7 @@ mod tests {
                 endpoint_parent: Some(endpoint_parent),
                 endpoint_self: Detach::new(
                     endpoint_self
-                        .as_context_builder()
+                        .as_context_endpoint_builder()
                         .request_id_prefix("gw_to_parent")
                         .build(),
                 ),
@@ -439,7 +439,7 @@ mod tests {
         let mut t_actor_endpoint = t_actor
             .take_parent_endpoint()
             .expect("exists")
-            .as_context_builder()
+            .as_context_endpoint_builder()
             .build::<(), i8>();
 
         // allow the actor to run this actor always creates a simulated incoming

--- a/crates/ghost_actor/src/lib.rs
+++ b/crates/ghost_actor/src/lib.rs
@@ -52,11 +52,15 @@ mod ghost_error;
 pub use ghost_error::{GhostError, GhostResult};
 
 mod ghost_tracker;
-pub use ghost_tracker::{GhostCallback, GhostCallbackData, GhostTracker, GhostTrackerBuilder};
+pub use ghost_tracker::{
+    GhostCallback, GhostCallbackData, GhostTracker, GhostTrackerBookmarkOptions,
+    GhostTrackerBuilder,
+};
 
 mod ghost_channel;
 pub use ghost_channel::{
     create_ghost_channel, GhostCanTrack, GhostContextEndpoint, GhostEndpoint, GhostMessage,
+    GhostTrackRequestOptions,
 };
 
 mod ghost_actor;
@@ -66,7 +70,8 @@ pub mod prelude {
     pub use super::{
         create_ghost_channel, GhostActor, GhostCallback, GhostCallbackData, GhostCanTrack,
         GhostContextEndpoint, GhostEndpoint, GhostError, GhostMessage, GhostParentWrapper,
-        GhostParentWrapperDyn, GhostResult, GhostTracker, WorkWasDone,
+        GhostParentWrapperDyn, GhostResult, GhostTrackRequestOptions, GhostTracker,
+        GhostTrackerBookmarkOptions, WorkWasDone,
     };
 }
 

--- a/crates/lib3h/src/keystore.rs
+++ b/crates/lib3h/src/keystore.rs
@@ -81,7 +81,12 @@ impl KeystoreStub {
     pub fn new() -> Self {
         let (endpoint_parent, endpoint_self) = create_ghost_channel();
         let endpoint_parent = Some(endpoint_parent);
-        let endpoint_self = Detach::new(endpoint_self.as_context_endpoint("keystore_to_parent_"));
+        let endpoint_self = Detach::new(
+            endpoint_self
+                .as_context_builder()
+                .request_id_prefix("keystore_to_parent_")
+                .build(),
+        );
         Self {
             endpoint_parent,
             endpoint_self,

--- a/crates/lib3h/src/keystore.rs
+++ b/crates/lib3h/src/keystore.rs
@@ -87,7 +87,7 @@ impl KeystoreStub {
         let endpoint_parent = Some(endpoint_parent);
         let endpoint_self = Detach::new(
             endpoint_self
-                .as_context_builder()
+                .as_context_endpoint_builder()
                 .request_id_prefix("keystore_to_parent_")
                 .build(),
         );

--- a/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
@@ -42,7 +42,12 @@ impl GhostTransportMemory {
         let (endpoint_parent, endpoint_self) = create_ghost_channel();
         Self {
             endpoint_parent: Some(endpoint_parent),
-            endpoint_self: Some(endpoint_self.as_context_endpoint("tmem_to_parent")),
+            endpoint_self: Some(
+                endpoint_self
+                    .as_context_builder()
+                    .request_id_prefix("tmem_to_parent")
+                    .build(),
+            ),
             connections: HashSet::new(),
             maybe_my_address: None,
         }
@@ -268,13 +273,17 @@ mod tests {
         let mut t1_endpoint = transport1
             .take_parent_endpoint()
             .expect("exists")
-            .as_context_endpoint::<()>("tmem_to_child1");
+            .as_context_builder()
+            .request_id_prefix("tmem_to_child1")
+            .build::<()>();
 
         let mut transport2 = GhostTransportMemory::new();
         let mut t2_endpoint = transport2
             .take_parent_endpoint()
             .expect("exists")
-            .as_context_endpoint::<()>("tmem_to_child2");
+            .as_context_builder()
+            .request_id_prefix("tmem_to_child2")
+            .build::<()>();
 
         // create two memory bindings so that we have addresses
         assert_eq!(transport1.maybe_my_address, None);
@@ -282,7 +291,6 @@ mod tests {
 
         let expected_transport1_address = Url::parse("mem://addr_1").unwrap();
         t1_endpoint.request(
-            std::time::Duration::from_millis(2000),
             (),
             RequestToChild::Bind {
                 spec: Url::parse("mem://_").unwrap(),
@@ -298,7 +306,6 @@ mod tests {
         );
         let expected_transport2_address = Url::parse("mem://addr_2").unwrap();
         t2_endpoint.request(
-            std::time::Duration::from_millis(2000),
             (),
             RequestToChild::Bind {
                 spec: Url::parse("mem://_").unwrap(),
@@ -330,7 +337,6 @@ mod tests {
 
         // now send a message from transport1 to transport2 over the bound addresses
         t1_endpoint.request(
-            std::time::Duration::from_millis(2000),
             (),
             RequestToChild::SendMessage {
                 address: Url::parse("mem://addr_2").unwrap(),

--- a/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
@@ -57,7 +57,7 @@ impl GhostTransportMemory {
             endpoint_parent: Some(endpoint_parent),
             endpoint_self: Some(
                 endpoint_self
-                    .as_context_builder()
+                    .as_context_endpoint_builder()
                     .request_id_prefix("tmem_to_parent")
                     .build(),
             ),
@@ -279,7 +279,7 @@ mod tests {
         let mut t1_endpoint: GhostTransportMemoryEndpointContextParent = transport1
             .take_parent_endpoint()
             .expect("exists")
-            .as_context_builder()
+            .as_context_endpoint_builder()
             .request_id_prefix("tmem_to_child1")
             .build::<(), ()>();
 
@@ -287,7 +287,7 @@ mod tests {
         let mut t2_endpoint = transport2
             .take_parent_endpoint()
             .expect("exists")
-            .as_context_builder()
+            .as_context_endpoint_builder()
             .request_id_prefix("tmem_to_child2")
             .build::<(), ()>();
 

--- a/crates/lib3h/src/transport/transport_encoding/mod.rs
+++ b/crates/lib3h/src/transport/transport_encoding/mod.rs
@@ -82,7 +82,7 @@ impl TransportEncoding {
         let endpoint_parent = Some(endpoint_parent);
         let endpoint_self = Detach::new(
             endpoint_self
-                .as_context_builder()
+                .as_context_endpoint_builder()
                 .request_id_prefix("enc_to_parent_")
                 .build(),
         );
@@ -426,7 +426,7 @@ mod tests {
             let endpoint_parent = Some(endpoint_parent);
             let endpoint_self = Detach::new(
                 endpoint_self
-                    .as_context_builder()
+                    .as_context_endpoint_builder()
                     .request_id_prefix("mock_to_parent_")
                     .build(),
             );

--- a/crates/lib3h/src/transport/transport_encoding/mod.rs
+++ b/crates/lib3h/src/transport/transport_encoding/mod.rs
@@ -79,7 +79,12 @@ impl TransportEncoding {
     ) -> Self {
         let (endpoint_parent, endpoint_self) = create_ghost_channel();
         let endpoint_parent = Some(endpoint_parent);
-        let endpoint_self = Detach::new(endpoint_self.as_context_endpoint("enc_to_parent_"));
+        let endpoint_self = Detach::new(
+            endpoint_self
+                .as_context_builder()
+                .request_id_prefix("enc_to_parent_")
+                .build(),
+        );
         let keystore = Detach::new(GhostParentWrapperDyn::new(keystore, "enc_to_keystore"));
         let inner_transport =
             Detach::new(GhostParentWrapperDyn::new(inner_transport, "enc_to_inner_"));
@@ -253,7 +258,6 @@ impl TransportEncoding {
 
         // forward the bind to our inner_transport
         self.inner_transport.as_mut().request(
-            std::time::Duration::from_millis(2000),
             ToInnerContext::AwaitBind(msg),
             RequestToChild::Bind { spec },
             Box::new(|m, context, response| {
@@ -303,7 +307,6 @@ impl TransportEncoding {
         payload: Vec<u8>,
     ) -> TransportResult<()> {
         self.inner_transport.as_mut().request(
-            std::time::Duration::from_millis(2000),
             ToInnerContext::AwaitSend(msg),
             RequestToChild::SendMessage { address, payload },
             Box::new(|_, context, response| {
@@ -427,7 +430,12 @@ mod tests {
         ) -> Self {
             let (endpoint_parent, endpoint_self) = create_ghost_channel();
             let endpoint_parent = Some(endpoint_parent);
-            let endpoint_self = Detach::new(endpoint_self.as_context_endpoint("mock_to_parent_"));
+            let endpoint_self = Detach::new(
+                endpoint_self
+                    .as_context_builder()
+                    .request_id_prefix("mock_to_parent_")
+                    .build(),
+            );
             Self {
                 endpoint_parent,
                 endpoint_self,
@@ -521,7 +529,6 @@ mod tests {
 
         // give it a bind point
         t1.request(
-            std::time::Duration::from_millis(2000),
             (),
             RequestToChild::Bind {
                 spec: Url::parse("test://1").expect("can parse url"),
@@ -555,7 +562,6 @@ mod tests {
 
         // give it a bind point
         t2.request(
-            std::time::Duration::from_millis(2000),
             (),
             RequestToChild::Bind {
                 spec: Url::parse("test://2").expect("can parse url"),
@@ -576,7 +582,6 @@ mod tests {
 
         // now we're going to send a message to our sibling #2
         t1.request(
-            std::time::Duration::from_millis(2000),
             (),
             RequestToChild::SendMessage {
                 address: addr2full.clone(),

--- a/crates/lib3h/tests/transport.rs
+++ b/crates/lib3h/tests/transport.rs
@@ -201,7 +201,7 @@ impl TestTransport {
         let endpoint_parent = Some(endpoint_parent);
         let endpoint_self = Detach::new(
             endpoint_self
-                .as_context_builder()
+                .as_context_endpoint_builder()
                 .request_id_prefix(&format!("{}_to_parent_", name))
                 .build(),
         );


### PR DESCRIPTION
## PR summary

This creates a default timeout that can be used for most normal use-cases.

Adds builder pattern for GhostTracker, and ContextEndpoints + adds default timeout to both which defaults to 2 seconds.

Separates:

- `bookmark_timeout` from `bookmark` (which uses the default timeout)
- `request_timeout` from `request` (which uses the default timeout)

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
