### PR TITLE
Fix wait connect

### DIFF
--- a/crates/lib3h/tests/utils/processor_harness.rs
+++ b/crates/lib3h/tests/utils/processor_harness.rs
@@ -402,8 +402,8 @@ macro_rules! wait_connect {
         let _connect_data = $connect_data;
         let re = regex::Regex::new("ConnectedData").expect("valid regex");
         let assertion = Box::new(predicates::prelude::predicate::function(move |x| {
-           let to_match = format!("{:?}", x);
-           re.is_match(&to_match)
+            let to_match = format!("{:?}", x);
+            re.is_match(&to_match)
         }));
 
         let predicate: Box<dyn $crate::utils::processor_harness::Processor> = Box::new(

--- a/crates/lib3h/tests/utils/processor_harness.rs
+++ b/crates/lib3h/tests/utils/processor_harness.rs
@@ -400,15 +400,16 @@ macro_rules! wait_connect {
         $other: ident
     ) => {{
         let _connect_data = $connect_data;
-        let connected_data =
-            Lib3hServerProtocol::Connected(lib3h_protocol::data_types::ConnectedData {
-                uri: $other.advertise(),
-                // TODO should be able to set non a blank request id
-                request_id: "".into(), //$connect_data.clone().request_id,
-            });
+        let re = regex::Regex::new("ConnectedData").expect("valid regex");
+        let assertion = Box::new(predicates::prelude::predicate::function(move |x| {
+           let to_match = format!("{:?}", x);
+           re.is_match(&to_match)
+        }));
+
         let predicate: Box<dyn $crate::utils::processor_harness::Processor> = Box::new(
-            $crate::utils::processor_harness::Lib3hServerProtocolEquals(connected_data),
+            $crate::utils::processor_harness::Lib3hServerProtocolAssert(assertion),
         );
+
         let result = assert_one_processed!($me, $other, predicate);
         result
     }};


### PR DESCRIPTION
## PR summary

This PR simplifies the processor harness `wait_connect!` to just ensure a `ConnectedData` message is received.


## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
