### PR TITLE
cleanup #172

### DIFF
--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -126,17 +126,6 @@ impl<'engine> GhostEngine<'engine> {
                 } else {
                     // FIXME #391
                     error!("unhandled error {}", error);
-                    /*
-                    self.network_connections.remove(uri);
-                    error!("{} Network error from {} : {:?}", self.name, uri, error);
-                    // Output a Lib3hToClient::Disconnected if it was the connection
-                    if self.network_connections.is_empty() {
-                        let data = DisconnectedData {
-                            network_id: "FIXME".to_string(), // TODO #172
-                        };
-                        self.lib3h_endpoint
-                            .publish(Span::fixme(), Lib3hToClient::Disconnected(data))?;
-                    }*/
                 }
             }
             transport::protocol::RequestToParent::IncomingConnection { uri } => {
@@ -145,16 +134,6 @@ impl<'engine> GhostEngine<'engine> {
                     uri.clone(),
                 )?;
             }
-            //            TransportEvent::ConnectionClosed(id) => {
-            //                self.network_connections.remove(id);
-            //                // Output a Lib3hToClient::Disconnected if it was the last connection
-            //                if self.network_connections.is_empty() {
-            //                    let data = DisconnectedData {
-            //                        network_id: "FIXME".to_string(), // TODO #172
-            //                    };
-            //                    outbox.push(Lib3hToClient::Disconnected(data));
-            //                }
-            //            }
             transport::protocol::RequestToParent::ReceivedData { uri, payload } => {
                 debug!("Received message from: {} | size: {}", uri, payload.len());
                 // zero len() means its just a ping, no need to deserialize and handle

--- a/crates/lib3h_protocol/src/data_types.rs
+++ b/crates/lib3h_protocol/src/data_types.rs
@@ -199,7 +199,6 @@ pub struct ConnectedData {
     pub request_id: String,
     /// The first uri we are connected to
     pub uri: Lib3hUri,
-    // TODO #172 - Add network_id? Or let local client figure it out with the request_id?
     // TODO #178 - Add some info on network state
     // pub peer_count: u32,
 }


### PR DESCRIPTION
## PR summary
closes #172 

This question was mostly about how whether ConnectedData should include the network_id.  Because the network id is passed in by the Client (Core) at initialization there is only one value that it could every be, so we don't need to add this as a field.

Cleaned up references.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
