### PR TITLE
Make macro to verify successful bind, use in all transport tests.

### DIFF
--- a/crates/lib3h/src/engine/ghost_engine.rs
+++ b/crates/lib3h/src/engine/ghost_engine.rs
@@ -753,7 +753,7 @@ mod tests {
         transport::memory_mock::memory_server,
     };
     use holochain_tracing::test_span;
-    use lib3h_ghost_actor::wait_can_track_did_work;
+    use lib3h_ghost_actor::{ghost_test_harness::ProcessingOptions, wait_can_track_did_work};
     use lib3h_sodium::SodiumCryptoSystem;
     use std::path::PathBuf;
 
@@ -867,7 +867,7 @@ mod tests {
         let my_url = &Lib3hUri::with_memory("addr_1");
         //let my_url = &engine.as_ref().advertise();
         assert!(network.lock().unwrap().unbind(my_url));
-        wait_can_track_did_work!(engine, core, false);
+        wait_can_track_did_work!(engine, core, ProcessingOptions::with_should_abort(false));
         let mut msgs = engine.drain_messages();
         println!("engine.drain() -> {:?}", msgs);
         assert_eq!(msgs.len(), 3);

--- a/crates/lib3h/src/lib.rs
+++ b/crates/lib3h/src/lib.rs
@@ -30,6 +30,7 @@ pub mod keystore;
 pub mod message_encoding;
 pub mod time;
 pub mod track;
+#[macro_use]
 pub mod transport;
 // FIXME
 // pub mod transport_wss;

--- a/crates/lib3h/src/transport/mod.rs
+++ b/crates/lib3h/src/transport/mod.rs
@@ -5,9 +5,10 @@ pub mod memory_mock;
 pub mod protocol;
 pub mod websocket;
 
-mod transport_test_harness;
+#[macro_use]
+pub mod transport_test_harness;
 
-mod transport_multiplex;
+pub mod transport_multiplex;
 pub use transport_multiplex::TransportMultiplex;
 
 // FIXME

--- a/crates/lib3h/src/transport/mod.rs
+++ b/crates/lib3h/src/transport/mod.rs
@@ -5,10 +5,13 @@ pub mod memory_mock;
 pub mod protocol;
 pub mod websocket;
 
+mod transport_test_harness;
+
 mod transport_multiplex;
 pub use transport_multiplex::TransportMultiplex;
 
 // FIXME
+// TODO do we still really need these tests?
 //#[cfg(test)]
 //pub mod tests {
 //    #![allow(non_snake_case)]

--- a/crates/lib3h/src/transport/transport_test_harness.rs
+++ b/crates/lib3h/src/transport/transport_test_harness.rs
@@ -1,0 +1,67 @@
+/// Macros to process a transport and await certain conditions or fail
+#[allow(dead_code)]
+pub const DEFAULT_PORT: u16 = 0;
+
+#[allow(dead_code)]
+fn port_is_available(port: u16) -> bool {
+    match std::net::TcpListener::bind(("127.0.0.1", port)) {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+#[allow(dead_code)]
+fn get_available_port(start: u16) -> Option<u16> {
+    (start..65535).find(|port| port_is_available(*port))
+}
+
+/// Waits until a bind result is produced by a ghost transport
+#[macro_export]
+#[allow(unused_macros)]
+macro_rules! wait_for_bind_result {
+    {
+        $actor: ident,
+        $can_track: ident,
+        $init_url: expr,
+        $options: expr
+    } => {{
+        let options = $crate::ghost_test_harness::ProcessingOptions::default();
+        $crate::wait_for_bind_result!($actor, $can_track, $init_url, options)
+    }};
+    {
+        $actor: ident,
+        $can_track: ident,
+        $init_url: expr,
+        $options: expr
+    } => {{
+        let init_transport_address: $crate::lib3h_protocol::Lib3hUri = $init_url.into();
+
+        let request_fn = Box::new(|transport_address: $crate::lib3h_protocol::Lib3hUri| {
+            let old_port = transport1_address.port().unwrap_or_else(|| $crate::ghost_test_harness::DEFAULT_PORT);
+            let old_host = transport1_address.hostname().or("");
+            let old_scheme = transport1_address.raw_scheme();
+            let port = $crate::ghost_test_harness::get_available_port(old_port + 1)
+                .expect("Must be able to find free port");
+
+            let expected_transport_address =
+                $crate::url::Builder::with_host(old_host)
+                .with_port(port)
+                .with_scheme(old_scheme)
+                .build()
+                .unwrap();
+
+            let request = RequestToChild::Bind {
+                spec: expected_transport_address.clone(),
+            };
+            let re = format!(
+                "Response\\(Ok\\(Bind\\(BindResultData \\{{ bound_url: Lib3hUri\\(\"{:?}\"\\) \\}}\\)\\)\\)",
+                expected_transport_address.to_string()
+            );
+
+            (request.clone(), re, expected_transport_address.clone())
+        });
+
+        $crate::test_wait_for_repeatable_callback!($actor, $can_track, request_fn,
+            init_transport_address, $options)
+    }}
+}

--- a/crates/lib3h/src/transport/websocket/actor.rs
+++ b/crates/lib3h/src/transport/websocket/actor.rs
@@ -410,10 +410,12 @@ impl
 mod tests {
 
     use super::*;
-    use crate::{tests::enable_logging_for_test, wait_for_bind_result, transport::websocket::tls::TlsConfig};
+    use crate::{
+        tests::enable_logging_for_test, transport::websocket::tls::TlsConfig, wait_for_bind_result,
+    };
+    use lib3h_ghost_actor::wait_for_message;
     use std::net::TcpListener;
     use url::Url;
-    use lib3h_ghost_actor::wait_for_message;
 
     fn port_is_available(port: u16) -> bool {
         match TcpListener::bind(("127.0.0.1", port)) {
@@ -467,11 +469,8 @@ mod tests {
             .unwrap()
             .into();
 
-        let (_is_match, expected_transport1_address) = wait_for_bind_result!(
-            transport1,
-            t1_endpoint,
-            init_transport1_address
-        );
+        let (_is_match, expected_transport1_address) =
+            wait_for_bind_result!(transport1, t1_endpoint, init_transport1_address);
 
         let port2 = get_available_port(expected_transport1_address.port().unwrap_or_else(|| 0))
             .expect("Must be able to find free port");

--- a/crates/lib3h/src/transport/websocket/actor.rs
+++ b/crates/lib3h/src/transport/websocket/actor.rs
@@ -413,7 +413,7 @@ mod tests {
     use crate::{
         tests::enable_logging_for_test, transport::websocket::tls::TlsConfig, wait_for_bind_result,
     };
-    use lib3h_ghost_actor::{wait_until_no_work, wait_for_message, wait1_for_callback};
+    use lib3h_ghost_actor::{wait1_for_callback, wait_for_message, wait_until_no_work};
     use std::net::TcpListener;
     use url::Url;
 
@@ -542,7 +542,6 @@ mod tests {
                 .with_port(port1)
                 .build();
 
-
         let (_is_match, expected_transport1_address) =
             wait_for_bind_result!(transport1, t1_endpoint, init_transport1_address);
 
@@ -574,7 +573,7 @@ mod tests {
                     Url::parse(&format!("wss://127.0.0.1:{}", port2))
                         .unwrap()
                         .into();
-                let (_is_match, expected_transport2_address) = 
+                let (_is_match, expected_transport2_address) =
                     wait_for_bind_result!(transport2, t2_endpoint, init_transport2_address);
 
                 assert_eq!(
@@ -582,21 +581,24 @@ mod tests {
                     Some(expected_transport2_address.clone())
                 );
 
-               
-                let wait_callback_options = crate::lib3h_ghost_actor::ghost_test_harness::ProcessingOptions {
-                    // TODO set this to true
-                    should_abort: false,
-                    max_iters:1,
-                    ..Default::default()
-                };
+                let wait_callback_options =
+                    crate::lib3h_ghost_actor::ghost_test_harness::ProcessingOptions {
+                        // TODO set this to true
+                        should_abort: false,
+                        max_iters: 1,
+                        ..Default::default()
+                    };
 
-                wait1_for_callback!(transport1, t1_endpoint, 
+                wait1_for_callback!(
+                    transport1,
+                    t1_endpoint,
                     RequestToChild::create_send_message(
                         expected_transport2_address.clone(),
                         b"test message".to_vec().into(),
                     ),
                     "Response(Ok(SendMessageSuccess))",
-                wait_callback_options);
+                    wait_callback_options
+                );
 
                 wait_for_message!(
                     vec![&mut transport1, &mut transport2],

--- a/crates/lib3h/src/transport/websocket/actor.rs
+++ b/crates/lib3h/src/transport/websocket/actor.rs
@@ -481,13 +481,6 @@ mod tests {
 
         let (_is_match, expected_transport2_address) =
             wait_for_bind_result!(transport2, t2_endpoint, init_transport2_address);
-
-        transport1.process().unwrap();
-        let _ = t1_endpoint.process(&mut None);
-
-        transport2.process().unwrap();
-        let _ = t2_endpoint.process(&mut None);
-
         assert_eq!(
             transport1.bound_url(),
             Some(expected_transport1_address.clone())

--- a/crates/lib3h_protocol/src/uri.rs
+++ b/crates/lib3h_protocol/src/uri.rs
@@ -89,6 +89,10 @@ impl Lib3hUri {
     fn parse(url_str: &str) -> Url {
         Url::parse(url_str).unwrap_or_else(|_| panic!("Invalid url format: '{}'", url_str))
     }
+
+    pub fn port(&self) -> Option<u16> {
+        self.0.port()
+    }
 }
 
 // -- Converters -- //

--- a/crates/lib3h_protocol/src/uri.rs
+++ b/crates/lib3h_protocol/src/uri.rs
@@ -117,6 +117,35 @@ impl Lib3hUri {
     pub fn with_port(&self, port: u16) -> Self {
         Builder::with_url(self.clone()).with_port(port).build()
     }
+
+    /// set a higher-level agent_id i.e. ?a=agent_id
+    pub fn set_agent_id(&mut self, agent_id: &Address) {
+        self.0
+            .query_pairs_mut()
+            .clear()
+            .append_pair("a", &agent_id.to_string());
+    }
+
+    /// clear any higher-level agent_id
+    pub fn clear_agent_id(&mut self) {
+        self.0.set_query(None);
+    }
+
+    /// do we have a higher-level agent_id? i.e. ?a=agent_id
+    pub fn agent_id(&self) -> Option<Address> {
+        for (n, v) in self.0.query_pairs() {
+            if &n == "a" {
+                return Some(v.to_string().into());
+            }
+        }
+        None
+    }
+
+    /// get our lower component as an address
+    /// i.e. transportid:HcMyada would return HcMyada
+    pub fn lower_address(&self) -> Address {
+        self.0.path().into()
+    }
 }
 
 /// Eases building of a `Lib3hUri` with a fluent api. Users need not
@@ -169,35 +198,6 @@ impl Builder {
 
     pub fn build(&self) -> Lib3hUri {
         self.url.clone().into()
-=======
-    /// set a higher-level agent_id i.e. ?a=agent_id
-    pub fn set_agent_id(&mut self, agent_id: &Address) {
-        self.0
-            .query_pairs_mut()
-            .clear()
-            .append_pair("a", &agent_id.to_string());
-    }
-
-    /// clear any higher-level agent_id
-    pub fn clear_agent_id(&mut self) {
-        self.0.set_query(None);
-    }
-
-    /// do we have a higher-level agent_id? i.e. ?a=agent_id
-    pub fn agent_id(&self) -> Option<Address> {
-        for (n, v) in self.0.query_pairs() {
-            if &n == "a" {
-                return Some(v.to_string().into());
-            }
-        }
-        None
-    }
-
-    /// get our lower component as an address
-    /// i.e. transportid:HcMyada would return HcMyada
-    pub fn lower_address(&self) -> Address {
-        self.0.path().into()
->>>>>>> cffa727668383387384e8b6d67263fab849b6c0f
     }
 }
 

--- a/crates/zombie_actor/src/ghost_test_harness.rs
+++ b/crates/zombie_actor/src/ghost_test_harness.rs
@@ -378,73 +378,6 @@ macro_rules! wait1_for_repeatable_callback {
     }};
 }
 
-#[allow(dead_code)]
-pub const DEFAULT_PORT: u16 = 0;
-
-#[allow(dead_code)]
-fn port_is_available(port: u16) -> bool {
-    match std::net::TcpListener::bind(("127.0.0.1", port)) {
-        Ok(_) => true,
-        Err(_) => false,
-    }
-}
-
-#[allow(dead_code)]
-fn get_available_port(start: u16) -> Option<u16> {
-    (start..65535).find(|port| port_is_available(*port))
-}
-
-/// Waits until a bind result is produced by a ghost transport
-#[macro_export]
-#[allow(unused_macros)]
-macro_rules! wait_for_bind_result {
-        {
-            $actor: ident,
-            $can_track: ident,
-            $init_url: expr,
-            $options: expr
-       } => {{
-           let options = $crate::ghost_test_harness::ProcessingOptions::default();
-           $crate::wait_for_bind_result!($actor, $can_track, $init_url, options)
-       }};
-       {
-            $actor: ident,
-            $can_track: ident,
-            $init_url: expr,
-            $options: expr
-       } => {{
-            let init_transport_address: $crate::lib3h_protocol::Lib3hUri = $init_url.into();
-
-            let request_fn = Box::new(|transport_address: $crate::lib3h_protocol::Lib3hUri| {
-                let old_port = transport1_address.port().unwrap_or_else(|| $crate::ghost_test_harness::DEFAULT_PORT);
-                let old_host = transport1_address.hostname().or("");
-                let old_scheme = transport1_address.raw_scheme();
-                let port = $crate::ghost_test_harness::get_available_port(old_port + 1)
-                    .expect("Must be able to find free port");
-
-                let expected_transport_address =
-                    $crate::url::Builder::with_host(old_host)
-                        .with_port(port)
-                        .with_scheme(old_scheme)
-                        .build()
-                        .unwrap();
-
-                let request = RequestToChild::Bind {
-                    spec: expected_transport_address.clone(),
-                };
-                let re = format!(
-                    "Response\\(Ok\\(Bind\\(BindResultData \\{{ bound_url: Lib3hUri\\(\"{:?}\"\\) \\}}\\)\\)\\)",
-                    expected_transport_address.to_string()
-                );
-
-                (request.clone(), re, expected_transport_address.clone())
-            });
-
-            $crate::test_wait_for_repeatable_callback!($actor, $can_track, request_fn,
-                init_transport_address, $options)
-        }}
-    }
-
 #[cfg(test)]
 mod tests {
 
@@ -639,8 +572,10 @@ mod tests {
 
         let request_fn = Box::new(|retried| {
             if retried {
+                // Test should succeed with these inputs
                 (RequestToOther::Ping, "Pong".to_string(), true)
             } else {
+                // Purposely cause the callback to be triggered again
                 (RequestToOther::Retry, "Pong".to_string(), true)
             }
         });
@@ -655,4 +590,5 @@ mod tests {
         assert!(is_match);
         assert!(retried);
     }
+
 }

--- a/crates/zombie_actor/src/ghost_test_harness.rs
+++ b/crates/zombie_actor/src/ghost_test_harness.rs
@@ -7,29 +7,60 @@
 ///
 ///
 
-pub const DEFAULT_MAX_ITERS: u16 = 10;
-pub const DEFAULT_MAX_RETRIES: u16 = 3;
+pub const DEFAULT_MAX_ITERS: u64 = 100;
+pub const DEFAULT_MAX_RETRIES: u64 = 3;
+pub const DEFAULT_DELAY_INTERVAL_MS: u64 = 1;
+pub const DEFAULT_TIMEOUT_MS: u64 = 10000;
+pub const DEFAULT_SHOULD_ABORT: bool = true;
+
+/// All configurable parameters when processing an actor.
+#[derive(Clone, Debug)]
+pub struct ProcessingOptions {
+    pub max_iters: u64,
+    pub max_retries: u64,
+    pub delay_interval_ms: u64,
+    pub timeout_ms: u64,
+    pub should_abort: bool,
+}
+
+impl ProcessingOptions {
+    pub fn with_should_abort(should_abort: bool) -> Self {
+        let options = Self {
+            should_abort,
+            ..Default::default()
+        };
+        options
+    }
+}
+
+impl Default for ProcessingOptions {
+    fn default() -> Self {
+        Self {
+            max_iters: DEFAULT_MAX_ITERS,
+            max_retries: DEFAULT_MAX_RETRIES,
+            delay_interval_ms: DEFAULT_DELAY_INTERVAL_MS,
+            timeout_ms: DEFAULT_TIMEOUT_MS,
+            should_abort: DEFAULT_SHOULD_ABORT,
+        }
+    }
+}
 
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! wait_did_work {
-    ($ghost_actor: ident,
-     $should_abort: expr
-    ) => {{
-        let timeout = std::time::Duration::from_millis(2000);
-        $crate::wait_did_work!($ghost_actor, $should_abort, timeout)
+    ($ghost_actor:ident) => {{
+        let options: $crate::ghost_test_harness::ProcessingOptions = Default::default();
+        $crate::wait_did_work!($ghost_actor, options);
     }};
-    ($ghost_actor:ident) => {
-        $crate::wait_did_work!($ghost_actor, true)
-    };
     ($ghost_actor: ident,
-     $should_abort: expr,
-     $timeout : expr
-      ) => {{
+     $options: expr
+    ) => {{
         let mut did_work = false;
         let clock = std::time::SystemTime::now();
 
-        for i in 0..$crate::ghost_test_harness::DEFAULT_MAX_ITERS {
+        let timeout = std::time::Duration::from_millis($options.timeout_ms);
+
+        for i in 0..$options.max_iters {
             did_work = $ghost_actor
                 .process()
                 .map_err(|e| error!("ghost actor processing error: {:?}", e))
@@ -39,13 +70,13 @@ macro_rules! wait_did_work {
                 break;
             }
             let elapsed = clock.elapsed().unwrap();
-            if elapsed > $timeout {
+            if elapsed > timeout {
                 break;
             }
             trace!("[{}] wait_did_work", i);
-            std::thread::sleep(std::time::Duration::from_millis(1))
+            std::thread::sleep(std::time::Duration::from_millis($options.delay_interval_ms))
         }
-        if $should_abort {
+        if $options.should_abort {
             assert!(did_work);
         }
         did_work
@@ -57,25 +88,19 @@ macro_rules! wait_did_work {
 #[macro_export]
 macro_rules! wait_can_track_did_work {
     ($ghost_can_track: ident,
-     $user_data: expr,
-     $should_abort: expr
-    ) => {{
-        let duration = std::time::Duration::from_millis(2000);
-        $crate::wait_can_track_did_work!($ghost_can_track, $user_data, $should_abort, duration)
-    }};
-    ($ghost_can_track: ident,
      $user_data: expr
     ) => {
-        wait_can_track_did_work!($ghost_can_track, $user_data, true)
+        let options: $crate::ghost_test_harness::ProcessingOptions = Default::default();
+        wait_can_track_did_work!($ghost_can_track, $user_data, options)
     };
     ($ghost_can_track: ident,
      $user_data: expr,
-     $should_abort: expr,
-     $timeout: expr
+     $options: expr
     ) => {{
         let mut did_work = false;
         let clock = std::time::SystemTime::now();
-        for i in 0..$crate::ghost_test_harness::DEFAULT_MAX_ITERS {
+        let timeout = std::time::Duration::from_millis($options.timeout_ms);
+        for i in 0..$options.max_iters {
             did_work = $ghost_can_track
                 .process(&mut $user_data)
                 .map_err(|e| error!("ghost actor processing error: {:?}", e))
@@ -85,27 +110,30 @@ macro_rules! wait_can_track_did_work {
                 break;
             }
             let elapsed = clock.elapsed().unwrap();
-            if elapsed > $timeout {
+            if elapsed > timeout {
                 break;
             }
             trace!("[{}] wait_did_work", i);
-            std::thread::sleep(std::time::Duration::from_millis(1))
+            std::thread::sleep(std::time::Duration::from_millis($options.delay_interval_ms))
         }
-        if $should_abort {
+        if $options.should_abort {
             assert!(did_work);
         }
         did_work
     }};
 }
 
-/// Continues processing the GhostActor trait until no work is being done.
+/// Continues processing the GhostActor or GhostCanTrack trait
+/// until no work is being done.
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! wait_until_no_work {
     ($ghost_actor: ident) => {{
-        let mut did_work;
-        loop {
-            did_work = $crate::wait_did_work!($ghost_actor, false);
+        let mut did_work = false;
+        let options = $crate::ghost_test_harness::ProcessingOptions::with_should_abort(false);
+
+        for _i in 0..options.max_iters {
+            did_work = $crate::wait_did_work!($ghost_actor, options);
             if !did_work {
                 break;
             }
@@ -113,9 +141,10 @@ macro_rules! wait_until_no_work {
         did_work
     }};
     ($ghost_can_track: ident, $user_data: ident) => {{
-        let mut did_work;
-        loop {
-            did_work = $crate::wait_can_track_did_work!($ghost_can_track, $user_data, false);
+        let mut did_work = false;
+        let options = $crate::ghost_test_harness::ProcessingOptions::with_should_abort(false);
+        for _i in 0..options.max_iters {
+            did_work = $crate::wait_can_track_did_work!($ghost_can_track, $user_data, options);
             if !did_work {
                 break;
             }
@@ -127,29 +156,20 @@ macro_rules! wait_until_no_work {
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! wait_for_messages {
-    ($ghost_actors: expr, $endpoint: ident, $user_data: expr, $regexes: expr) => {{
-        $crate::wait_for_messages!($ghost_actors, $endpoint, $user_data, $regexes, 5000, true)
-    }};
-    ($ghost_actors: expr, $endpoint: ident, $user_data: expr, $regexes: expr, $timeout_ms: expr) => {{
-        $crate::wait_for_messages!(
-            $ghost_actors,
-            $endpoint,
-            $user_data,
-            $regexes,
-            $timeout_ms,
-            true
-        )
+    ($ghost_actors: expr,
+     $endpoint: ident,
+     $user_data: expr,
+     $regexes: expr) => {{
+        let options: $crate::ghost_test_harness::ProcessingOptions = Default::default();
+        $crate::wait_for_messages!($ghost_actors, $endpoint, $user_data, $regexes, options)
     }};
     (
         $ghost_actors: expr,
         $endpoint: ident,
         $user_data: expr,
         $regexes: expr,
-        $timeout_ms: expr,
-        $should_abort: expr
+        $options: expr
     ) => {{
-        let mut tries = 0;
-
         let mut message_regexes: Vec<regex::Regex> = $regexes
             .into_iter()
             .map(|re| {
@@ -158,15 +178,17 @@ macro_rules! wait_for_messages {
             })
             .collect();
 
-        let POLL_INTERVAL = 2;
         let mut actors = $ghost_actors;
-        loop {
-            tries += 1;
-            std::thread::sleep(std::time::Duration::from_millis(POLL_INTERVAL));
+        for tries in 0..$options.max_iters {
+            std::thread::sleep(std::time::Duration::from_millis($options.delay_interval_ms));
             actors = actors
                 .into_iter()
                 .map(|mut actor| {
-                    let _ = $crate::wait_did_work!(actor, false);
+                    let wait_options = $crate::ghost_test_harness::ProcessingOptions {
+                        should_abort: false,
+                        ..$options
+                    };
+                    let _ = $crate::wait_did_work!(actor, wait_options);
                     actor
                 })
                 .collect::<Vec<_>>();
@@ -177,7 +199,7 @@ macro_rules! wait_for_messages {
                     .take_message()
                     .map(|message| {
                         let message_string = &format!("{:?}", message);
-                        trace!("[wait_for_messsage] drained {:?}", message_string);
+                        trace!("[wait_for_messsages] drained {:?}", message_string);
                         message_regexes
                             .into_iter()
                             .filter(|message_regex| !message_regex.is_match(message_string))
@@ -189,13 +211,15 @@ macro_rules! wait_for_messages {
                 }
             }
 
-            if message_regexes.is_empty() || tries > $timeout_ms / POLL_INTERVAL {
+            if message_regexes.is_empty()
+                || tries > $options.timeout_ms / $options.delay_interval_ms
+            {
                 break;
             }
         }
         let is_empty = message_regexes.is_empty();
 
-        if $should_abort {
+        if $options.should_abort {
             assert!(
                 is_empty,
                 "Did not receive a message matching the provided regexes"
@@ -209,35 +233,18 @@ macro_rules! wait_for_messages {
 #[macro_export]
 macro_rules! wait_for_message {
     ($ghost_actors: expr, $endpoint: ident, $user_data: expr, $regex: expr) => {{
-        $crate::wait_for_message!($ghost_actors, $endpoint, $user_data, $regex, 5000, true)
-    }};
-    ($ghost_actors: expr, $endpoint: ident, $user_data: expr, $regexes: expr, $timeout_ms: expr) => {{
-        $crate::wait_for_message!(
-            $ghost_actors,
-            $endpoint,
-            $user_data,
-            $regex,
-            $timeout_ms,
-            true
-        )
+        let options: $crate::ghost_test_harness::ProcessingOptions = Default::default();
+        $crate::wait_for_message!($ghost_actors, $endpoint, $user_data, $regex, options)
     }};
     (
         $ghost_actors: expr,
         $endpoint: ident,
         $user_data: expr,
         $regex: expr,
-        $timeout_ms: expr,
-        $should_abort: expr
+        $options: expr
     ) => {{
         let regexes = vec![$regex];
-        $crate::wait_for_messages!(
-            $ghost_actors,
-            $endpoint,
-            $user_data,
-            regexes,
-            $timeout_ms,
-            $should_abort
-        )
+        $crate::wait_for_messages!($ghost_actors, $endpoint, $user_data, regexes, $options)
     }};
 }
 
@@ -248,6 +255,10 @@ macro_rules! wait1_for_message {
         let actors = vec![&mut $ghost_actor];
         $crate::wait_for_message!(actors, $endpoint, $regex)
     }};
+    ($ghost_actor: expr, $endpoint: ident, $regex: expr, $options: expr) => {{
+        let actors = vec![&mut $ghost_actor];
+        $crate::wait_for_message!(actors, $endpoint, $regex, $options)
+    }};
 }
 
 #[allow(unused_macros)]
@@ -257,15 +268,20 @@ macro_rules! wait1_for_messages {
         let actors = vec![&mut $ghost_actor];
         $crate::wait_for_messages!(actors, $endpoint, $user_data, $regexes)
     }};
+    ($ghost_actor: expr, $endpoint: ident, $user_data: expr, $regexes: expr, $options: expr) => {{
+        let actors = vec![&mut $ghost_actor];
+        $crate::wait_for_messages!(actors, $endpoint, $user_data, $regexes, $options)
+    }};
 }
 
 #[allow(unused_macros)]
 #[macro_export]
 macro_rules! wait1_for_callback {
     ($actor: ident, $ghost_can_track: ident, $request: expr, $re: expr) => {{
-        $crate::wait1_for_callback!($actor, $ghost_can_track, $request, $re, true)
+        let options: $crate::ghost_test_harness::ProcessingOptions = Default::default();
+        $crate::wait1_for_callback!($actor, $ghost_can_track, $request, $re, options)
     }};
-    ($actor: ident, $ghost_can_track: ident, $request: expr, $re: expr, $should_abort: expr) => {{
+    ($actor: ident, $ghost_can_track: ident, $request: expr, $re: expr, $options: expr) => {{
         let regex = regex::Regex::new($re.clone())
             .expect(format!("[wait1_for_callback] invalid regex: {:?}", $re).as_str());
 
@@ -285,20 +301,24 @@ macro_rules! wait1_for_callback {
             .unwrap();
 
         let mut work_to_do = true;
-        for _iter in 0..$crate::ghost_test_harness::DEFAULT_MAX_ITERS {
+        for iter in 0..$options.max_iters {
             work_to_do |= $crate::wait_until_no_work!($actor);
             work_to_do |= $crate::wait_until_no_work!($ghost_can_track, user_data);
             if !work_to_do {
                 break;
             }
-            std::thread::sleep(std::time::Duration::from_millis(1))
+
+            if iter > $options.timeout_ms / $options.delay_interval_ms {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis($options.delay_interval_ms))
         }
 
         let actual = user_data.unwrap_or("Callback not triggered".to_string());
 
         let is_match = regex.is_match(actual.as_str());
 
-        if $should_abort {
+        if $options.should_abort {
             if is_match {
                 assert!(is_match);
             } else {
@@ -318,24 +338,28 @@ macro_rules! wait1_for_repeatable_callback {
             $ghost_can_track,
             $request_fn,
             $init_value,
-            true
+            $crate::ghost_test_harness::ProcessingOptions::default()
         )
     }};
-    ($actor: ident, $ghost_can_track: ident, $request_fn: expr, $init_value: expr, $should_abort: expr) => {{
+    ($actor: ident, $ghost_can_track: ident, $request_fn: expr, $init_value: expr, $options: expr) => {{
         let mut is_match = false;
 
         let mut state = $init_value;
-        for iter in 0..$crate::ghost_test_harness::DEFAULT_MAX_RETRIES {
+
+        for iter in 0..$options.max_retries {
             let (request, re, state_prime) = ($request_fn)(state);
             state = state_prime;
-            let should_abort =
-                $should_abort && iter == $crate::ghost_test_harness::DEFAULT_MAX_RETRIES - 1;
+            let should_abort = $options.should_abort && iter == $options.max_retries;
+            let wait_options = $crate::ghost_test_harness::ProcessingOptions {
+                should_abort: should_abort,
+                ..$options
+            };
             is_match = $crate::wait1_for_callback!(
                 $actor,
                 $ghost_can_track,
                 request,
                 re.as_str(),
-                should_abort
+                wait_options
             );
             if is_match {
                 break;
@@ -346,7 +370,7 @@ macro_rules! wait1_for_repeatable_callback {
 }
 
 #[allow(dead_code)]
-const DEFAULT_PORT : u16 = 0;
+pub const DEFAULT_PORT: u16 = 0;
 
 #[macro_export]
 macro_rules! wait_for_bind_result {
@@ -377,12 +401,11 @@ macro_rules! wait_for_bind_result {
         }}
     }
 
- 
 #[cfg(test)]
 mod tests {
 
+    use super::ProcessingOptions;
     use crate::{GhostCallback, GhostCallbackData, GhostResult, WorkWasDone};
-
     #[derive(Debug, Clone, PartialEq)]
     struct DidWorkActor(i8);
 
@@ -425,7 +448,7 @@ mod tests {
     pub type Callback = GhostCallback<Option<String>, RequestToOtherResponse, CallbackError>;
     #[allow(dead_code)]
     pub type CallbackData = GhostCallbackData<RequestToOtherResponse, CallbackError>;
-    
+
     struct CallbackParentWrapper(pub Vec<(Callback, CallbackData)>);
 
     pub type CallbackUserData = Option<String>;
@@ -470,15 +493,22 @@ mod tests {
 
         wait_did_work!(actor);
 
-        assert_eq!(false, wait_did_work!(actor, false));
+        assert_eq!(
+            false,
+            wait_did_work!(actor, ProcessingOptions::with_should_abort(false))
+        );
     }
 
     #[test]
     fn test_wait_did_work_timeout() {
         let actor = &mut DidWorkActor(-1);
 
-        let timeout = std::time::Duration::from_millis(0);
-        let did_work: bool = wait_did_work!(actor, false, timeout);
+        let options = ProcessingOptions {
+            should_abort: false,
+            timeout_ms: 0,
+            ..Default::default()
+        };
+        let did_work: bool = wait_did_work!(actor, options);
         assert_eq!(false, did_work);
     }
 
@@ -487,8 +517,12 @@ mod tests {
         let parent = &mut DidWorkParentWrapper;
         let mut actor = &mut DidWorkActor(-1);
 
-        let timeout = std::time::Duration::from_millis(0);
-        let did_work: bool = wait_can_track_did_work!(parent, actor, false, timeout);
+        let options = ProcessingOptions {
+            should_abort: false,
+            timeout_ms: 0,
+            ..Default::default()
+        };
+        let did_work: bool = wait_can_track_did_work!(parent, actor, options);
         assert_eq!(false, did_work);
     }
 
@@ -498,7 +532,10 @@ mod tests {
         let mut actor = &mut DidWorkActor(1);
         wait_can_track_did_work!(parent, actor);
 
-        assert_eq!(false, wait_can_track_did_work!(parent, actor, false));
+        assert_eq!(
+            false,
+            wait_can_track_did_work!(parent, actor, ProcessingOptions::with_should_abort(false))
+        );
     }
 
     #[test]
@@ -507,7 +544,10 @@ mod tests {
 
         wait_until_no_work!(actor);
 
-        assert_eq!(false, wait_did_work!(actor, false));
+        assert_eq!(
+            false,
+            wait_did_work!(actor, ProcessingOptions::with_should_abort(false))
+        );
     }
 
     #[test]
@@ -516,7 +556,10 @@ mod tests {
         let mut actor = &mut DidWorkActor(2);
         wait_until_no_work!(parent, actor);
 
-        assert_eq!(false, wait_can_track_did_work!(parent, actor, false));
+        assert_eq!(
+            false,
+            wait_can_track_did_work!(parent, actor, ProcessingOptions::with_should_abort(false))
+        );
     }
 
     #[test]
@@ -525,11 +568,23 @@ mod tests {
         let actor = &mut DidWorkActor(1);
 
         let request = RequestToOther::Ping;
-        let is_match = wait1_for_callback!(actor, parent, request, "Pong", false);
+        let is_match = wait1_for_callback!(
+            actor,
+            parent,
+            request,
+            "Pong",
+            ProcessingOptions::with_should_abort(false)
+        );
         assert!(is_match);
 
         let request = RequestToOther::Retry;
-        let is_match = wait1_for_callback!(actor, parent, request, "Pong", false);
+        let is_match = wait1_for_callback!(
+            actor,
+            parent,
+            request,
+            "Pong",
+            ProcessingOptions::with_should_abort(false)
+        );
         assert!(!is_match);
     }
 
@@ -546,8 +601,13 @@ mod tests {
             }
         });
 
-        let (is_match, retried) =
-            wait1_for_repeatable_callback!(actor, parent, request_fn, false, false);
+        let (is_match, retried) = wait1_for_repeatable_callback!(
+            actor,
+            parent,
+            request_fn,
+            false,
+            ProcessingOptions::with_should_abort(false)
+        );
         assert!(is_match);
         assert!(retried);
     }

--- a/crates/zombie_actor/src/ghost_test_harness.rs
+++ b/crates/zombie_actor/src/ghost_test_harness.rs
@@ -7,7 +7,7 @@
 ///
 ///
 
-pub const DEFAULT_MAX_ITERS: u64 = 20;
+pub const DEFAULT_MAX_ITERS: u64 = 100;
 pub const DEFAULT_MAX_RETRIES: u64 = 5;
 pub const DEFAULT_DELAY_INTERVAL_MS: u64 = 1;
 pub const DEFAULT_TIMEOUT_MS: u64 = 2000;

--- a/crates/zombie_actor/src/ghost_test_harness.rs
+++ b/crates/zombie_actor/src/ghost_test_harness.rs
@@ -381,32 +381,67 @@ macro_rules! wait1_for_repeatable_callback {
 #[allow(dead_code)]
 pub const DEFAULT_PORT: u16 = 0;
 
+#[allow(dead_code)]
+fn port_is_available(port: u16) -> bool {
+    match std::net::TcpListener::bind(("127.0.0.1", port)) {
+        Ok(_) => true,
+        Err(_) => false,
+    }
+}
+
+#[allow(dead_code)]
+fn get_available_port(start: u16) -> Option<u16> {
+    (start..65535).find(|port| port_is_available(*port))
+}
+
+/// Waits until a bind result is produced by a ghost transport
 #[macro_export]
+#[allow(unused_macros)]
 macro_rules! wait_for_bind_result {
         {
-            url: expr
-        } => {{
-            let init_transport1_address: Lib3hUri = url.into();
+            $actor: ident,
+            $can_track: ident,
+            $init_url: expr,
+            $options: expr
+       } => {{
+           let options = $crate::ghost_test_harness::ProcessingOptions::default();
+           $crate::wait_for_bind_result!($actor, $can_track, $init_url, options)
+       }};
+       {
+            $actor: ident,
+            $can_track: ident,
+            $init_url: expr,
+            $options: expr
+       } => {{
+            let init_transport_address: $crate::lib3h_protocol::Lib3hUri = $init_url.into();
 
-            let request_fn = Box::new(|transport1_address: Lib3hUri| {
+            let request_fn = Box::new(|transport_address: $crate::lib3h_protocol::Lib3hUri| {
                 let old_port = transport1_address.port().unwrap_or_else(|| $crate::ghost_test_harness::DEFAULT_PORT);
-                let port = get_available_port(old_port + 1).expect("Must be able to find free port");
-                let expected_transport1_address: Lib3hUri =
-                    Url::parse(&format!("wss://127.0.0.1:{}", port))
-                    .unwrap()
-                    .into();
+                let old_host = transport1_address.hostname().or("");
+                let old_scheme = transport1_address.raw_scheme();
+                let port = $crate::ghost_test_harness::get_available_port(old_port + 1)
+                    .expect("Must be able to find free port");
+
+                let expected_transport_address =
+                    $crate::url::Builder::with_host(old_host)
+                        .with_port(port)
+                        .with_scheme(old_scheme)
+                        .build()
+                        .unwrap();
 
                 let request = RequestToChild::Bind {
-                    spec: expected_transport1_address.clone(),
+                    spec: expected_transport_address.clone(),
                 };
                 let re = format!(
-                    "Response\\(Ok\\(Bind\\(BindResultData \\{{ bound_url: Lib3hUri\\(\"wss://127.0.0.1:{}/\"\\) \\}}\\)\\)\\)",
-                    port.clone(),
+                    "Response\\(Ok\\(Bind\\(BindResultData \\{{ bound_url: Lib3hUri\\(\"{:?}\"\\) \\}}\\)\\)\\)",
+                    expected_transport_address.to_string()
                 );
 
-                (request.clone(), re, expected_transport1_address.clone())
+                (request.clone(), re, expected_transport_address.clone())
             });
-            request_fn
+
+            $crate::test_wait_for_repeatable_callback!($actor, $can_track, request_fn,
+                init_transport_address, $options)
         }}
     }
 

--- a/crates/zombie_actor/src/ghost_test_harness.rs
+++ b/crates/zombie_actor/src/ghost_test_harness.rs
@@ -7,8 +7,8 @@
 ///
 ///
 
-pub const DEFAULT_MAX_ITERS: u64 = 100;
-pub const DEFAULT_MAX_RETRIES: u64 = 3;
+pub const DEFAULT_MAX_ITERS: u64 = 10;
+pub const DEFAULT_MAX_RETRIES: u64 = 5;
 pub const DEFAULT_DELAY_INTERVAL_MS: u64 = 1;
 pub const DEFAULT_TIMEOUT_MS: u64 = 10000;
 pub const DEFAULT_SHOULD_ABORT: bool = true;

--- a/crates/zombie_actor/src/ghost_test_harness.rs
+++ b/crates/zombie_actor/src/ghost_test_harness.rs
@@ -152,25 +152,23 @@ macro_rules! wait_until_no_work {
             ..options
         };
 
-        
         let clock = std::time::SystemTime::now();
 
         let timeout = std::time::Duration::from_millis(options.timeout_ms);
 
- 
         for i in 0..options.max_iters {
             did_work = $crate::wait_did_work!($ghost_actor, wait_options);
 
             if !did_work {
                 break;
             }
-            
+
             let elapsed = clock.elapsed().unwrap();
             if elapsed > timeout {
                 trace!("[epoch {}] wait_until_no_work timeout", i);
                 break;
             }
-         }
+        }
         did_work
     }};
     ($ghost_can_track: ident, $user_data: ident) => {{
@@ -181,7 +179,7 @@ macro_rules! wait_until_no_work {
             timeout_ms: $crate::ghost_test_harness::DEFAULT_WAIT_DID_WORK_TIMEOUT_MS,
             ..options
         };
- 
+
         let clock = std::time::SystemTime::now();
 
         let timeout = std::time::Duration::from_millis(options.timeout_ms);
@@ -196,7 +194,6 @@ macro_rules! wait_until_no_work {
                 trace!("[epoch {}] wait_until_no_work timeout", i);
                 break;
             }
-
         }
 
         did_work


### PR DESCRIPTION
## PR summary

Generalizes the work of #430 so its reusable by other parts of the test suite. Contributes to #414 .

- [x] make options container for ghost test harness that eases configuration of timeout, max iters, delay interval, etc. See #440.
- [x] improve uri api with a builder pattern and some utility functions so we can build a new uri with modified version of an old one easily.
- [x] make macro to try binding multiple times with different ports if necessary (eg `wait_for_bind_result!`)
- [ ] replace existing bind tests with the macro
  - [x] `test_websocket_transport_send_msg`
  - [ ] `test_websocket_transport_reconnect`

## Review checklist 
- [x] The story has unit or integration tests
- [x] No new bugs, and any tech-debt is identified and justified
- [x] There is enough API documentation (how to use)
- [x] There is enough code documentation (how the code works)
