### PR TITLE
Do not capture backtraces by default

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,7 @@ jobs:
    working_directory: ~/repo
    steps:
      - checkout
-     - run:
-       name: linux benchmarks
-       command: |
+     - run: |
          apt-get update && apt-get install -y --no-install-recommends git make pkg-config libssl-dev
          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
          export PATH=$HOME/.cargo/bin:$PATH

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,20 @@ jobs:
   steps:
    - checkout
    - run: nix-shell --run l3h-test
+ linux_bench:
+   docker:
+     - image: debian:10.1-slim
+   resource_class: small
+   working_directory: ~/repo
+   steps:
+     - checkout
+     - run:
+       name: linux benchmarks
+       command: |
+         apt-get update && apt-get install -y --no-install-recommends git make pkg-config libssl-dev
+         curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
+         export PATH=$HOME/.cargo/bin:$PATH
+         MAKE_ENV=local make benchmarks
  macos:
   macos:
    xcode: "10.2.0"
@@ -20,10 +34,23 @@ jobs:
        # same as linux from here
        nix-shell --run echo
        nix-shell --run l3h-test
+ macos_bench:
+  macos:
+   xcode: "10.2.0"
+  steps:
+   - checkout
+   - run:
+      name: macos benchmarks
+      command: |
+       curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
+       export PATH=$HOME/.cargo/bin:$PATH
+       MAKE_ENV=local make benchmarks
 
 workflows:
  version: 2
  tests:
   jobs:
    - build
+   - linux_bench
    - macos
+   - macos_bench

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
    steps:
      - checkout
      - run: |
-         apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates make pkg-config libssl-dev
+         apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates build-essential make pkg-config libssl-dev
          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
          export PATH=$HOME/.cargo/bin:$PATH
          MAKE_ENV=local make benchmarks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
    steps:
      - checkout
      - run: |
-         apt-get update && apt-get install -y --no-install-recommends git make pkg-config libssl-dev
+         apt-get update && apt-get install -y --no-install-recommends git curl make pkg-config libssl-dev
          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
          export PATH=$HOME/.cargo/bin:$PATH
          MAKE_ENV=local make benchmarks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
    steps:
      - checkout
      - run: |
-         apt-get update && apt-get install -y --no-install-recommends git curl make pkg-config libssl-dev
+         apt-get update && apt-get install -y --no-install-recommends git curl ca-certificates make pkg-config libssl-dev
          curl --proto '=https' --tlsv1.2 https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain none
          export PATH=$HOME/.cargo/bin:$PATH
          MAKE_ENV=local make benchmarks

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -49,6 +49,6 @@ workflows:
  tests:
   jobs:
    - build
-   - linux_bench
+#   - linux_bench
    - macos
-   - macos_bench
+#   - macos_bench

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # Top-Level Environment Switcher
 # This will delegate to sub Makefile.* files
 
-.PHONY: all test fmt clean
+.PHONY: all test fmt clean benchmarks
 
 export
-all test fmt clean:
+all test fmt clean benchmarks:
 ifeq ($(MAKE_ENV),local)
 	$(MAKE) -f scripts/make/Makefile.local.mk $@
 else

--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -48,6 +48,7 @@ regex = "=1.1.2"
 xoroshiro128 = "0.3.0"
 hexf = "0.1.0"
 rand = "0.7.0"
+tempfile = "=3.1.0"
 
 [[bin]]
 name = "send-demo"

--- a/crates/lib3h/src/error.rs
+++ b/crates/lib3h/src/error.rs
@@ -2,7 +2,7 @@
 
 use crate::transport::error::TransportError;
 use lib3h_crypto_api::CryptoError;
-use lib3h_ghost_actor::GhostError;
+use lib3h_ghost_actor::{Backtwrap, GhostError};
 use lib3h_protocol::error::{ErrorKind as Lib3hProtocolErrorKind, Lib3hProtocolError};
 use rmp_serde::decode::Error as RMPSerdeDecodeError;
 use std::{error::Error as StdError, fmt, io, result};
@@ -175,10 +175,10 @@ impl From<CryptoError> for Lib3hError {
 // TODO I'm not so sure about this...
 impl From<Lib3hError> for Lib3hProtocolError {
     fn from(err: Lib3hError) -> Self {
-        let bt = backtrace::Backtrace::new();
+        let bt = Backtwrap::new();
         Lib3hProtocolError::new(Lib3hProtocolErrorKind::Lib3hError(
             format!("lib3h internal: {:?}", err),
-            Some(bt),
+            bt.into(),
         ))
     }
 }
@@ -186,13 +186,17 @@ impl From<Lib3hError> for Lib3hProtocolError {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use lib3h_ghost_actor::BacktwrapCaptureStrategy;
 
     #[test]
     fn it_should_upgrade_and_backtrace_lib3h_protocol_errors() {
+        let store = Backtwrap::get_capture_strategy();
+        Backtwrap::set_capture_strategy(BacktwrapCaptureStrategy::CaptureResolved);
         let e: Lib3hProtocolError =
             Lib3hError::new(ErrorKind::Other("test-str-abcdefg".to_string())).into();
         let res = format!("{:?}", e);
         assert!(res.contains("test-str-abcdefg"));
         assert!(res.contains("it_should_upgrade_and_backtrace_lib3h_protocol_errors"));
+        Backtwrap::set_capture_strategy(store);
     }
 }

--- a/crates/lib3h/src/lib.rs
+++ b/crates/lib3h/src/lib.rs
@@ -77,6 +77,12 @@ mod tests {
         assert_eq!(&format!("{:?}", bt)[0..16], "stack backtrace:");
     }
 
+    fn bench_unit_capture_backtrace_unresolved() {
+        bench_unit_control_work();
+        let bt = backtrace::Backtrace::new_unresolved();
+        assert_eq!(&format!("{:?}", bt)[0..16], "stack backtrace:");
+    }
+
     fn bench_unit_sync_crossbeam() {
         bench_unit_control_work();
         let (send, recv) = crossbeam_channel::unbounded();
@@ -122,6 +128,7 @@ mod tests {
         bench_helper_use_logging(true);
         bench_unit_control_work();
         bench_unit_capture_backtrace();
+        bench_unit_capture_backtrace_unresolved();
         bench_unit_sync_crossbeam();
         bench_unit_logging();
     }
@@ -136,6 +143,12 @@ mod tests {
     fn bench_capture_backtrace(b: &mut test::Bencher) {
         bench_helper_use_logging(false);
         b.iter(|| bench_unit_capture_backtrace());
+    }
+
+    #[bench]
+    fn bench_capture_backtrace_unresolved(b: &mut test::Bencher) {
+        bench_helper_use_logging(false);
+        b.iter(|| bench_unit_capture_backtrace_unresolved());
     }
 
     #[bench]

--- a/crates/lib3h/src/lib.rs
+++ b/crates/lib3h/src/lib.rs
@@ -136,30 +136,50 @@ mod tests {
     #[bench]
     fn bench_control_work(b: &mut test::Bencher) {
         bench_helper_use_logging(false);
-        b.iter(|| bench_unit_control_work());
+        let cb = || bench_unit_control_work();
+        for _ in 0..10 {
+            cb();
+        }
+        b.iter(cb);
     }
 
     #[bench]
     fn bench_capture_backtrace(b: &mut test::Bencher) {
         bench_helper_use_logging(false);
-        b.iter(|| bench_unit_capture_backtrace());
+        let cb = || bench_unit_capture_backtrace();
+        for _ in 0..10 {
+            cb();
+        }
+        b.iter(cb);
     }
 
     #[bench]
     fn bench_capture_backtrace_unresolved(b: &mut test::Bencher) {
         bench_helper_use_logging(false);
-        b.iter(|| bench_unit_capture_backtrace_unresolved());
+        let cb = || bench_unit_capture_backtrace_unresolved();
+        for _ in 0..10 {
+            cb();
+        }
+        b.iter(cb);
     }
 
     #[bench]
     fn bench_sync_crossbeam(b: &mut test::Bencher) {
         bench_helper_use_logging(false);
-        b.iter(|| bench_unit_sync_crossbeam());
+        let cb = || bench_unit_sync_crossbeam();
+        for _ in 0..10 {
+            cb();
+        }
+        b.iter(cb);
     }
 
     #[bench]
     fn bench_logging(b: &mut test::Bencher) {
         bench_helper_use_logging(true);
-        b.iter(|| bench_unit_logging());
+        let cb = || bench_unit_logging();
+        for _ in 0..10 {
+            cb();
+        }
+        b.iter(cb);
     }
 }

--- a/crates/zombie_actor/Cargo.toml
+++ b/crates/zombie_actor/Cargo.toml
@@ -20,6 +20,7 @@ nanoid = "=0.2.0"
 shrinkwraprs = "=0.2.1"
 log = "=0.4.8"
 predicates = "=1.0.0"
+lazy_static = "=1.2.0"
 
 [dev-dependencies]
 env_logger = "=0.6.1"

--- a/crates/zombie_actor/src/backtwrap.rs
+++ b/crates/zombie_actor/src/backtwrap.rs
@@ -1,0 +1,77 @@
+#[derive(Debug, Clone, Copy)]
+pub enum BacktwrapCaptureStrategy {
+    DoNotCapture,
+    CaptureUnresolved,
+    CaptureResolved,
+}
+
+use BacktwrapCaptureStrategy::*;
+
+lazy_static! {
+    static ref CAPTURE_STRATEGY: std::sync::Mutex<BacktwrapCaptureStrategy> = {
+        std::sync::Mutex::new(match std::env::var("BACKTRACE_STRATEGY") {
+            Ok(s) => match s.as_str() {
+                "CAPTURE_RESOLVED" => CaptureResolved,
+                "CAPTURE_UNRESOLVED" => CaptureUnresolved,
+                _ => DoNotCapture,
+            },
+            _ => DoNotCapture,
+        })
+    };
+}
+
+#[derive(Shrinkwrap, Debug, Clone)]
+#[shrinkwrap(mutable)]
+pub struct Backtwrap(pub Option<backtrace::Backtrace>);
+
+impl Backtwrap {
+    pub fn new() -> Self {
+        Self(
+            match *CAPTURE_STRATEGY.lock().expect("failed to lock mutex") {
+                CaptureResolved => Some(backtrace::Backtrace::new()),
+                CaptureUnresolved => Some(backtrace::Backtrace::new_unresolved()),
+                DoNotCapture => None,
+            },
+        )
+    }
+
+    pub fn get_capture_strategy() -> BacktwrapCaptureStrategy {
+        *CAPTURE_STRATEGY.lock().expect("failed to lock mutex")
+    }
+
+    pub fn set_capture_strategy(strategy: BacktwrapCaptureStrategy) {
+        *CAPTURE_STRATEGY.lock().expect("failed to lock mutex") = strategy;
+    }
+}
+
+impl PartialEq for Backtwrap {
+    fn eq(&self, other: &Backtwrap) -> bool {
+        format!("{:?}", self) == format!("{:?}", other)
+    }
+}
+
+impl Eq for Backtwrap {}
+
+impl std::hash::Hash for Backtwrap {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        format!("{:?}", self).hash(state);
+    }
+}
+
+impl std::convert::From<backtrace::Backtrace> for Backtwrap {
+    fn from(bt: backtrace::Backtrace) -> Backtwrap {
+        Self(Some(bt))
+    }
+}
+
+impl std::convert::From<Option<backtrace::Backtrace>> for Backtwrap {
+    fn from(bt: Option<backtrace::Backtrace>) -> Backtwrap {
+        Self(bt)
+    }
+}
+
+impl std::convert::From<Backtwrap> for Option<backtrace::Backtrace> {
+    fn from(bt: Backtwrap) -> Option<backtrace::Backtrace> {
+        bt.0
+    }
+}

--- a/crates/zombie_actor/src/lib.rs
+++ b/crates/zombie_actor/src/lib.rs
@@ -4,6 +4,8 @@ extern crate crossbeam_channel;
 #[macro_use]
 extern crate detach;
 extern crate holochain_tracing;
+#[macro_use]
+extern crate lazy_static;
 extern crate nanoid;
 #[macro_use]
 extern crate shrinkwraprs;
@@ -13,6 +15,9 @@ extern crate log;
 
 #[macro_use]
 pub mod ghost_test_harness;
+
+mod backtwrap;
+pub use backtwrap::{Backtwrap, BacktwrapCaptureStrategy};
 
 #[derive(Shrinkwrap, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[shrinkwrap(mutable)]

--- a/scripts/make/Makefile.local.mk
+++ b/scripts/make/Makefile.local.mk
@@ -17,6 +17,9 @@ ENV = RUSTFLAGS='$(RUSTFLAGS)' OPENSSL_STATIC='1' CARGO_BUILD_JOBS='$(shell npro
 
 all: test
 
+benchmarks: tools
+	cd crates/lib3h && cargo bench
+
 test: tools
 	$(ENV) cargo fmt -- --check
 	$(ENV) cargo clippy -- \

--- a/scripts/make/Makefile.local.mk
+++ b/scripts/make/Makefile.local.mk
@@ -18,7 +18,7 @@ ENV = RUSTFLAGS='$(RUSTFLAGS)' OPENSSL_STATIC='1' CARGO_BUILD_JOBS='$(shell npro
 all: test
 
 benchmarks: tools
-	cd crates/lib3h && cargo bench
+	cd crates/lib3h && cargo bench -j 1 -- --test-threads=1
 
 test: tools
 	$(ENV) cargo fmt -- --check

--- a/scripts/windows/do-ci-test.bat
+++ b/scripts/windows/do-ci-test.bat
@@ -5,4 +5,4 @@ rem KEEP IN SYNC WITH HOLONIX
 set RUST_LOG=lib3h=debug
 set RUST_BACKTRACE=1
 cargo test --target-dir c:\build\lib3h\target --verbose
-cargo bench -p lib3h --target-dir c:\build\lib3h\target -j 1 -- --test-threads=1
+rem cargo bench -p lib3h --target-dir c:\build\lib3h\target -j 1 -- --test-threads=1

--- a/scripts/windows/do-ci-test.bat
+++ b/scripts/windows/do-ci-test.bat
@@ -4,4 +4,5 @@ setlocal enabledelayedexpansion
 rem KEEP IN SYNC WITH HOLONIX
 set RUST_LOG=lib3h=debug
 set RUST_BACKTRACE=1
+cargo bench -p lib3h --target-dir c:\build\lib3h\target
 cargo test --target-dir c:\build\lib3h\target --verbose

--- a/scripts/windows/do-ci-test.bat
+++ b/scripts/windows/do-ci-test.bat
@@ -4,5 +4,5 @@ setlocal enabledelayedexpansion
 rem KEEP IN SYNC WITH HOLONIX
 set RUST_LOG=lib3h=debug
 set RUST_BACKTRACE=1
-cargo bench -p lib3h --target-dir c:\build\lib3h\target -j 1 -- --test-threads=1
 cargo test --target-dir c:\build\lib3h\target --verbose
+cargo bench -p lib3h --target-dir c:\build\lib3h\target -j 1 -- --test-threads=1

--- a/scripts/windows/do-ci-test.bat
+++ b/scripts/windows/do-ci-test.bat
@@ -4,5 +4,5 @@ setlocal enabledelayedexpansion
 rem KEEP IN SYNC WITH HOLONIX
 set RUST_LOG=lib3h=debug
 set RUST_BACKTRACE=1
-cargo bench -p lib3h --target-dir c:\build\lib3h\target
+cargo bench -p lib3h --target-dir c:\build\lib3h\target -j 1 -- --test-threads=1
 cargo test --target-dir c:\build\lib3h\target --verbose


### PR DESCRIPTION
## PR summary

- adds some benchmarking code that *can* run in CI, but doesn't by default. You can also run `cargo bench` or `MAKE_ENV=local make benchmarks`
- causes backtrace logic to NOT capture by default. It turns out macOs and Windows cannot handle it

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
