### PR TITLE
Ghost actor enum tagging

### DIFF
--- a/crates/lib3h/src/engine/mod.rs
+++ b/crates/lib3h/src/engine/mod.rs
@@ -71,8 +71,10 @@ enum RealEngineTrackerData {
     HoldEntryRequested,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 /// Transport specific configuration
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "lowercase")]
+#[serde(tag = "type", content = "data")]
 pub enum TransportConfig {
     Websocket(TlsConfig),
     Memory(String),

--- a/crates/lib3h/src/engine/mod.rs
+++ b/crates/lib3h/src/engine/mod.rs
@@ -72,6 +72,8 @@ enum RealEngineTrackerData {
 }
 
 /// Transport specific configuration
+/// NB: must be externally tagged because that is the only way that
+/// tuple struct variants can be serialized to TOML
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "lowercase")]
 #[serde(tag = "type", content = "data")]


### PR DESCRIPTION
## PR summary

This is a blocker for core integration. Without external tagging of this enum it can't be serialized to TOML (needed for saving conductor config)

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
