### PR TITLE
Fix hold entry test

### DIFF
--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -234,7 +234,8 @@ impl MirrorDht {
             }
             Some(mut peer) => {
                 if peer_info.timestamp <= peer.timestamp {
-                    debug!("@MirrorDht@ Adding peer - BAD");
+                    debug!("@MirrorDht@ Adding peer - BAD {:?} has earlier timestamp than {:?}", 
+                        peer_info.timestamp, peer.timestamp);
                     return false;
                 }
                 debug!(

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -234,8 +234,10 @@ impl MirrorDht {
             }
             Some(mut peer) => {
                 if peer_info.timestamp <= peer.timestamp {
-                    debug!("@MirrorDht@ Adding peer - BAD {:?} has earlier timestamp than {:?}", 
-                        peer_info.timestamp, peer.timestamp);
+                    debug!(
+                        "@MirrorDht@ Adding peer - BAD {:?} has earlier timestamp than {:?}",
+                        peer_info.timestamp, peer.timestamp
+                    );
                     return false;
                 }
                 debug!(

--- a/crates/lib3h/src/engine/ghost_engine.rs
+++ b/crates/lib3h/src/engine/ghost_engine.rs
@@ -273,7 +273,11 @@ impl<'engine> GhostEngine<'engine> {
                     .map_err(|e| GhostError::from(e.to_string()))
             }
             ClientToLib3h::HoldEntry(data) => {
-                trace!("[ghost_engine {}] ClientToLib3h::HoldEntry: {:?}", self.name, data);
+                trace!(
+                    "[ghost_engine {}] ClientToLib3h::HoldEntry: {:?}",
+                    self.name,
+                    data
+                );
                 self.handle_hold_entry(span.follower("TODO name"), &data)
                     .map_err(|e| GhostError::from(e.to_string()))
             }

--- a/crates/lib3h/src/engine/ghost_engine.rs
+++ b/crates/lib3h/src/engine/ghost_engine.rs
@@ -273,7 +273,7 @@ impl<'engine> GhostEngine<'engine> {
                     .map_err(|e| GhostError::from(e.to_string()))
             }
             ClientToLib3h::HoldEntry(data) => {
-                trace!("ClientToLib3h::HoldEntry: {:?}", data);
+                trace!("[ghost_engine {}] ClientToLib3h::HoldEntry: {:?}", self.name, data);
                 self.handle_hold_entry(span.follower("TODO name"), &data)
                     .map_err(|e| GhostError::from(e.to_string()))
             }

--- a/crates/lib3h/src/engine/ghost_engine_wrapper.rs
+++ b/crates/lib3h/src/engine/ghost_engine_wrapper.rs
@@ -231,8 +231,7 @@ where
             result.map_err(|e| Lib3hProtocolError::new(ErrorKind::Other(e.to_string())))
         } else {
             // TODO This will result will fail if its a failure result - what is proper error handling behavior?
-            let lib3h_to_client_response: Lib3hToClientResponse =
-                client_msg.clone().try_into()?;
+            let lib3h_to_client_response: Lib3hToClientResponse = client_msg.clone().try_into()?;
             let maybe_ghost_message: Option<GhostMessage<_, _, Lib3hToClientResponse, _>> =
                 self.tracker.remove(request_id.as_str());
             let ghost_mesage = maybe_ghost_message.ok_or_else(|| {
@@ -245,37 +244,32 @@ where
             // HACK: If it is send message result, put back the original request id.
             // TODO: consider this operation for all messages
             let response = match lib3h_to_client_response.clone() {
-                Lib3hToClientResponse::HandleSendDirectMessageResult(mut data) =>
-            {
-                let result = self.request_id_map.remove(&request_id);
-                if let Some(request_id) = result {
-                    trace!(
-                        "REPLACE request_id {:?} with {:?}",
-                        data.request_id,
-                        request_id
-                    );
-                    data.request_id = request_id.clone();
+                Lib3hToClientResponse::HandleSendDirectMessageResult(mut data) => {
+                    let result = self.request_id_map.remove(&request_id);
+                    if let Some(request_id) = result {
+                        trace!(
+                            "REPLACE request_id {:?} with {:?}",
+                            data.request_id,
+                            request_id
+                        );
+                        data.request_id = request_id.clone();
+                    }
+                    Lib3hToClientResponse::HandleSendDirectMessageResult(data)
                 }
-                Lib3hToClientResponse::HandleSendDirectMessageResult(data)
-            },
-            Lib3hToClientResponse::HandleQueryEntryResult(mut data) =>
-            {
-                let result = self.request_id_map.remove(&request_id);
-                if let Some(request_id) = result {
-                    trace!(
-                        "REPLACE request_id {:?} with {:?}",
-                        data.request_id,
-                        request_id
-                    );
-                    data.request_id = request_id.clone();
+                Lib3hToClientResponse::HandleQueryEntryResult(mut data) => {
+                    let result = self.request_id_map.remove(&request_id);
+                    if let Some(request_id) = result {
+                        trace!(
+                            "REPLACE request_id {:?} with {:?}",
+                            data.request_id,
+                            request_id
+                        );
+                        data.request_id = request_id.clone();
+                    }
+                    Lib3hToClientResponse::HandleQueryEntryResult(data)
                 }
-                Lib3hToClientResponse::HandleQueryEntryResult(data)
-            },
-            _ => 
-            {
-                lib3h_to_client_response.clone()
-            }
-        };
+                _ => lib3h_to_client_response.clone(),
+            };
 
             ghost_mesage
                 .respond(Ok(response))

--- a/crates/lib3h/src/engine/ghost_engine_wrapper.rs
+++ b/crates/lib3h/src/engine/ghost_engine_wrapper.rs
@@ -256,18 +256,6 @@ where
                     }
                     Lib3hToClientResponse::HandleSendDirectMessageResult(data)
                 }
-                Lib3hToClientResponse::HandleQueryEntryResult(mut data) => {
-                    let result = self.request_id_map.remove(&request_id);
-                    if let Some(request_id) = result {
-                        trace!(
-                            "REPLACE request_id {:?} with {:?}",
-                            data.request_id,
-                            request_id
-                        );
-                        data.request_id = request_id.clone();
-                    }
-                    Lib3hToClientResponse::HandleQueryEntryResult(data)
-                }
                 _ => lib3h_to_client_response.clone(),
             };
 
@@ -324,14 +312,9 @@ where
         match &mut msg {
             Lib3hServerProtocol::Connected(data) => data.request_id = request_id,
             Lib3hServerProtocol::FetchEntryResult(data) => data.request_id = request_id,
-            Lib3hServerProtocol::HandleFetchEntry(data) => data.request_id = request_id,
             Lib3hServerProtocol::HandleStoreEntryAspect(data) => data.request_id = request_id,
             Lib3hServerProtocol::HandleDropEntry(data) => data.request_id = request_id,
-            Lib3hServerProtocol::HandleQueryEntry(data) => {
-                self.request_id_map
-                    .insert(request_id.clone(), data.request_id.clone());
-                data.request_id = request_id
-            }
+            Lib3hServerProtocol::HandleQueryEntry(data) => data.request_id = request_id,
             Lib3hServerProtocol::HandleGetAuthoringEntryList(data) => data.request_id = request_id,
             Lib3hServerProtocol::HandleGetGossipingEntryList(data) => data.request_id = request_id,
             Lib3hServerProtocol::HandleSendDirectMessage(data) => {

--- a/crates/lib3h/src/engine/ghost_engine_wrapper.rs
+++ b/crates/lib3h/src/engine/ghost_engine_wrapper.rs
@@ -209,7 +209,12 @@ where
                 data.space_address.clone(),
                 data.provider_agent_id.clone(),
             ),
-            _ => unimplemented!(),
+            Lib3hClientProtocol::FailureResult(data) => (
+                "".to_string(),
+                data.space_address.clone(),
+                data.to_agent_id.clone(),
+            ),
+            msg => unimplemented!("Handle this case: {:?}", msg),
         };
 
         let maybe_client_to_lib3h: Result<ClientToLib3h, _> = client_msg.clone().try_into();
@@ -225,9 +230,9 @@ where
             };
             result.map_err(|e| Lib3hProtocolError::new(ErrorKind::Other(e.to_string())))
         } else {
-            // TODO Handle errors better here!
+            // TODO This will result will fail if its a failure result - what is proper error handling behavior?
             let lib3h_to_client_response: Lib3hToClientResponse =
-                client_msg.clone().try_into().unwrap();
+                client_msg.clone().try_into()?;
             let maybe_ghost_message: Option<GhostMessage<_, _, Lib3hToClientResponse, _>> =
                 self.tracker.remove(request_id.as_str());
             let ghost_mesage = maybe_ghost_message.ok_or_else(|| {
@@ -239,9 +244,8 @@ where
 
             // HACK: If it is send message result, put back the original request id.
             // TODO: consider this operation for all messages
-            let response;
-            if let Lib3hToClientResponse::HandleSendDirectMessageResult(mut data) =
-                lib3h_to_client_response.clone()
+            let response = match lib3h_to_client_response.clone() {
+                Lib3hToClientResponse::HandleSendDirectMessageResult(mut data) =>
             {
                 let result = self.request_id_map.remove(&request_id);
                 if let Some(request_id) = result {
@@ -252,10 +256,26 @@ where
                     );
                     data.request_id = request_id.clone();
                 }
-                response = Lib3hToClientResponse::HandleSendDirectMessageResult(data);
-            } else {
-                response = lib3h_to_client_response.clone();
+                Lib3hToClientResponse::HandleSendDirectMessageResult(data)
+            },
+            Lib3hToClientResponse::HandleQueryEntryResult(mut data) =>
+            {
+                let result = self.request_id_map.remove(&request_id);
+                if let Some(request_id) = result {
+                    trace!(
+                        "REPLACE request_id {:?} with {:?}",
+                        data.request_id,
+                        request_id
+                    );
+                    data.request_id = request_id.clone();
+                }
+                Lib3hToClientResponse::HandleQueryEntryResult(data)
+            },
+            _ => 
+            {
+                lib3h_to_client_response.clone()
             }
+        };
 
             ghost_mesage
                 .respond(Ok(response))
@@ -313,7 +333,11 @@ where
             Lib3hServerProtocol::HandleFetchEntry(data) => data.request_id = request_id,
             Lib3hServerProtocol::HandleStoreEntryAspect(data) => data.request_id = request_id,
             Lib3hServerProtocol::HandleDropEntry(data) => data.request_id = request_id,
-            Lib3hServerProtocol::HandleQueryEntry(data) => data.request_id = request_id,
+            Lib3hServerProtocol::HandleQueryEntry(data) => {
+                self.request_id_map
+                    .insert(request_id.clone(), data.request_id.clone());
+                data.request_id = request_id
+            }
             Lib3hServerProtocol::HandleGetAuthoringEntryList(data) => data.request_id = request_id,
             Lib3hServerProtocol::HandleGetGossipingEntryList(data) => data.request_id = request_id,
             Lib3hServerProtocol::HandleSendDirectMessage(data) => {

--- a/crates/lib3h/tests/node_mock/methods.rs
+++ b/crates/lib3h/tests/node_mock/methods.rs
@@ -358,8 +358,11 @@ impl NodeMock {
         &mut self,
         query: &QueryEntryData,
     ) -> Result<QueryEntryResultData, GenericResultData> {
-
-        trace!("[NodeMock {}] reply_to_HandleQueryEntry: query={:?}", self.name(), query);
+        trace!(
+            "[NodeMock {}] reply_to_HandleQueryEntry: query={:?}",
+            self.name(),
+            query
+        );
         if query.query != b"test_query".to_vec().into() {
             panic!("invalid test query opaque data: {:?}", query.query);
         }
@@ -433,8 +436,11 @@ impl NodeMock {
         let maybe_store = self.chain_store_list.get(&fetch.space_address);
         let maybe_entry = match maybe_store {
             None => {
-                trace!("[NodeMock {}] no chain store for space address: {:?}", 
-                    self.name(), fetch.space_address);
+                trace!(
+                    "[NodeMock {}] no chain store for space address: {:?}",
+                    self.name(),
+                    fetch.space_address
+                );
                 None
             }
             Some(chain_store) => chain_store.get_entry(&fetch.entry_address),
@@ -445,9 +451,9 @@ impl NodeMock {
                 space_address: fetch.space_address.clone(),
                 request_id: fetch.request_id.clone(),
                 to_agent_id: fetch.provider_agent_id.clone(),
-                result_info: 
-                format!("No entry found for address: {:?}", fetch.entry_address)
-                    .as_bytes().into(),
+                result_info: format!("No entry found for address: {:?}", fetch.entry_address)
+                    .as_bytes()
+                    .into(),
             };
             return Err(msg_data);
         }

--- a/crates/lib3h/tests/node_mock/methods.rs
+++ b/crates/lib3h/tests/node_mock/methods.rs
@@ -280,6 +280,7 @@ impl NodeMock {
         aspect_content_list: Vec<Vec<u8>>,
         can_tell_engine: bool,
     ) -> Lib3hResult<EntryData> {
+        trace!("[NodeMock {:?}] hold_entry start: address={:?}", self.name(), entry_address);
         let current_space = self.current_space.clone().expect("Current Space not set");
         let entry = NodeMock::form_EntryData(entry_address, aspect_content_list);
         let chain_store = self
@@ -309,6 +310,7 @@ impl NodeMock {
             self.engine
                 .post(Lib3hClientProtocol::HoldEntry(msg_data).into())?;
         }
+        trace!("[NodeMock {:?}] hold_entry end: entry={:?}", self.name(), entry);
         // Done
         Ok(entry)
     }

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -52,7 +52,11 @@ pub fn request_entry_ok(node: &mut NodeMock, entry: &EntryData) {
     let expected = "HandleQueryEntry\\(QueryEntryData \\{ space_address: HashString\\(\"appA\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), request_id: \"[\\w\\d_~]+\", requester_agent_id: HashString\\(\"billy\"\\), query: \"test_query\" \\}\\)";
 
     let srv_msg_list = assert_msg_matches!(node, expected);
-    trace!("\n{} [request_entry_ok] srv_msg_list: {:?}", node.name(), srv_msg_list);
+    trace!(
+        "\n{} [request_entry_ok] srv_msg_list: {:?}",
+        node.name(),
+        srv_msg_list
+    );
     // #fullsync
     // Billy sends that data back to the network
     trace!("\n{} reply to own request:\n", node.name());
@@ -108,8 +112,6 @@ pub fn two_join_space(alex: &mut NodeMock, billy: &mut NodeMock, space_address: 
     wait_engine_wrapper_until_no_work!(billy);
     wait_engine_wrapper_until_no_work!(alex);
     wait_engine_wrapper_until_no_work!(billy);
- 
-
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -211,7 +213,7 @@ fn test_hold_entry(alex: &mut NodeMock, billy: &mut NodeMock) {
         .unwrap();
 
     wait2_engine_wrapper_until_no_work!(alex, billy);
-  
+
     request_entry_ok(billy, &entry);
 
     // Billy asks for unknown entry

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -7,18 +7,17 @@ pub type TwoNodesTestFn = fn(alex: &mut NodeMock, billy: &mut NodeMock);
 
 lazy_static! {
     pub static ref TWO_NODES_BASIC_TEST_FNS: Vec<(TwoNodesTestFn, bool)> = vec![
- //       (test_setup_only, true),
-//        (test_send_message, true),
- //       (test_send_message_fail, true),
+        (test_setup_only, true),
+        (test_send_message, true),
+        (test_send_message_fail, true),
 // TODO will comment out as they are fixed
-        (test_hold_entry, true),
-/*
         (test_author_no_aspect, true),
+/*
         (test_author_one_aspect, true),
-        (test_author_two_aspects, true),
-        (test_two_authors, true),
-*/
-    ];
+        (test_author_two_aspects, true),*/
+ /*       (test_two_authors, true),*/
+
+  ];
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -175,10 +174,8 @@ pub fn test_author_one_aspect(alex: &mut NodeMock, billy: &mut NodeMock) {
     let entry = alex
         .author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
         .unwrap();
-    let (did_work, srv_msg_list) = alex.process().unwrap();
-    assert!(did_work);
-    assert_eq!(srv_msg_list.len(), 1);
 
+    wait2_engine_wrapper_until_no_work!(alex, billy);
     // #fullsync
     // Alex or Billy should receive the entry store request
     let store_result = billy.wait(Box::new(one_is!(
@@ -195,30 +192,6 @@ pub fn test_author_one_aspect(alex: &mut NodeMock, billy: &mut NodeMock) {
 
     // Billy asks for unknown entry
     // ============================
-    let query_data = billy.request_entry(ENTRY_ADDRESS_2.clone());
-    let res = alex.reply_to_HandleQueryEntry(&query_data);
-    println!("\nAlex gives response {:?}\n", res);
-    assert!(res.is_err());
-    let res_data: GenericResultData = res.err().unwrap();
-    let res_info = std::str::from_utf8(res_data.result_info.as_slice()).unwrap();
-    assert_eq!(res_info, "No entry found");
-}
-
-/// Test Hold & Query
-#[allow(dead_code)]
-fn test_hold_entry(alex: &mut NodeMock, billy: &mut NodeMock) {
-    // Alex holds an entry
-    let entry = alex
-        .hold_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
-        .unwrap();
-
-    wait2_engine_wrapper_until_no_work!(alex, billy);
-
-    request_entry_ok(billy, &entry);
-
-    // Billy asks for unknown entry
-    // ============================
-    println!("\nBilly requesting unknown entry:\n");
     let query_data = billy.request_entry(ENTRY_ADDRESS_2.clone());
     let res = alex.reply_to_HandleQueryEntry(&query_data);
     println!("\nAlex gives response {:?}\n", res);

--- a/crates/lib3h/tests/utils/processor_harness.rs
+++ b/crates/lib3h/tests/utils/processor_harness.rs
@@ -313,13 +313,12 @@ impl predicates::reflection::PredicateReflection for Lib3hServerProtocolAssert {
 #[allow(dead_code)]
 #[derive(PartialEq, Debug)]
 pub struct DidWorkAssert {
-    pub engine_name: String , 
-    pub should_assert: bool
+    pub engine_name: String,
+    pub should_assert: bool,
 }
 
 impl Processor for DidWorkAssert {
     fn test(&self, args: &ProcessorResult) {
-
         if self.should_assert {
             assert!(args.engine_name == self.engine_name);
             assert!(args.did_work);
@@ -335,8 +334,11 @@ impl Predicate<ProcessorResult> for DidWorkAssert {
 
 impl std::fmt::Display for DidWorkAssert {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:?} did work (should_assert={:?})", 
-            self.engine_name, self.should_assert)
+        write!(
+            f,
+            "{:?} did work (should_assert={:?})",
+            self.engine_name, self.should_assert
+        )
     }
 }
 
@@ -705,18 +707,24 @@ macro_rules! wait2_engine_wrapper_did_work {
      $should_abort: expr
     ) => {{
         let processors = vec![
-            Box::new($crate::utils::processor_harness::DidWorkAssert { engine_name: $engine1.name(), should_assert: $should_abort}), 
-            Box::new($crate::utils::processor_harness::DidWorkAssert{ engine_name: $engine2.name(), should_assert: $should_abort})];
+            Box::new($crate::utils::processor_harness::DidWorkAssert {
+                engine_name: $engine1.name(),
+                should_assert: $should_abort,
+            }),
+            Box::new($crate::utils::processor_harness::DidWorkAssert {
+                engine_name: $engine2.name(),
+                should_assert: $should_abort,
+            }),
+        ];
         $crate::assert2_processed_all!($engine1, $engine2, processors)
     }};
     ($engine1: ident,
      $engine2: ident
     ) => {{
         $crate::wait2_engine_wrapper_did_work!($engine1, $engine2, true)
-    }}
- 
+    }};
 }
- 
+
 /// Continues processing the engine wrapper until nso more work is observed
 #[allow(unused_macros)]
 #[macro_export]
@@ -725,7 +733,8 @@ macro_rules! wait2_engine_wrapper_until_no_work {
         let mut did_work;
         loop {
             did_work = $crate::wait2_engine_wrapper_did_work!($engine1, $engine2, false)
-                .iter().find(|result| result.did_work)
+                .iter()
+                .find(|result| result.did_work)
                 .is_some();
             if !did_work {
                 break;
@@ -734,5 +743,3 @@ macro_rules! wait2_engine_wrapper_until_no_work {
         did_work
     }};
 }
-
-

--- a/crates/lib3h/tests/utils/processor_harness.rs
+++ b/crates/lib3h/tests/utils/processor_harness.rs
@@ -312,23 +312,31 @@ impl predicates::reflection::PredicateReflection for Lib3hServerProtocolAssert {
 /// Asserts work was done
 #[allow(dead_code)]
 #[derive(PartialEq, Debug)]
-pub struct DidWorkAssert(pub String /* engine name */);
+pub struct DidWorkAssert {
+    pub engine_name: String , 
+    pub should_assert: bool
+}
+
 impl Processor for DidWorkAssert {
     fn test(&self, args: &ProcessorResult) {
-        assert!(args.engine_name == self.0);
-        assert!(args.did_work);
+
+        if self.should_assert {
+            assert!(args.engine_name == self.engine_name);
+            assert!(args.did_work);
+        }
     }
 }
 
 impl Predicate<ProcessorResult> for DidWorkAssert {
     fn eval(&self, args: &ProcessorResult) -> bool {
-        args.engine_name == self.0 && args.did_work
+        args.engine_name == self.engine_name && args.did_work
     }
 }
 
 impl std::fmt::Display for DidWorkAssert {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        write!(f, "{:?} did work", self.0)
+        write!(f, "{:?} did work (should_assert={:?})", 
+            self.engine_name, self.should_assert)
     }
 }
 
@@ -687,3 +695,44 @@ macro_rules! wait_engine_wrapper_until_no_work {
         did_work
     }};
 }
+
+/// Continues processing two engine wrappers until they both exhibit work.
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! wait2_engine_wrapper_did_work {
+    ($engine1: ident,
+     $engine2: ident,
+     $should_abort: expr
+    ) => {{
+        let processors = vec![
+            Box::new($crate::utils::processor_harness::DidWorkAssert { engine_name: $engine1.name(), should_assert: $should_abort}), 
+            Box::new($crate::utils::processor_harness::DidWorkAssert{ engine_name: $engine2.name(), should_assert: $should_abort})];
+        $crate::assert2_processed_all!($engine1, $engine2, processors)
+    }};
+    ($engine1: ident,
+     $engine2: ident
+    ) => {{
+        $crate::wait2_engine_wrapper_did_work!($engine1, $engine2, true)
+    }}
+ 
+}
+ 
+/// Continues processing the engine wrapper until nso more work is observed
+#[allow(unused_macros)]
+#[macro_export]
+macro_rules! wait2_engine_wrapper_until_no_work {
+    ($engine1: ident, $engine2: ident) => {{
+        let mut did_work;
+        loop {
+            did_work = $crate::wait2_engine_wrapper_did_work!($engine1, $engine2, false)
+                .iter().find(|result| result.did_work)
+                .is_some();
+            if !did_work {
+                break;
+            }
+        }
+        did_work
+    }};
+}
+
+

--- a/crates/lib3h_protocol/src/protocol.rs
+++ b/crates/lib3h_protocol/src/protocol.rs
@@ -39,8 +39,6 @@ pub enum ClientToLib3h {
     FetchEntry(FetchEntryData), // NOTE: MAY BE DEPRECATED
     /// Publish data to the dht (event)
     PublishEntry(ProvidedEntryData),
-    /// Tell Engine that Client is holding this entry (event)
-    HoldEntry(ProvidedEntryData),
     /// Request some info / data from a Entry
     QueryEntry(QueryEntryData),
 }
@@ -129,9 +127,6 @@ impl TryFrom<Lib3hClientProtocol> for ClientToLib3h {
             }
             Lib3hClientProtocol::PublishEntry(provided_entry_data) => {
                 Ok(ClientToLib3h::PublishEntry(provided_entry_data))
-            }
-            Lib3hClientProtocol::HoldEntry(provided_entry_data) => {
-                Ok(ClientToLib3h::HoldEntry(provided_entry_data))
             }
             Lib3hClientProtocol::QueryEntry(query_entry_data) => {
                 Ok(ClientToLib3h::QueryEntry(query_entry_data))
@@ -254,9 +249,6 @@ impl From<ClientToLib3h> for Lib3hClientProtocol {
             }
             ClientToLib3h::PublishEntry(provided_entry_data) => {
                 Lib3hClientProtocol::PublishEntry(provided_entry_data)
-            }
-            ClientToLib3h::HoldEntry(provided_entry_data) => {
-                Lib3hClientProtocol::HoldEntry(provided_entry_data)
             }
             ClientToLib3h::QueryEntry(query_entry_data) => {
                 Lib3hClientProtocol::QueryEntry(query_entry_data)


### PR DESCRIPTION
## PR summary

This resolves issue #402.

Removes hold entry test and the client level enum values (so Core no longer can attempt a hold entry workflow). It is still in the DHT protocol level. Improved some failure result error handling and some logging improvements as well. Also added `wait2_engine_wrapper_*!` macros which accept two engines and ensure both of them have done work.


## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
