### PR TITLE
add bubble up of IncommingConnection to network layer for sending AllJoinedSpace

### DIFF
--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -239,7 +239,7 @@ impl P2pGateway {
             };
 
         trace!(
-            "({}).priv_low_level_send message from {} to {}",
+            "({}).priv_low_level_send message from '{}' to '{}'",
             self.identifier.nickname,
             self.this_peer.peer_name.clone(),
             uri.clone()

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -34,14 +34,15 @@ impl P2pGateway {
                     }
                 };
                 if let DhtRequestToChildResponse::RequestThisPeer(this_peer) = response {
-
                     // once we have the peer info from the other side, bubble the incoming connection
                     // to the network layer
                     me.endpoint_self.publish(
                         Span::fixme(),
-                        GatewayRequestToParent::Transport(transport::protocol::RequestToParent::IncomingConnection {
-                            uri: this_peer.clone().peer_name.into(),
-                        }),
+                        GatewayRequestToParent::Transport(
+                            transport::protocol::RequestToParent::IncomingConnection {
+                                uri: this_peer.clone().peer_name.into(),
+                            },
+                        ),
                     )?;
 
                     // Send to other node our PeerName

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -40,7 +40,7 @@ impl P2pGateway {
                         Span::fixme(),
                         GatewayRequestToParent::Transport(
                             transport::protocol::RequestToParent::IncomingConnection {
-                                uri: this_peer.clone().peer_name.into(),
+                                uri: this_peer.peer_name.clone(),
                             },
                         ),
                     )?;

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -34,6 +34,16 @@ impl P2pGateway {
                     }
                 };
                 if let DhtRequestToChildResponse::RequestThisPeer(this_peer) = response {
+
+                    // once we have the peer info from the other side, bubble the incoming connection
+                    // to the network layer
+                    me.endpoint_self.publish(
+                        Span::fixme(),
+                        GatewayRequestToParent::Transport(transport::protocol::RequestToParent::IncomingConnection {
+                            uri: this_peer.clone().peer_name.into(),
+                        }),
+                    )?;
+
                     // Send to other node our PeerName
                     let our_peer_name = P2pProtocol::PeerName(
                         me.identifier.id.to_owned().into(),
@@ -228,7 +238,7 @@ impl P2pGateway {
             };
 
         trace!(
-            "({}).priv_low_level_send message from '{}' to '{}'",
+            "({}).priv_low_level_send message from {} to {}",
             self.identifier.nickname,
             self.this_peer.peer_name.clone(),
             uri.clone()

--- a/crates/lib3h/tests/utils/processor_harness.rs
+++ b/crates/lib3h/tests/utils/processor_harness.rs
@@ -623,7 +623,7 @@ macro_rules! wait_connect {
         $other: ident
     ) => {{
         let _connect_data = $connect_data;
-        assert2_msg_matches!($me, $other, "Connected\\(ConnectedData \\{ request_id: \"client_to_lib3_response_.*\", uri: Lib3hUri\\(\"transportid:Hc.*\"\\) \\}\\)");
+      $crate::assert2_msg_matches!($me, $other, "Connected\\(ConnectedData \\{ request_id: \"client_to_lib3_response_.*\", uri: Lib3hUri\\(\"transportid:Hc.*\"\\) \\}\\)");
     }};
 }
 

--- a/crates/lib3h/tests/utils/processor_harness.rs
+++ b/crates/lib3h/tests/utils/processor_harness.rs
@@ -443,7 +443,7 @@ macro_rules! process_one_engine {
             .unwrap_or((false, vec![]));
         if events.is_empty() {
         } else {
-            trace!("[process_one_engine]: {:?}", events);
+            trace!("[process_one_engine] by {} {:?}", $engine.name(), events);
             let processor_result = $crate::utils::processor_harness::ProcessorResult {
                 did_work,
                 events,
@@ -623,18 +623,7 @@ macro_rules! wait_connect {
         $other: ident
     ) => {{
         let _connect_data = $connect_data;
-        let re = regex::Regex::new("ConnectedData").expect("valid regex");
-        let assertion = Box::new(predicates::prelude::predicate::function(move |x| {
-            let to_match = format!("{:?}", x);
-            re.is_match(&to_match)
-        }));
-
-        let predicate: Box<dyn $crate::utils::processor_harness::Processor> = Box::new(
-            $crate::utils::processor_harness::Lib3hServerProtocolAssert(assertion),
-        );
-
-        let result = assert2_processed!($me, $other, predicate);
-        result
+        assert2_msg_matches!($me, $other, "Connected\\(ConnectedData \\{ request_id: \"client_to_lib3_response_.*\", uri: Lib3hUri\\(\"transportid:Hc.*\"\\) \\}\\)");
     }};
 }
 


### PR DESCRIPTION
## PR summary

As part of getting all the hacks we need to get our interim MirrorDHT working we need bubble up of IncommingConnection to network layer for sending AllJoinedSpace messages.  This PR simply adds that.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
