### PR TITLE
Remove obsolete Context structs

### DIFF
--- a/crates/ghost_actor/src/ghost_channel.rs
+++ b/crates/ghost_actor/src/ghost_channel.rs
@@ -18,23 +18,6 @@ enum GhostEndpointMessage<Request: 'static, Response: 'static, Error: 'static> {
     },
 }
 
-/// A GhostMessage with only the data, i.e. minus the Sender
-/// This is so that it is more easily cloneable
-#[derive(Debug, Clone)]
-pub struct GhostMessageData<T: 'static + Clone> {
-    pub request_id: Option<RequestId>,
-    pub message: Option<T>,
-}
-
-impl<T: 'static + Clone> GhostMessageData<T> {
-    pub fn with_message<A, B, C>(msg: &GhostMessage<T, A, B, C>) -> Self {
-        GhostMessageData {
-            request_id: msg.request_id.clone(),
-            message: msg.message.clone(),
-        }
-    }
-}
-
 /// GhostContextEndpoints allow you to drain these incoming `GhostMessage`s
 /// A GhostMessage contains the incoming request, as well as a hook to
 /// allow a response to automatically be returned.

--- a/crates/ghost_actor/src/lib.rs
+++ b/crates/ghost_actor/src/lib.rs
@@ -65,7 +65,7 @@ pub use ghost_tracker::{
 mod ghost_channel;
 pub use ghost_channel::{
     create_ghost_channel, GhostCanTrack, GhostContextEndpoint, GhostEndpoint, GhostMessage,
-    GhostMessageData, GhostTrackRequestOptions,
+    GhostTrackRequestOptions,
 };
 
 mod ghost_actor;
@@ -74,9 +74,9 @@ pub use ghost_actor::{GhostActor, GhostParentWrapper, GhostParentWrapperDyn};
 pub mod prelude {
     pub use super::{
         create_ghost_channel, GhostActor, GhostCallback, GhostCallbackData, GhostCanTrack,
-        GhostContextEndpoint, GhostEndpoint, GhostError, GhostMessage, GhostMessageData,
-        GhostParentWrapper, GhostParentWrapperDyn, GhostResult, GhostTrackRequestOptions,
-        GhostTracker, GhostTrackerBookmarkOptions, WorkWasDone,
+        GhostContextEndpoint, GhostEndpoint, GhostError, GhostMessage, GhostParentWrapper,
+        GhostParentWrapperDyn, GhostResult, GhostTrackRequestOptions, GhostTracker,
+        GhostTrackerBookmarkOptions, WorkWasDone,
     };
 }
 
@@ -236,18 +236,6 @@ mod tests {
     }
 
     use transport_protocol::*;
-
-    #[derive(Debug)]
-    enum _GwDht {
-        ResolveAddressForId {
-            msg: GhostMessage<RequestToChild, RequestToParent, RequestToChildResponse, FakeError>,
-        },
-    }
-
-    #[derive(Debug)]
-    enum _RequestToParentContext {
-        IncomingConnection { address: String },
-    }
 
     struct GatewayTransport {
         endpoint_parent: Option<

--- a/crates/lib3h/src/dht/dht_protocol.rs
+++ b/crates/lib3h/src/dht/dht_protocol.rs
@@ -7,7 +7,6 @@ use url::Url;
 
 use crate::{dht::dht_config::DhtConfig, error::*};
 use lib3h_ghost_actor::prelude::*;
-use lib3h_protocol::data_types::*;
 
 pub type FromPeerAddress = PeerAddress;
 
@@ -48,24 +47,9 @@ pub type ChildDhtWrapperDyn<UserData, TraceContext> = GhostParentWrapperDyn<
 
 pub type DhtToChildMessage =
     GhostMessage<DhtRequestToChild, DhtRequestToParent, DhtRequestToChildResponse, Lib3hError>;
-pub type DhtToChildMessageData = GhostMessageData<DhtRequestToChild>;
 
 pub type DhtToParentMessage =
     GhostMessage<DhtRequestToParent, DhtRequestToChild, DhtRequestToParentResponse, Lib3hError>;
-pub type DhtToParentMessageData = GhostMessageData<DhtRequestToParent>;
-
-#[derive(Debug, Clone)]
-pub enum DhtContext {
-    NoOp,
-    RequestAspectsOf {
-        entry_address: Address,
-        aspect_address_list: Vec<Address>,
-        msg: EntryListData,
-        request_id: String,
-    },
-    RequestEntry(DhtToChildMessageData),
-    QueryEntry(QueryEntryData),
-}
 
 #[derive(Debug, Clone)]
 pub enum DhtRequestToChild {

--- a/crates/lib3h/src/engine/ghost_engine_wrapper.rs
+++ b/crates/lib3h/src/engine/ghost_engine_wrapper.rs
@@ -11,18 +11,6 @@ use lib3h_protocol::{
 };
 use lib3h_tracing::Lib3hTrace;
 
-/// the context when making a request from core
-/// this is always the request_id
-pub struct ClientRequestContext(String);
-impl ClientRequestContext {
-    pub fn new(id: &str) -> Self {
-        Self(id.to_string())
-    }
-    pub fn get_request_id(&self) -> String {
-        self.0.clone()
-    }
-}
-
 /// A wrapper for talking to lib3h using the legacy Lib3hClient/Server enums
 #[allow(dead_code)]
 struct LegacyLib3h<Engine, EngineError: 'static>
@@ -118,42 +106,31 @@ where
 
     /// Add incoming Lib3hClientProtocol message in FIFO
     fn post(&mut self, client_msg: Lib3hClientProtocol) -> Lib3hProtocolResult<()> {
-        let ctx = match &client_msg {
-            Lib3hClientProtocol::Connect(data) => ClientRequestContext::new(&data.request_id),
-            Lib3hClientProtocol::JoinSpace(data) => ClientRequestContext::new(&data.request_id),
-            Lib3hClientProtocol::LeaveSpace(data) => ClientRequestContext::new(&data.request_id),
-            Lib3hClientProtocol::SendDirectMessage(data) => {
-                ClientRequestContext::new(&data.request_id)
-            }
-            Lib3hClientProtocol::FetchEntry(data) => ClientRequestContext::new(&data.request_id),
-            Lib3hClientProtocol::QueryEntry(data) => ClientRequestContext::new(&data.request_id),
-            Lib3hClientProtocol::HandleSendDirectMessageResult(data) => {
-                ClientRequestContext::new(&data.request_id)
-            }
-            Lib3hClientProtocol::HandleFetchEntryResult(data) => {
-                ClientRequestContext::new(&data.request_id)
-            }
-            Lib3hClientProtocol::HandleQueryEntryResult(data) => {
-                ClientRequestContext::new(&data.request_id)
-            }
-            Lib3hClientProtocol::HandleGetAuthoringEntryListResult(data) => {
-                ClientRequestContext::new(&data.request_id)
-            }
-            Lib3hClientProtocol::HandleGetGossipingEntryListResult(data) => {
-                ClientRequestContext::new(&data.request_id)
-            }
-            Lib3hClientProtocol::PublishEntry(_) => ClientRequestContext::new(""),
-            Lib3hClientProtocol::HoldEntry(_) => ClientRequestContext::new(""),
+        let request_id: String = match &client_msg {
+            Lib3hClientProtocol::Connect(data) => &data.request_id,
+            Lib3hClientProtocol::JoinSpace(data) => &data.request_id,
+            Lib3hClientProtocol::LeaveSpace(data) => &data.request_id,
+            Lib3hClientProtocol::SendDirectMessage(data) => &data.request_id,
+            Lib3hClientProtocol::FetchEntry(data) => &data.request_id,
+            Lib3hClientProtocol::QueryEntry(data) => &data.request_id,
+            Lib3hClientProtocol::HandleSendDirectMessageResult(data) => &data.request_id,
+            Lib3hClientProtocol::HandleFetchEntryResult(data) => &data.request_id,
+            Lib3hClientProtocol::HandleQueryEntryResult(data) => &data.request_id,
+            Lib3hClientProtocol::HandleGetAuthoringEntryListResult(data) => &data.request_id,
+            Lib3hClientProtocol::HandleGetGossipingEntryListResult(data) => &data.request_id,
+            Lib3hClientProtocol::PublishEntry(_) => "",
+            Lib3hClientProtocol::HoldEntry(_) => "",
             _ => unimplemented!(),
-        };
-        let request_id = ctx.get_request_id();
-        let result = if &request_id == "" {
+        }
+        .to_string();
+
+        let result = if request_id == "" {
             self.engine.publish(client_msg.into())
         } else {
             self.engine.request(
                 Lib3hTrace,
                 client_msg.into(),
-                LegacyLib3h::make_callback(request_id),
+                LegacyLib3h::make_callback(request_id.to_string()),
             )
         };
         result.map_err(|e| Lib3hProtocolError::new(ErrorKind::Other(e.to_string())))

--- a/crates/lib3h/src/engine/real_engine.rs
+++ b/crates/lib3h/src/engine/real_engine.rs
@@ -477,12 +477,6 @@ impl<'engine> RealEngine<'engine> {
         for (entry_address, aspect_address_list) in msg.address_map.clone() {
             let request_id = self.request_track.reserve();
             let msg = msg.clone();
-            let _ctx = DhtContext::RequestAspectsOf {
-                entry_address: entry_address.clone(),
-                aspect_address_list: aspect_address_list.clone(),
-                msg: msg.clone(),
-                request_id: request_id.clone(),
-            };
             // Check aspects and only request entry with new aspects
             space_gateway.as_mut().as_dht_mut().request(
                 Lib3hTrace,

--- a/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
@@ -4,12 +4,6 @@ use lib3h_tracing::Lib3hTrace;
 use std::collections::HashSet;
 use url::Url;
 
-#[derive(Debug)]
-#[allow(dead_code)]
-enum RequestToParentContext {
-    Source { address: Url },
-}
-
 pub type UserData = GhostTransportMemory;
 
 type GhostTransportMemoryEndpoint = GhostEndpoint<

--- a/crates/lib3h/src/transport/transport_encoding/mod.rs
+++ b/crates/lib3h/src/transport/transport_encoding/mod.rs
@@ -10,10 +10,6 @@ use lib3h_tracing::Lib3hTrace;
 use std::collections::HashMap;
 use url::Url;
 
-type ToParentContext = Lib3hTrace;
-type ToInnerContext = Lib3hTrace;
-type ToKeystoreContext = Lib3hTrace;
-
 /// Wraps a lower-level transport in either Open or Encrypted communication
 /// Also adds a concept of MachineId and AgentId
 /// This is currently a stub, only the Id concept is in place.
@@ -23,14 +19,14 @@ pub struct TransportEncoding {
     // the machine_id or agent_id of this encoding instance
     this_id: String,
     // the keystore to use for getting signatures for `this_id`
-    keystore: Detach<KeystoreActorParentWrapperDyn<ToKeystoreContext>>,
+    keystore: Detach<KeystoreActorParentWrapperDyn<Lib3hTrace>>,
     // our parent channel endpoint
     endpoint_parent: Option<TransportActorParentEndpoint>,
     // our self channel endpoint
     endpoint_self: Detach<
         GhostContextEndpoint<
             Self,
-            ToParentContext,
+            Lib3hTrace,
             RequestToParent,
             RequestToParentResponse,
             RequestToChild,
@@ -39,7 +35,7 @@ pub struct TransportEncoding {
         >,
     >,
     // ref to our inner transport
-    inner_transport: Detach<TransportActorParentWrapperDyn<TransportEncoding, ToInnerContext>>,
+    inner_transport: Detach<TransportActorParentWrapperDyn<TransportEncoding, Lib3hTrace>>,
     // if we have never sent a message to this node before,
     // we need to first handshake. Store the send payload && msg object
     // we will continue the transaction once the handshake completes
@@ -386,7 +382,7 @@ mod tests {
         endpoint_self: Detach<
             GhostContextEndpoint<
                 TransportMock,
-                ToParentContext,
+                Lib3hTrace,
                 RequestToParent,
                 RequestToParentResponse,
                 RequestToChild,

--- a/crates/lib3h/src/transport/transport_multiplex/mod.rs
+++ b/crates/lib3h/src/transport/transport_multiplex/mod.rs
@@ -31,14 +31,12 @@ mod tests {
     use lib3h_tracing::Lib3hTrace;
     use url::Url;
 
-    type MockToParentContext = Lib3hTrace;
-
     pub struct TransportMock {
         endpoint_parent: Option<TransportActorParentEndpoint>,
         endpoint_self: Detach<
             GhostContextEndpoint<
                 TransportMock,
-                MockToParentContext,
+                Lib3hTrace,
                 RequestToParent,
                 RequestToParentResponse,
                 RequestToChild,

--- a/crates/lib3h/src/transport/transport_multiplex/mplex.rs
+++ b/crates/lib3h/src/transport/transport_multiplex/mplex.rs
@@ -12,12 +12,6 @@ struct LocalRouteSpec {
     pub local_agent_id: Address,
 }
 
-#[derive(Debug)]
-enum MplexToInnerContext {
-    AwaitBind(GhostMessageData<RequestToChild>),
-    AwaitSend(GhostMessageData<RequestToChild>),
-}
-
 pub struct TransportMultiplex {
     // our parent channel endpoint
     endpoint_parent: Option<TransportActorParentEndpoint>,
@@ -186,7 +180,6 @@ impl TransportMultiplex {
         msg: GhostMessage<RequestToChild, RequestToParent, RequestToChildResponse, TransportError>,
         spec: Url,
     ) -> TransportResult<()> {
-        let _unused_context = MplexToInnerContext::AwaitBind(GhostMessageData::with_message(&msg));
         // forward the bind to our inner_transport
         self.inner_transport.as_mut().request(
             Lib3hTrace,
@@ -215,7 +208,6 @@ impl TransportMultiplex {
         address: Url,
         payload: Opaque,
     ) -> TransportResult<()> {
-        let _unused_context = MplexToInnerContext::AwaitSend(GhostMessageData::with_message(&msg));
         // forward the request to our inner_transport
         self.inner_transport.as_mut().request(
             Lib3hTrace,
@@ -261,7 +253,6 @@ impl TransportMultiplex {
         msg: GhostMessage<RequestToChild, RequestToParent, RequestToChildResponse, TransportError>,
         spec: Url,
     ) -> TransportResult<()> {
-        let _unused_context = MplexToInnerContext::AwaitBind(GhostMessageData::with_message(&msg));
         // forward the bind to our inner_transport
         self.inner_transport.as_mut().request(
             Lib3hTrace,
@@ -290,7 +281,6 @@ impl TransportMultiplex {
         address: Url,
         payload: Opaque,
     ) -> TransportResult<()> {
-        let _unused_context = MplexToInnerContext::AwaitSend(GhostMessageData::with_message(&msg));
         // forward the request to our inner_transport
         self.inner_transport.as_mut().request(
             Lib3hTrace,


### PR DESCRIPTION
## PR summary

#311 removed the notion of "context", allowing data to be moved directly into callback closures. This removes some leftover structs that were no longer being used to clean things up.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
