### PR TITLE
Implement drop for web socket transport

### DIFF
--- a/crates/discovery/Cargo.toml
+++ b/crates/discovery/Cargo.toml
@@ -12,4 +12,5 @@ documentation = "https://docs.rs/lib3h_discovery"
 repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
-url = "=1.7.2"
+url = { version = "=2.1.0", features = ["serde"] }
+

--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -25,9 +25,9 @@ lib3h_zombie_actor = { version = "=0.0.10", path = "../zombie_actor" }
 lib3h_discovery = { version = "=0.0.10", path = "../discovery" }
 lib3h_sodium = { version = "=0.0.10", path = "../sodium" }
 nanoid = "=0.2.0"
-tungstenite = "=0.6.1"
-url = "=1.7.2"
-url_serde = "=0.2.0"
+tungstenite = "=0.9.1"
+url = { version = "=2.1.0", features = ["serde"] }
+
 native-tls = "=0.2.2"
 rmp-serde = "=0.13.7"
 serde = "=1.0.89"

--- a/crates/lib3h/src/dht/dht_protocol.rs
+++ b/crates/lib3h/src/dht/dht_protocol.rs
@@ -141,7 +141,6 @@ pub struct GossipToData {
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]
 pub struct PeerData {
     pub peer_address: PeerAddress,
-    #[serde(with = "url_serde")]
     pub peer_uri: Url,
     pub timestamp: u64,
 }

--- a/crates/lib3h/src/engine/mod.rs
+++ b/crates/lib3h/src/engine/mod.rs
@@ -16,7 +16,6 @@ use detach::Detach;
 use lib3h_crypto_api::{Buffer, CryptoSystem};
 use lib3h_ghost_actor::prelude::*;
 use lib3h_protocol::{protocol::*, Address};
-use serde::{ser::SerializeSeq, Deserialize, Deserializer, Serializer};
 use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,
@@ -30,31 +29,6 @@ pub type ChainId = (Address, Address);
 pub struct GatewayId {
     pub nickname: String,
     pub id: Address,
-}
-
-fn vec_url_de<'de, D>(deserializer: D) -> Result<Vec<Url>, D::Error>
-where
-    D: Deserializer<'de>,
-{
-    #[derive(Deserialize)]
-    struct Wrapper(#[serde(with = "url_serde")] Url);
-
-    let v = Vec::deserialize(deserializer)?;
-    Ok(v.into_iter().map(|Wrapper(a)| a).collect())
-}
-
-fn vec_url_se<S>(v: &[Url], serializer: S) -> Result<S::Ok, S::Error>
-where
-    S: Serializer,
-{
-    #[derive(Serialize)]
-    struct Wrapper(#[serde(with = "url_serde")] Url);
-
-    let mut seq = serializer.serialize_seq(Some(v.len()))?;
-    for u in v {
-        seq.serialize_element(&Wrapper(u.clone()))?;
-    }
-    seq.end()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -87,11 +61,9 @@ pub enum TransportConfig {
 pub struct EngineConfig {
     pub network_id: GatewayId,
     pub transport_configs: Vec<TransportConfig>,
-    #[serde(deserialize_with = "vec_url_de", serialize_with = "vec_url_se")]
     pub bootstrap_nodes: Vec<Url>,
     pub work_dir: PathBuf,
     pub log_level: char,
-    #[serde(with = "url_serde")]
     pub bind_url: Url,
     pub dht_gossip_interval: u64,
     pub dht_timeout_threshold: u64,

--- a/crates/lib3h/src/lib.rs
+++ b/crates/lib3h/src/lib.rs
@@ -8,7 +8,6 @@ extern crate lib3h_zombie_actor as lib3h_ghost_actor;
 extern crate nanoid;
 extern crate native_tls;
 extern crate tungstenite;
-extern crate url_serde;
 #[macro_use]
 extern crate lazy_static;
 extern crate serde;

--- a/crates/lib3h/src/transport/websocket/actor.rs
+++ b/crates/lib3h/src/transport/websocket/actor.rs
@@ -43,14 +43,12 @@ impl Discovery for GhostTransportWebsocket {
 }
 
 impl Drop for GhostTransportWebsocket {
-
     fn drop(&mut self) {
-        self.streams.close_all().
-            unwrap_or_else(|e| error!("Error closing streams: {:?}", e));
+        self.streams
+            .close_all()
+            .unwrap_or_else(|e| error!("Error closing streams: {:?}", e));
     }
-
 }
-
 
 impl GhostTransportWebsocket {
     pub fn new(machine_id: Address, tls_config: TlsConfig) -> GhostTransportWebsocket {
@@ -330,7 +328,7 @@ mod tests {
     use super::*;
     use crate::{tests::enable_logging_for_test, transport::websocket::tls::TlsConfig};
     use lib3h_ghost_actor::wait_for_message;
-    use std::{net::TcpListener};
+    use std::net::TcpListener;
     use url::Url;
 
     fn port_is_available(port: u16) -> bool {
@@ -544,5 +542,10 @@ mod tests {
 
             println!("Try {} successful!", index);
         }
+    }
+
+    #[test]
+    fn should_invoke_drop() {
+        // TODO
     }
 }

--- a/crates/lib3h/src/transport/websocket/actor.rs
+++ b/crates/lib3h/src/transport/websocket/actor.rs
@@ -42,6 +42,16 @@ impl Discovery for GhostTransportWebsocket {
     }
 }
 
+impl Drop for GhostTransportWebsocket {
+
+    fn drop(&mut self) {
+        self.streams.close_all().
+            unwrap_or_else(|e| error!("Error closing streams: {:?}", e));
+    }
+
+}
+
+
 impl GhostTransportWebsocket {
     pub fn new(machine_id: Address, tls_config: TlsConfig) -> GhostTransportWebsocket {
         let (endpoint_parent, endpoint_self) = create_ghost_channel();
@@ -320,7 +330,7 @@ mod tests {
     use super::*;
     use crate::{tests::enable_logging_for_test, transport::websocket::tls::TlsConfig};
     use lib3h_ghost_actor::wait_for_message;
-    use std::{net::TcpListener, thread, time};
+    use std::{net::TcpListener};
     use url::Url;
 
     fn port_is_available(port: u16) -> bool {
@@ -533,7 +543,6 @@ mod tests {
             }
 
             println!("Try {} successful!", index);
-            thread::sleep(time::Duration::from_millis(1));
         }
     }
 }

--- a/crates/lib3h/src/transport/websocket/streams.rs
+++ b/crates/lib3h/src/transport/websocket/streams.rs
@@ -389,6 +389,7 @@ impl<T: Read + Write + std::fmt::Debug> StreamManager<T> {
                         Err(e.into())
                     }
                     Err(tungstenite::error::Error::ConnectionClosed) => {
+                        error!("Connection unexpectedly closed");
                         // close event will be published
                         Ok(())
                     }
@@ -422,6 +423,7 @@ impl<T: Read + Write + std::fmt::Debug> StreamManager<T> {
                     }
                     Err(tungstenite::error::Error::ConnectionClosed) => {
                         // close event will be published
+                        error!("Connection unexpectedly closed");
                         Ok(())
                     }
                     Err(e) => Err(e.into()),

--- a/crates/lib3h/src/transport/websocket/streams.rs
+++ b/crates/lib3h/src/transport/websocket/streams.rs
@@ -124,7 +124,7 @@ impl<T: Read + Write + std::fmt::Debug> StreamManager<T> {
 
     /// close all currently tracked connections
     #[allow(dead_code)]
-    fn close_all(&mut self) -> TransportResult<()> {
+    pub fn close_all(&mut self) -> TransportResult<()> {
         let mut errors: Vec<TransportError> = Vec::new();
 
         while !self.stream_sockets.is_empty() {

--- a/crates/lib3h/src/transport/websocket/streams.rs
+++ b/crates/lib3h/src/transport/websocket/streams.rs
@@ -388,7 +388,7 @@ impl<T: Read + Write + std::fmt::Debug> StreamManager<T> {
                         }
                         Err(e.into())
                     }
-                    Err(tungstenite::error::Error::ConnectionClosed(_)) => {
+                    Err(tungstenite::error::Error::ConnectionClosed) => {
                         // close event will be published
                         Ok(())
                     }
@@ -420,7 +420,7 @@ impl<T: Read + Write + std::fmt::Debug> StreamManager<T> {
                         }
                         Err(e.into())
                     }
-                    Err(tungstenite::error::Error::ConnectionClosed(_)) => {
+                    Err(tungstenite::error::Error::ConnectionClosed) => {
                         // close event will be published
                         Ok(())
                     }

--- a/crates/lib3h/src/transport/websocket/wss_info.rs
+++ b/crates/lib3h/src/transport/websocket/wss_info.rs
@@ -12,6 +12,7 @@ pub struct WssInfo<T: std::io::Read + std::io::Write + std::fmt::Debug> {
 impl<T: std::io::Read + std::io::Write + std::fmt::Debug> WssInfo<T> {
     pub fn close(&mut self) -> TransportResult<()> {
         if let WebsocketStreamState::ReadyWss(socket) = &mut self.stateful_socket {
+            socket.write_message(tungstenite::Message::Close(None))?;
             socket.close(None)?;
             socket.write_pending()?;
         }

--- a/crates/lib3h_protocol/Cargo.toml
+++ b/crates/lib3h_protocol/Cargo.toml
@@ -19,5 +19,4 @@ holochain_persistence_api = "=0.0.8"
 rmp-serde = "=0.13.7"
 serde = "=1.0.89"
 serde_derive = "=1.0.89"
-url = "=1.7.2"
-url_serde = "=0.2.0"
+url = { version = "=2.1.0", features = ["serde"] }

--- a/crates/lib3h_protocol/src/data_types.rs
+++ b/crates/lib3h_protocol/src/data_types.rs
@@ -176,7 +176,6 @@ pub struct BootstrapData {
     /// connection uri, such as
     ///   `wss://1.2.3.4:55888?a=HcMyada`
     ///   `transportid:HcMyada?a=HcSagent`
-    #[serde(with = "url_serde")]
     pub bootstrap_uri: Url,
 }
 
@@ -189,7 +188,6 @@ pub struct ConnectData {
     /// Ex:
     ///  - `wss://192.168.0.102:58081/`
     ///  - `holorelay://x.x.x.x`
-    #[serde(with = "url_serde")]
     pub peer_uri: Url,
     /// Specify to which network to connect to.
     /// Empty string for 'any'
@@ -201,7 +199,6 @@ pub struct ConnectedData {
     /// Identifier of the `Connect` request we are responding to
     pub request_id: String,
     /// The first uri we are connected to
-    #[serde(with = "url_serde")]
     pub uri: Url,
     // TODO #172 - Add network_id? Or let local client figure it out with the request_id?
     // TODO #178 - Add some info on network state

--- a/crates/mdns/Cargo.toml
+++ b/crates/mdns/Cargo.toml
@@ -19,7 +19,7 @@ regex = "1.1.2"
 log = "0.4.8"
 lib3h_discovery = { version = "=0.0.10", path = "../discovery" }
 zeroize = "0.10.0"
-url = "=1.7.2"
+url = "=2.1.0"
 
 [dev-dependencies]
 lib3h = { version = "=0.0.10", path = "../lib3h" }

--- a/crates/tools/dump_lib3h_protocol_as_json_for_n3h/Cargo.toml
+++ b/crates/tools/dump_lib3h_protocol_as_json_for_n3h/Cargo.toml
@@ -10,4 +10,5 @@ readme = "README.md"
 [dependencies]
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }
 lib3h_protocol = { version = "=0.0.10", path = "../../lib3h_protocol" }
-url = "=1.7.2"
+url = { version = "=2.1.0", features = ["serde"] }
+

--- a/crates/tools/sim_chat/Cargo.toml
+++ b/crates/tools/sim_chat/Cargo.toml
@@ -23,7 +23,8 @@ lib3h_crypto_api = { "path" = "../../crypto_api" }
 lib3h = { "path" = "../../lib3h" }
 lib3h_zombie_actor = { "path" = "../../zombie_actor" }
 detach = { "path" = "../../detach" }
-url = "=1.7.2"
+url = { version = "=2.1.0", features = ["serde"] }
+
 lazy_static = "=1.2.0"
 
 [lib]


### PR DESCRIPTION
## PR summary

This PR upgrades `tungstenite` and dependent crate `url` so we can gracefully send close commands to peers before dropping. The stream manager, before closing a socket, writes a close message to the other end. The web socket `Drop` trait is implemented and invokes `close_all` on the stream manager.

## Review checklist 
- [ ] The story has unit or integration tests _TODO!!!_
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
