### PR TITLE
capture backtraces on linux ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
    - image: holochain/holonix:latest
   steps:
    - checkout
-   - run: nix-shell --run l3h-test
+   - run: BACKTRACE_STRATEGY=CAPTURE_RESOLVED nix-shell --run l3h-test
  linux_bench:
    docker:
      - image: debian:10.1-slim

--- a/crates/zombie_actor/src/backtwrap.rs
+++ b/crates/zombie_actor/src/backtwrap.rs
@@ -13,14 +13,16 @@ use BacktwrapCaptureStrategy::*;
 
 lazy_static! {
     static ref CAPTURE_STRATEGY: std::sync::Mutex<BacktwrapCaptureStrategy> = {
-        std::sync::Mutex::new(match std::env::var("BACKTRACE_STRATEGY") {
+        let out = std::sync::Mutex::new(match std::env::var("BACKTRACE_STRATEGY") {
             Ok(s) => match s.as_str() {
                 "CAPTURE_RESOLVED" => CaptureResolved,
                 "CAPTURE_UNRESOLVED" => CaptureUnresolved,
                 _ => DoNotCapture,
             },
             _ => DoNotCapture,
-        })
+        });
+        warn!("Using Backtrace Capture Strategy: {:?}", out);
+        out
     };
 }
 

--- a/scripts/nix/test/default.nix
+++ b/scripts/nix/test/default.nix
@@ -4,6 +4,7 @@ let
 
   script = pkgs.writeShellScriptBin name
   ''
+  echo BACKTRACE_STRATEGY=$BACKTRACE_STRATEGY
   RUST_BACKTRACE=1 \
   hn-rust-fmt-check \
   && hn-rust-clippy \


### PR DESCRIPTION
## PR summary

since linux can capture backtraces without major overhead, go ahead and enable capturing on linux CI

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
