### PR TITLE
Fixes for getting mutex access to MemoryVerse

### DIFF
--- a/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
@@ -63,7 +63,7 @@ impl Discovery for GhostTransportMemory {
         let uri = self
             .maybe_my_address
             .clone()
-            .ok_or_else(|| DiscoveryError::new_other("must bind before discovering"))?;
+            .ok_or_else(|| DiscoveryError::new_other("must bind before advertising"))?;
         self.network.lock().unwrap()
             .advertise(uri, self.machine_id.clone());
         Ok(())
@@ -408,6 +408,7 @@ mod tests {
 
         // check that machine_ids were advertised
         let found = transport1.discover().unwrap();
+        println!("FOUND: {:?}", found);
         assert!(
             &format!("{:?}", found[0]) == "\"mem://addr_1/\""
                 || &format!("{:?}", found[0]) == "\"mem://addr_2/\""

--- a/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
@@ -409,7 +409,6 @@ mod tests {
 
         // check that machine_ids were advertised
         let found = transport1.discover().unwrap();
-        println!("FOUND: {:?}", found);
         assert!(
             &format!("{:?}", found[0]) == "\"mem://addr_1/\""
                 || &format!("{:?}", found[0]) == "\"mem://addr_2/\""

--- a/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
@@ -11,7 +11,9 @@ use lib3h_discovery::{
 };
 use lib3h_ghost_actor::prelude::*;
 use lib3h_protocol::Address;
-use std::{collections::HashSet, time::Instant};
+use std::{collections::HashSet, time::Instant,
+          sync::{Arc, Mutex,},
+};
 use url::Url;
 
 pub type UserData = GhostTransportMemory;
@@ -45,7 +47,7 @@ pub type GhostTransportMemoryEndpointContextParent = GhostContextEndpoint<
 #[allow(dead_code)]
 pub struct GhostTransportMemory {
     machine_id: Address,
-    network: String,
+    network: Arc<Mutex<MemoryNet>>,
     endpoint_parent: Option<GhostTransportMemoryEndpoint>,
     endpoint_self: Detach<GhostTransportMemoryEndpointContext>,
     /// My peer uri on the network layer (not None after a bind)
@@ -62,18 +64,12 @@ impl Discovery for GhostTransportMemory {
             .maybe_my_address
             .clone()
             .ok_or_else(|| DiscoveryError::new_other("must bind before discovering"))?;
-        let mut verse = memory_server::get_memory_verse();
-        verse
-            .get_net(&self.network)
-            .ok_or_else(|| DiscoveryError::new_other("net not found"))?
+        self.network.lock().unwrap()
             .advertise(uri, self.machine_id.clone());
         Ok(())
     }
     fn discover(&mut self) -> DiscoveryResult<Vec<Url>> {
-        let mut verse = memory_server::get_memory_verse();
-        let machines = verse
-            .get_net(&self.network)
-            .ok_or_else(|| DiscoveryError::new_other("net not found"))?
+        let machines = self.network.lock().unwrap()
             .discover();
         Ok(machines.into_iter().map(|(uri, _)| uri).collect())
     }
@@ -87,14 +83,17 @@ impl Discovery for GhostTransportMemory {
 const DEFAULT_DISCOVERY_INTERVAL_MS: u64 = 30000;
 
 impl GhostTransportMemory {
-    #[allow(dead_code)]
     pub fn new(machine_id: Address, network_name: &str) -> Self {
         let (endpoint_parent, endpoint_self) = create_ghost_channel();
         let interval = DEFAULT_DISCOVERY_INTERVAL_MS;
         let start = Instant::now().checked_sub(std::time::Duration::from_millis(interval + 1));
+        let network = {
+            let mut verse = memory_server::get_memory_verse();
+            verse.get_network(network_name)
+        };
         Self {
             machine_id,
-            network: network_name.to_string(),
+            network,
             endpoint_parent: Some(endpoint_parent),
             endpoint_self: Detach::new(
                 endpoint_self
@@ -117,7 +116,6 @@ impl GhostTransportMemory {
                 if let Ok(machines) = self.discover() {
                     if machines.len() > 0 {
                         let my_addr = self.maybe_my_address.as_ref().expect("should have bound");
-                        let mut verse = memory_server::get_memory_verse();
                         for found_uri in machines {
                             if found_uri == *my_addr {
                                 continue;
@@ -125,8 +123,7 @@ impl GhostTransportMemory {
                             // if not already connected, request a connections
                             if self.connections.get(&found_uri).is_none() {
                                 // Get other node's server
-                                let maybe_server = verse.get_server(&self.network, &found_uri);
-                                match maybe_server {
+                                match self.network.lock().unwrap().get_server(&found_uri) {
                                     Some(remote_server) => {
                                         let _result = remote_server.request_connect(&my_addr);
                                         self.connections.insert(found_uri.clone());
@@ -186,8 +183,7 @@ impl
 
             // get our own server
             let (success, event_list) = {
-                let mut verse = memory_server::get_memory_verse();
-                match verse.get_server(&self.network, &my_addr) {
+                match self.network.lock().unwrap().get_server(&my_addr) {
                     None => return Err(format!("No Memory server at this uri: {}", my_addr).into()),
                     Some(server) => server.process()?,
                 }
@@ -222,8 +218,7 @@ impl
                     // if not already connected, request a connection
                     if self.connections.get(&remote_addr).is_none() {
                         // Get other node's server
-                        let mut verse = memory_server::get_memory_verse();
-                        match verse.get_server(&self.network, &remote_addr) {
+                        match self.network.lock().unwrap().get_server(&my_addr) {
                             Some(server) => {
                                 server.request_connect(&my_addr)?;
                                 self.connections.insert(remote_addr.clone());
@@ -267,8 +262,7 @@ impl
                 RequestToChild::Bind { spec: _url } => {
                     // get a new bound url from the memory server (we ignore the spec here)
                     let bound_url = {
-                        let mut verse = memory_server::get_memory_verse();
-                        verse.bind(&self.network)
+                        self.network.lock().unwrap().bind()
                     };
                     self.maybe_my_address = Some(bound_url.clone());
                     self.advertise()
@@ -291,8 +285,7 @@ impl
                         }
                         Some(my_addr) => {
                             // get destinations server
-                            let mut verse = memory_server::get_memory_verse();
-                            match verse.get_server(&self.network, &uri) {
+                            match self.network.lock().unwrap().get_server(&uri) {
                                 None => {
                                     msg.respond(Err(TransportError::new(format!(
                                         "No Memory server at this uri: {}",

--- a/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
@@ -11,8 +11,10 @@ use lib3h_discovery::{
 };
 use lib3h_ghost_actor::prelude::*;
 use lib3h_protocol::Address;
-use std::{collections::HashSet, time::Instant,
-          sync::{Arc, Mutex,},
+use std::{
+    collections::HashSet,
+    sync::{Arc, Mutex},
+    time::Instant,
 };
 use url::Url;
 
@@ -64,13 +66,14 @@ impl Discovery for GhostTransportMemory {
             .maybe_my_address
             .clone()
             .ok_or_else(|| DiscoveryError::new_other("must bind before advertising"))?;
-        self.network.lock().unwrap()
+        self.network
+            .lock()
+            .unwrap()
             .advertise(uri, self.machine_id.clone());
         Ok(())
     }
     fn discover(&mut self) -> DiscoveryResult<Vec<Url>> {
-        let machines = self.network.lock().unwrap()
-            .discover();
+        let machines = self.network.lock().unwrap().discover();
         Ok(machines.into_iter().map(|(uri, _)| uri).collect())
     }
     fn release(&mut self) -> DiscoveryResult<()> {
@@ -261,9 +264,7 @@ impl
             match msg.take_message().expect("exists") {
                 RequestToChild::Bind { spec: _url } => {
                     // get a new bound url from the memory server (we ignore the spec here)
-                    let bound_url = {
-                        self.network.lock().unwrap().bind()
-                    };
+                    let bound_url = { self.network.lock().unwrap().bind() };
                     self.maybe_my_address = Some(bound_url.clone());
                     self.advertise()
                         .map_err(|e| GhostError::from(e.to_string()))?;

--- a/crates/lib3h/src/transport/memory_mock/memory_server.rs
+++ b/crates/lib3h/src/transport/memory_mock/memory_server.rs
@@ -57,13 +57,12 @@ impl MemoryNet {
     }
     pub fn bind(&mut self) -> Url {
         let binding = self.new_url();
-        trace!("In Memory bind for {}, url:{}",self.name,binding);
+        trace!("In Memory bind for {}, url:{}", self.name, binding);
         self.server_map
             .entry(binding.clone())
             .or_insert_with(|| MemoryServer::new(&binding));
         binding
     }
-
 }
 
 /// Holds a universe of memory networks so we can run tests in separate universes
@@ -77,10 +76,10 @@ impl MemoryVerse {
         }
     }
     pub fn get_network(&mut self, network_name: &str) -> Arc<Mutex<MemoryNet>> {
-        self
-            .server_maps
+        self.server_maps
             .entry(network_name.to_string())
-            .or_insert_with(|| Arc::new(Mutex::new(MemoryNet::new(network_name)))).clone()
+            .or_insert_with(|| Arc::new(Mutex::new(MemoryNet::new(network_name))))
+            .clone()
     }
 }
 

--- a/crates/lib3h/src/transport/memory_mock/memory_server.rs
+++ b/crates/lib3h/src/transport/memory_mock/memory_server.rs
@@ -2,7 +2,7 @@ use crate::transport::error::{TransportError, TransportResult};
 use lib3h_protocol::{data_types::Opaque, Address, DidWork};
 use std::{
     collections::{HashMap, HashSet, VecDeque},
-    sync::{Mutex, MutexGuard},
+    sync::{Arc, Mutex, MutexGuard},
 };
 use url::Url;
 
@@ -50,11 +50,22 @@ impl MemoryNet {
         self.url_count += 1;
         Url::parse(&format!("mem://addr_{}", self.url_count).as_str()).unwrap()
     }
+    pub fn get_server(&mut self, url: &Url) -> Option<&mut MemoryServer> {
+        self.server_map.get_mut(url)
+    }
+    pub fn bind(&mut self) -> Url {
+        let binding = self.new_url();
+        self.server_map
+            .entry(binding.clone())
+            .or_insert_with(|| MemoryServer::new(&binding));
+        binding
+    }
+
 }
 
 /// Holds a universe of memory networks so we can run tests in separate universes
 pub struct MemoryVerse {
-    server_maps: HashMap<String, MemoryNet>,
+    server_maps: HashMap<String, Arc<Mutex<MemoryNet>>>,
 }
 impl MemoryVerse {
     pub fn new() -> Self {
@@ -62,24 +73,13 @@ impl MemoryVerse {
             server_maps: HashMap::new(),
         }
     }
-    pub fn get_net(&mut self, network: &str) -> Option<&mut MemoryNet> {
-        self.server_maps.get_mut(network)
-    }
-
-    pub fn get_server(&mut self, network: &str, url: &Url) -> Option<&mut MemoryServer> {
-        self.server_maps.get_mut(network)?.server_map.get_mut(url)
-    }
-
-    pub fn bind(&mut self, network: &str) -> Url {
-        let net = self
+    pub fn get_network(&mut self, network: &str) -> Arc<Mutex<MemoryNet>> {
+        let net = Arc::new(Mutex::new(MemoryNet::new()));
+        self
             .server_maps
             .entry(network.to_string())
-            .or_insert_with(|| MemoryNet::new());
-        let binding = net.new_url();
-        net.server_map
-            .entry(binding.clone())
-            .or_insert_with(|| MemoryServer::new(&binding));
-        binding
+            .or_insert_with(|| net.clone());
+        net
     }
 }
 
@@ -89,7 +89,7 @@ lazy_static! {
 }
 
 pub fn get_memory_verse<'a>() -> MutexGuard<'a, MemoryVerse> {
-    for _ in 0..100 {
+    for _ in 0..1 {
         match MEMORY_VERSE.try_lock() {
             Ok(l) => return l,
             _ => std::thread::sleep(std::time::Duration::from_millis(1)),


### PR DESCRIPTION
## PR summary

moves the network an ArcMutex which each memory transport can hold, so possible collision time should only be during transport construction.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
