### PR TITLE
Allow send to self for in-memory transport

### DIFF
--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -103,6 +103,9 @@ impl MirrorDht {
     }
 
     fn get_peer(&self, peer_name: &Lib3hUri) -> Option<PeerData> {
+        if peer_name == &self.this_peer.peer_name {
+            return Some(self.this_peer.clone());
+        }
         let res = self.peer_map.get(peer_name);
         if let Some(pd) = res {
             return Some(pd.clone());

--- a/crates/lib3h/src/dht/mod.rs
+++ b/crates/lib3h/src/dht/mod.rs
@@ -294,8 +294,14 @@ pub mod tests {
         enable_logging_for_test(true);
         let mut dht = new_dht_wrapper(true, &*PEER_A);
         let mut ud = DhtData::new();
-        // Should be empty
+        // Should get self
         let maybe_peer = get_peer(&mut dht, &*PEER_A);
+        assert_eq!(
+            "Lib3hUri(\"agentid:alex\")",
+            format!("{:?}", maybe_peer.unwrap().peer_name)
+        );
+        // Should be empty
+        let maybe_peer = get_peer(&mut dht, &*PEER_B);
         assert!(maybe_peer.is_none());
         let peer_list = get_peer_list(&mut dht);
         assert_eq!(peer_list.len(), 0);
@@ -405,7 +411,7 @@ pub mod tests {
         let mut dht = new_dht_wrapper(true, &*PEER_A);
         let mut ud = DhtData::new();
         // Should be empty
-        let this = get_peer(&mut dht, &*PEER_A);
+        let this = get_peer(&mut dht, &*PEER_B);
         assert!(this.is_none());
         let peer_list = get_peer_list(&mut dht);
         assert_eq!(peer_list.len(), 0);

--- a/crates/lib3h/src/engine/ghost_engine.rs
+++ b/crates/lib3h/src/engine/ghost_engine.rs
@@ -560,7 +560,7 @@ impl<'engine> GhostEngine<'engine> {
         &mut self,
         space_address: Address,
         from_agent_id: Address,
-        to_agent_id: Address,
+        _to_agent_id: Address,
         net_msg: P2pProtocol,
     ) -> Lib3hResult<(
         &mut GatewayParentWrapper<GhostEngine<'engine>, P2pGateway>,
@@ -572,11 +572,11 @@ impl<'engine> GhostEngine<'engine> {
         if let Err(error) = maybe_this_peer {
             return Err(error);
         };
-        let this_peer = maybe_this_peer.unwrap();
+        /*        let this_peer = maybe_this_peer.unwrap();
 
         if &this_peer.peer_name == &Lib3hUri::with_agent_id(&to_agent_id) {
             return Err(Lib3hError::new_other("messaging self not allowed"));
-        }
+        }*/
 
         // Serialize payload
         let mut payload = Vec::new();

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -10,6 +10,7 @@ lazy_static! {
         (test_setup_only, true),
         (test_send_message, true),
         (test_send_message_fail, true),
+        (test_send_message_self, true),
 // TODO will comment out as they are fixed
 /*
         (test_hold_entry, true),
@@ -151,17 +152,41 @@ pub fn test_send_message(alex: &mut NodeMock, billy: &mut NodeMock) {
 /// Test SendDirectMessage and response
 #[allow(dead_code)]
 fn test_send_message_fail(alex: &mut NodeMock, _billy: &mut NodeMock) {
-    // Send to self
-    let _req_id = alex.send_direct_message(&ALEX_AGENT_ID, "wah".as_bytes().to_vec());
-    let expected = "FailureResult\\(GenericResultData \\{ request_id: \"req_alex_3\", space_address: HashString\\(\"appA\"\\), to_agent_id: HashString\\(\"alex\"\\), result_info: ";
-    assert_msg_matches!(alex, expected);
-
     trace!("[test_send_message_fail] alex send to camille");
     // Send to unknown
     let _req_id = alex.send_direct_message(&CAMILLE_AGENT_ID, "wah".as_bytes().to_vec());
 
-    let expected = "FailureResult\\(GenericResultData \\{ request_id: \"req_alex_4\", space_address: HashString\\(\"appA\"\\), to_agent_id: HashString\\(\"camille\"\\), result_info: ";
+    let expected = "FailureResult\\(GenericResultData \\{ request_id: \"req_alex_3\", space_address: HashString\\(\"appA\"\\), to_agent_id: HashString\\(\"camille\"\\), result_info: ";
     assert_msg_matches!(alex, expected);
+}
+
+/// Test SendDirectMessage and response to self
+pub fn test_send_message_self(alex: &mut NodeMock, _billy: &mut NodeMock) {
+    // Send DM
+    let _req_id = alex.send_direct_message(&ALEX_AGENT_ID, "wah".as_bytes().to_vec());
+
+    let expected = "HandleSendDirectMessage\\(DirectMessageData \\{ space_address: HashString\\(\"appA\"\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"alex\"\\), from_agent_id: HashString\\(\"alex\"\\), content: \"wah\" \\}\\)";
+
+    let results = assert2_msg_matches!(alex, alex, expected);
+
+    let handle_send_direct_msg = results.first().unwrap();
+
+    let event = handle_send_direct_msg.events.first().unwrap();
+
+    let msg = unwrap_to!(event => Lib3hServerProtocol::HandleSendDirectMessage);
+
+    // Send response
+    let response_content = format!("echo: {}", "wah").as_bytes().to_vec();
+    trace!(
+        "alex send response with msg.request_id={:?}",
+        msg.request_id
+    );
+    alex.send_response(&msg.request_id, &alex.agent_id(), response_content.clone());
+
+    // TODO Set this to correct value once test passes
+    let expected = "SendDirectMessageResult\\(DirectMessageData \\{ space_address: HashString\\(\"appA\"\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"alex\"\\), from_agent_id: HashString\\(\"alex\"\\), content: \"echo: wah\" \\}\\)";
+
+    assert2_msg_matches!(alex, alex, expected);
 }
 
 /// Test publish, Store, Query

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -186,7 +186,7 @@ pub fn test_send_message_self(alex: &mut NodeMock, _billy: &mut NodeMock) {
     // TODO Set this to correct value once test passes
     let expected = "SendDirectMessageResult\\(DirectMessageData \\{ space_address: HashString\\(\"appA\"\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"alex\"\\), from_agent_id: HashString\\(\"alex\"\\), content: \"echo: wah\" \\}\\)";
 
-    assert2_msg_matches!(alex, alex, expected);
+    assert_msg_matches!(alex, expected);
 }
 
 /// Test publish, Store, Query

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -167,7 +167,7 @@ pub fn test_send_message_self(alex: &mut NodeMock, _billy: &mut NodeMock) {
 
     let expected = "HandleSendDirectMessage\\(DirectMessageData \\{ space_address: HashString\\(\"appA\"\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"alex\"\\), from_agent_id: HashString\\(\"alex\"\\), content: \"wah\" \\}\\)";
 
-    let results = assert2_msg_matches!(alex, alex, expected);
+    let results = assert_msg_matches!(alex, expected);
 
     let handle_send_direct_msg = results.first().unwrap();
 


### PR DESCRIPTION
## PR summary

- adds ability for in-memory transport to send messages to self.
- updates DHT to assume can resolve RequestPeer of own peer_name.
- updates `two_basic` tests to include send-to-self testing.

## Review checklist 
- [x] The story has unit or integration tests
- [x] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
