### PR TITLE
Uncomment out code in test

### DIFF
--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -173,7 +173,6 @@ fn print_test_name(print_str: &str, test_fn: *mut std::os::raw::c_void) {
 
 // -- Memory Transport Tests --
 #[test]
-#[ignore]
 fn test_two_memory_nodes_basic_suite() {
     enable_logging_for_test(true);
     for (test_fn, can_setup) in TWO_NODES_BASIC_TEST_FNS.iter() {

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -173,6 +173,7 @@ fn print_test_name(print_str: &str, test_fn: *mut std::os::raw::c_void) {
 
 // -- Memory Transport Tests --
 #[test]
+#[ignore]
 fn test_two_memory_nodes_basic_suite() {
     enable_logging_for_test(true);
     for (test_fn, can_setup) in TWO_NODES_BASIC_TEST_FNS.iter() {

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -116,7 +116,7 @@ fn test_setup_only(_alex: &mut NodeMock, _billy: &mut NodeMock) {
 /// Test SendDirectMessage and response
 pub fn test_send_message(alex: &mut NodeMock, billy: &mut NodeMock) {
     // Send DM
-    //let req_id = alex.send_direct_message(&BILLY_AGENT_ID, "wah".as_bytes().to_vec());
+    let _req_id = alex.send_direct_message(&BILLY_AGENT_ID, "wah".as_bytes().to_vec());
 
     let expected = "HandleSendDirectMessage\\(DirectMessageData \\{ space_address: HashString\\(\"SPACE_A\"\\), request_id: \"client_to_lib3_response[\\w\\d_~]+\", to_agent_id: HashString\\(\"billy\"\\), from_agent_id: HashString\\(\"alex\"\\), content: \"wah\" \\}\\)";
 


### PR DESCRIPTION
## PR summary

This fixes an accidental uncommenting out of some send message code in a test.
## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
