### PR TITLE
lib3h: Use PathBuf for work_dir field (github fork/ci workaround)

### DIFF
--- a/crates/lib3h/src/engine/mod.rs
+++ b/crates/lib3h/src/engine/mod.rs
@@ -3,7 +3,10 @@ pub mod p2p_protocol;
 pub mod real_engine;
 mod space_layer;
 
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::{
+    collections::{HashMap, HashSet, VecDeque},
+    path::PathBuf,
+};
 
 use crate::{
     dht::dht_trait::{Dht, DhtFactory},
@@ -41,7 +44,7 @@ pub struct RealEngineConfig {
     pub tls_config: TlsConfig,
     pub socket_type: String,
     pub bootstrap_nodes: Vec<String>,
-    pub work_dir: String,
+    pub work_dir: PathBuf,
     pub log_level: char,
     #[serde(with = "url_serde")]
     pub bind_url: Url,

--- a/crates/lib3h/tests/engine_test.rs
+++ b/crates/lib3h/tests/engine_test.rs
@@ -20,6 +20,7 @@ use lib3h_protocol::{
     protocol_server::Lib3hServerProtocol,
 };
 use lib3h_sodium::SodiumCryptoSystem;
+use std::path::PathBuf;
 use url::Url;
 use utils::{
     constants::*,
@@ -69,7 +70,7 @@ fn basic_setup_mock(name: &str) -> RealEngine<MirrorDht> {
         tls_config: TlsConfig::Unencrypted,
         socket_type: "mem".into(),
         bootstrap_nodes: vec![],
-        work_dir: String::new(),
+        work_dir: PathBuf::new(),
         log_level: 'd',
         bind_url: Url::parse(format!("mem://{}", name).as_str()).unwrap(),
         dht_gossip_interval: 100,
@@ -96,7 +97,7 @@ fn basic_setup_wss<'a>() -> RealEngine<'a, MirrorDht> {
         tls_config: TlsConfig::Unencrypted,
         socket_type: "ws".into(),
         bootstrap_nodes: vec![],
-        work_dir: String::new(),
+        work_dir: PathBuf::new(),
         log_level: 'd',
         bind_url: Url::parse("wss://127.0.0.1:64519").unwrap(),
         dht_gossip_interval: 200,

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -23,6 +23,7 @@ use lib3h::{
 };
 use lib3h_protocol::{network_engine::NetworkEngine, Address};
 use node_mock::NodeMock;
+use std::path::PathBuf;
 use test_suites::{
     three_basic::*, two_basic::*, two_connection::*, two_get_lists::*, two_spaces::*,
 };
@@ -85,7 +86,7 @@ fn setup_memory_node(name: &str, agent_id_arg: Address, fn_name: &str) -> NodeMo
         tls_config: TlsConfig::Unencrypted,
         socket_type: "mem".into(),
         bootstrap_nodes: vec![],
-        work_dir: String::new(),
+        work_dir: PathBuf::new(),
         log_level: 'd',
         bind_url: Url::parse(format!("mem://{}/{}", fn_name, name).as_str()).unwrap(),
         dht_gossip_interval: 500,
@@ -114,7 +115,7 @@ fn setup_wss_node(
         tls_config: tls_config,
         socket_type: protocol.into(),
         bootstrap_nodes: vec![],
-        work_dir: String::new(),
+        work_dir: PathBuf::new(),
         log_level: 'd',
         bind_url,
         dht_gossip_interval: 500,


### PR DESCRIPTION
Workaround a weird issue with github forks and ci integration.
Hopefully when tests pass I'll be able to merge this, and https://github.com/holochain/lib3h/pull/309 will merge automatically.

## PR summary

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
