### PR TITLE
added transport config and unified ghost engine new

### DIFF
--- a/crates/lib3h/src/engine/ghost_engine.rs
+++ b/crates/lib3h/src/engine/ghost_engine.rs
@@ -7,18 +7,15 @@ use crate::{
     dht::{dht_config::DhtConfig, dht_protocol::*},
     engine::{
         engine_actor::*, p2p_protocol::*, CanAdvertise, ChainId, EngineConfig, GhostEngine,
-        TransportKeys, NETWORK_GATEWAY_ID,
+        TransportConfig, TransportKeys, NETWORK_GATEWAY_ID,
     },
     error::{ErrorKind, Lib3hError, Lib3hResult},
     gateway::{protocol::*, P2pGateway},
     keystore::KeystoreStub,
     track::Tracker,
     transport::{
-        self,
-        memory_mock::ghost_transport_memory::*,
-        protocol::*,
-        websocket::{actor::GhostTransportWebsocket, tls::TlsConfig},
-        TransportEncoding, TransportMultiplex,
+        self, memory_mock::ghost_transport_memory::*, protocol::*,
+        websocket::actor::GhostTransportWebsocket, TransportEncoding, TransportMultiplex,
     },
 };
 use lib3h_crypto_api::CryptoSystem;
@@ -84,40 +81,37 @@ impl<'engine> CanAdvertise for GhostEngine<'engine> {
     }
 }
 impl<'engine> GhostEngine<'engine> {
-    /// Constructor with WebsocketTransport
+    /// Constructor with for GhostEngine
     pub fn new(
-        crypto: Box<dyn CryptoSystem>,
-        config: EngineConfig,
-        name: &str,
-        dht_factory: DhtFactory,
-    ) -> Lib3hResult<Self> {
-        Self::with_transport(
-            Lib3hSpan::fixme(),
-            crypto,
-            config,
-            name,
-            dht_factory,
-            Box::new(GhostTransportWebsocket::new(TlsConfig::Unencrypted)),
-        )
-    }
-
-    /// Constructor with TransportMemory
-    pub fn new_mock(
         span: Lib3hSpan,
         crypto: Box<dyn CryptoSystem>,
         config: EngineConfig,
         name: &str,
         dht_factory: DhtFactory,
     ) -> Lib3hResult<Self> {
-        // Create TransportMemory as the network transport
-        Self::with_transport(
-            span,
-            crypto,
-            config,
-            name,
-            dht_factory,
-            Box::new(GhostTransportMemory::new()),
-        )
+        // This will change when multi-transport is impelmented
+        assert_eq!(config.transport_configs.len(), 1);
+        match &config.transport_configs[0] {
+            TransportConfig::Websocket(tls_config) => {
+                let tls = tls_config.clone();
+                Self::with_transport(
+                    span,
+                    crypto,
+                    config,
+                    name,
+                    dht_factory,
+                    Box::new(GhostTransportWebsocket::new(tls)),
+                )
+            }
+            TransportConfig::Memory => Self::with_transport(
+                span,
+                crypto,
+                config,
+                name,
+                dht_factory,
+                Box::new(GhostTransportMemory::new()),
+            ),
+        }
     }
 
     pub fn with_transport(
@@ -833,7 +827,7 @@ mod tests {
     fn make_test_engine() -> GhostEngine<'static> {
         let crypto = Box::new(SodiumCryptoSystem::new());
         let config = EngineConfig {
-            socket_type: "mem".into(),
+            transport_configs: vec![TransportConfig::Memory],
             bootstrap_nodes: vec![],
             work_dir: PathBuf::new(),
             log_level: 'd',
@@ -845,8 +839,7 @@ mod tests {
         let dht_factory = MirrorDht::new_with_config;
 
         let engine =
-            GhostEngine::new_mock(test_span(""), crypto, config, "test_engine", dht_factory)
-                .unwrap();
+            GhostEngine::new(test_span(""), crypto, config, "test_engine", dht_factory).unwrap();
         engine
     }
 

--- a/crates/lib3h/src/engine/mod.rs
+++ b/crates/lib3h/src/engine/mod.rs
@@ -10,7 +10,7 @@ use crate::{
     error::*,
     gateway::{protocol::*, P2pGateway},
     track::Tracker,
-    transport::TransportMultiplex,
+    transport::{websocket::tls::TlsConfig, TransportMultiplex},
 };
 use detach::Detach;
 use lib3h_crypto_api::{Buffer, CryptoSystem};
@@ -67,11 +67,17 @@ enum RealEngineTrackerData {
     HoldEntryRequested,
 }
 
-/// Struct holding all config settings for the RealEngine
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+/// Transport specific configuration
+pub enum TransportConfig {
+    Websocket(TlsConfig),
+    Memory,
+}
+
+/// Struct holding all config settings for the Engine
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct EngineConfig {
-    //pub tls_config: TlsConfig,
-    pub socket_type: String,
+    pub transport_configs: Vec<TransportConfig>,
     #[serde(deserialize_with = "vec_url_de", serialize_with = "vec_url_se")]
     pub bootstrap_nodes: Vec<Url>,
     pub work_dir: PathBuf,

--- a/crates/lib3h/tests/engine_test.rs
+++ b/crates/lib3h/tests/engine_test.rs
@@ -14,7 +14,8 @@ use predicates::prelude::*;
 
 use lib3h::{
     dht::mirror_dht::MirrorDht,
-    engine::{ghost_engine_wrapper::WrappedGhostLib3h, EngineConfig, GhostEngine},
+    engine::{ghost_engine_wrapper::WrappedGhostLib3h, EngineConfig, GhostEngine, TransportConfig},
+    transport::websocket::tls::TlsConfig,
 };
 use lib3h_protocol::{
     data_types::*, protocol_client::Lib3hClientProtocol, protocol_server::Lib3hServerProtocol,
@@ -69,8 +70,7 @@ fn basic_setup_mock_bootstrap(name: &str, bs: Option<Vec<Url>>) -> WrappedGhostL
         None => vec![],
     };
     let config = EngineConfig {
-        // tls_config: TlsConfig::Unencrypted,
-        socket_type: "mem".into(),
+        transport_configs: vec![TransportConfig::Memory],
         bootstrap_nodes,
         work_dir: PathBuf::new(),
         log_level: 'd',
@@ -79,7 +79,7 @@ fn basic_setup_mock_bootstrap(name: &str, bs: Option<Vec<Url>>) -> WrappedGhostL
         dht_timeout_threshold: 1000,
         dht_custom_config: vec![],
     };
-    let engine = GhostEngine::new_mock(
+    let engine = GhostEngine::new(
         Lib3hSpan::fixme(),
         Box::new(SodiumCryptoSystem::new()),
         config,
@@ -102,7 +102,7 @@ fn basic_setup_mock(name: &str) -> WrappedGhostLib3h {
 
 fn basic_setup_wss(name: &str) -> WrappedGhostLib3h {
     let config = EngineConfig {
-        socket_type: "ws".into(),
+        transport_configs: vec![TransportConfig::Websocket(TlsConfig::Unencrypted)],
         bootstrap_nodes: vec![],
         work_dir: PathBuf::new(),
         log_level: 'd',
@@ -112,6 +112,7 @@ fn basic_setup_wss(name: &str) -> WrappedGhostLib3h {
         dht_custom_config: vec![],
     };
     let engine = GhostEngine::new(
+        Lib3hSpan::fixme(),
         Box::new(SodiumCryptoSystem::new()),
         config,
         "test_engine_wss".into(),

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -20,7 +20,7 @@ mod test_suites;
 
 use lib3h::{
     dht::mirror_dht::MirrorDht,
-    engine::{ghost_engine_wrapper::WrappedGhostLib3h, EngineConfig, GhostEngine},
+    engine::{ghost_engine_wrapper::WrappedGhostLib3h, EngineConfig, GhostEngine, TransportConfig},
     error::Lib3hResult,
     transport::websocket::tls::TlsConfig,
 };
@@ -60,7 +60,7 @@ fn enable_logging_for_test(enable: bool) {
 //--------------------------------------------------------------------------------------------------
 
 fn construct_mock_engine(config: &EngineConfig, name: &str) -> Lib3hResult<WrappedGhostLib3h> {
-    let engine: GhostEngine = GhostEngine::new_mock(
+    let engine: GhostEngine = GhostEngine::new(
         Lib3hSpan::fixme(),
         Box::new(lib3h_sodium::SodiumCryptoSystem::new()),
         config.clone(),
@@ -79,6 +79,7 @@ fn construct_mock_engine(config: &EngineConfig, name: &str) -> Lib3hResult<Wrapp
 
 fn construct_wss_engine(config: &EngineConfig, name: &str) -> Lib3hResult<WrappedGhostLib3h> {
     let engine: GhostEngine = GhostEngine::new(
+        Lib3hSpan::fixme(),
         Box::new(lib3h_sodium::SodiumCryptoSystem::new()),
         config.clone(),
         name.into(),
@@ -103,8 +104,7 @@ pub type NodeFactory = fn(name: &str, agent_id_arg: Address) -> NodeMock;
 fn setup_memory_node(name: &str, agent_id_arg: Address, fn_name: &str) -> NodeMock {
     let fn_name = fn_name.replace("::", "__");
     let config = EngineConfig {
-        //tls_config: TlsConfig::Unencrypted,
-        socket_type: "mem".into(),
+        transport_configs: vec![TransportConfig::Memory],
         bootstrap_nodes: vec![],
         work_dir: PathBuf::new(),
         log_level: 'd',
@@ -132,7 +132,7 @@ fn setup_wss_node(
         .expect("invalid web socket url");
 
     let config = EngineConfig {
-        socket_type: protocol.into(),
+        transport_configs: vec![TransportConfig::Websocket(tls_config)],
         bootstrap_nodes: vec![],
         work_dir: PathBuf::new(),
         log_level: 'd',

--- a/crates/tools/sim_chat/src/main.rs
+++ b/crates/tools/sim_chat/src/main.rs
@@ -10,7 +10,7 @@ use url::Url;
 
 use lib3h::{
     dht::mirror_dht::MirrorDht,
-    engine::{EngineConfig, GhostEngine},
+    engine::{EngineConfig, GhostEngine, TransportConfig},
 };
 use lib3h_sodium::SodiumCryptoSystem;
 use lib3h_tracing::Lib3hSpan;
@@ -18,7 +18,7 @@ use lib3h_tracing::Lib3hSpan;
 fn engine_builder() -> GhostEngine<'static> {
     let crypto = Box::new(SodiumCryptoSystem::new());
     let config = EngineConfig {
-        socket_type: "mem".into(),
+        transport_configs: vec![TransportConfig::Memory],
         bootstrap_nodes: vec![],
         work_dir: PathBuf::new(),
         log_level: 'd',
@@ -28,7 +28,7 @@ fn engine_builder() -> GhostEngine<'static> {
         dht_custom_config: vec![],
     };
     let dht_factory = MirrorDht::new_with_config;
-    GhostEngine::new_mock(
+    GhostEngine::new(
         Lib3hSpan::fixme(), // TODO: actually hook up real tracer here
         crypto,
         config,


### PR DESCRIPTION
## PR summary

Creates a TransportConfig enum to be part of the the Engine config and puts the Tls config in it.
It's a vector in preparation for when we have multi-transport, right now you simply have to allways have one entry.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
