### PR TITLE
Roll to version 0.0.11

### DIFF
--- a/crates/crypto_api/Cargo.toml
+++ b/crates/crypto_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib3h_crypto_api"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "lib3h abstract cryptography traits and data types"

--- a/crates/detach/Cargo.toml
+++ b/crates/detach/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "detach"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "helper type for being able to detach/reatach a member item"

--- a/crates/ghost_actor/Cargo.toml
+++ b/crates/ghost_actor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghost_actor"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "Actor System designed for ergonomic async request callbacks"

--- a/crates/ghost_actor/ghost_actor_derive/Cargo.toml
+++ b/crates/ghost_actor/ghost_actor_derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ghost_actor_derive"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "This is a procedural macro support crate for GhostActor: Actor System designed for ergonomic async request callbacks"
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/ghost_actor_derive"
 repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
-ghost_actor = { version = "=0.0.10", path = ".." }
+ghost_actor = { version = "=0.0.11", path = ".." }
 quote = "=1.0.2"
 
 [lib]

--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/lib3h"
 repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
-backtrace = "=0.3.14"
+backtrace = "=0.3.27"
 detach = { version = "=0.0.11", path = "../detach" }
 env_logger = "=0.6.1"
 hcid = "=0.0.6"

--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib3h"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 # crates.io stuff
@@ -13,18 +13,18 @@ documentation = "https://docs.rs/lib3h"
 repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
-backtrace = "=0.3.27"
-detach = { version = "=0.0.10", path = "../detach" }
+backtrace = "=0.3.14"
+detach = { version = "=0.0.11", path = "../detach" }
 env_logger = "=0.6.1"
 hcid = "=0.0.6"
 holochain_persistence_api = "=0.0.8"
 holochain_tracing = { version = "=0.0.1", git = "https://github.com/holochain/holochain-tracing" }
 # version on the left for release regex
-lib3h_protocol = { version = "=0.0.10", path = "../lib3h_protocol" }
-lib3h_crypto_api = { version = "=0.0.10", path = "../crypto_api" }
-lib3h_zombie_actor = { version = "=0.0.10", path = "../zombie_actor" }
-lib3h_sodium = { version = "=0.0.10", path = "../sodium" }
-lib3h_mdns = { version = "=0.0.10", path = "../mdns" }
+lib3h_protocol = { version = "=0.0.11", path = "../lib3h_protocol" }
+lib3h_crypto_api = { version = "=0.0.11", path = "../crypto_api" }
+lib3h_zombie_actor = { version = "=0.0.11", path = "../zombie_actor" }
+lib3h_sodium = { version = "=0.0.11", path = "../sodium" }
+lib3h_mdns = { version = "=0.0.11", path = "../mdns" }
 nanoid = "=0.2.0"
 tungstenite = "=0.9.1"
 url = { version = "=2.1.0", features = ["serde"] }

--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -35,7 +35,7 @@ serde = "=1.0.89"
 serde_derive = "=1.0.89"
 serde_json = "=1.0.39"
 log = "=0.4.8"
-predicates = "=1.0.0"
+predicates = "=1.0.1"
 # Should be dev only
 lazy_static = "=1.2.0"
 

--- a/crates/lib3h_protocol/Cargo.toml
+++ b/crates/lib3h_protocol/Cargo.toml
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/lib3h_protocol"
 repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
-backtrace = "=0.3.14"
+backtrace = "=0.3.27"
 base64 = "=0.10.1"
 holochain_persistence_api = "=0.0.8"
 rmp-serde = "=0.13.7"

--- a/crates/lib3h_protocol/Cargo.toml
+++ b/crates/lib3h_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib3h_protocol"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 # crates.io stuff
@@ -13,7 +13,7 @@ documentation = "https://docs.rs/lib3h_protocol"
 repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
-backtrace = "=0.3.27"
+backtrace = "=0.3.14"
 base64 = "=0.10.1"
 holochain_persistence_api = "=0.0.8"
 rmp-serde = "=0.13.7"

--- a/crates/mdns/Cargo.toml
+++ b/crates/mdns/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib3h_mdns"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "lib3h mdns LAN discovery module"
@@ -20,9 +20,9 @@ log = "0.4.8"
 zeroize = "0.10.0"
 url = "=2.1.0"
 nanoid = "0.2.0"
-lib3h_protocol = { version = "=0.0.10", path = "../lib3h_protocol" }
+lib3h_protocol = { version = "=0.0.11", path = "../lib3h_protocol" }
 
 [dev-dependencies]
-lib3h = { version = "=0.0.10", path = "../lib3h" }
-lib3h_sodium = { version = "=0.0.10", path = "../sodium" }
+lib3h = { version = "=0.0.11", path = "../lib3h" }
+lib3h_sodium = { version = "=0.0.11", path = "../sodium" }
 get_if_addrs = "0.5.3"

--- a/crates/mdns/Cargo.toml
+++ b/crates/mdns/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/lib3h_mdns"
 repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
-byteorder = "=1.3.1"
+byteorder = "=1.3.2"
 net2 = "=0.2.33"
 hostname = "^0.1"
 regex = "1.1.2"

--- a/crates/p2p_protocol/Cargo.toml
+++ b/crates/p2p_protocol/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib3h_p2p_protocol"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "Lib3h Protocol definition for inter-node p2p communication."

--- a/crates/sodium/Cargo.toml
+++ b/crates/sodium/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib3h_sodium"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "lib3h libsodium wrapper providing memory secure api access"
@@ -13,7 +13,7 @@ repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
 # keep version on the left for regex
-lib3h_crypto_api = { version = "=0.0.10", path = "../crypto_api" }
+lib3h_crypto_api = { version = "=0.0.11", path = "../crypto_api" }
 lazy_static = "=1.2.0"
 libc = "=0.2.58"
 rust_sodium = "=0.10.2"

--- a/crates/tools/capnp_build/Cargo.toml
+++ b/crates/tools/capnp_build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib3h_capnp_build"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["neonphog <neonphog@gmail.com>"]
 edition = "2018"
 

--- a/crates/tools/dump_lib3h_protocol_as_json_for_n3h/Cargo.toml
+++ b/crates/tools/dump_lib3h_protocol_as_json_for_n3h/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dump_lib3h_protocol_as_json_for_n3h"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "delete me once n3h is deprecated"
@@ -9,6 +9,6 @@ readme = "README.md"
 
 [dependencies]
 serde_json = { version = "=1.0.39", features = ["preserve_order"] }
-lib3h_protocol = { version = "=0.0.10", path = "../../lib3h_protocol" }
+lib3h_protocol = { version = "=0.0.11", path = "../../lib3h_protocol" }
 url = { version = "=2.1.0", features = ["serde"] }
 

--- a/crates/zombie_actor/Cargo.toml
+++ b/crates/zombie_actor/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "https://docs.rs/lib3h_ghost_actor"
 repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
-backtrace = "=0.3.14"
+backtrace = "=0.3.27"
 crossbeam-channel = "=0.3.8"
 detach = { version = "=0.0.11", path = "../detach" }
 holochain_tracing = { version = "=0.0.1", git = "https://github.com/holochain/holochain-tracing" }

--- a/crates/zombie_actor/Cargo.toml
+++ b/crates/zombie_actor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "lib3h_zombie_actor"
-version = "0.0.10"
+version = "0.0.11"
 authors = ["Holochain Core Dev Team <devcore@holochain.org>"]
 edition = "2018"
 description = "lib3h actor request tracking module"
@@ -12,9 +12,9 @@ documentation = "https://docs.rs/lib3h_ghost_actor"
 repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
-backtrace = "=0.3.27"
+backtrace = "=0.3.14"
 crossbeam-channel = "=0.3.8"
-detach = { version = "=0.0.10", path = "../detach" }
+detach = { version = "=0.0.11", path = "../detach" }
 holochain_tracing = { version = "=0.0.1", git = "https://github.com/holochain/holochain-tracing" }
 nanoid = "=0.2.0"
 shrinkwraprs = "=0.2.1"

--- a/crates/zombie_actor/Cargo.toml
+++ b/crates/zombie_actor/Cargo.toml
@@ -19,7 +19,7 @@ holochain_tracing = { version = "=0.0.1", git = "https://github.com/holochain/ho
 nanoid = "=0.2.0"
 shrinkwraprs = "=0.2.1"
 log = "=0.4.8"
-predicates = "=1.0.0"
+predicates = "=1.0.1"
 lazy_static = "=1.2.0"
 regex = "=1.1.2"
 [dev-dependencies]

--- a/scripts/nix/config.nix
+++ b/scripts/nix/config.nix
@@ -12,14 +12,14 @@
 
    # can be any github ref
    # branch, tag, commit, etc.
-   ref = "v0.0.33";
+   ref = "v0.0.36";
 
    # the sha of what is downloaded from the above ref
    # note: even if you change the above ref it will not be redownloaded until
    #       the sha here changes (the sha is the cache key for downloads)
    # note: to get a new sha, get nix to try and download a bad sha
    #       it will complain and tell you the right sha
-   sha256 = "1ay4pj6g04kvdsyy81wf6xwrdbyk7y4kzh2v63fpqsnslfb0wpva";
+   sha256 = "10wslqp5h8fypjp9f4bwqv0qgx9kzwk2092nkn3s3dcivlyjgav4";
 
    # the github owner of the holonix repo
    owner = "holochain";


### PR DESCRIPTION
## PR summary

In preparation for releasing version 0.0.11, change the Cargo.toml version number from 0.0.10 to 0.0.11.

Also, change some other crate version numbers to be more compatible with those required by holochain-rust.

This version is necessary, to allow cloning a SecBuf (among other things, no doubt!), in an environment where it is necessary to *read* an immutable SecBuf (ie. where we cannot invoke SecBuf::read_lock(), as it requires `&mut` access).

This is necessary, for example, in order to implement Display, Debug or De/Serialize Trait methods which render data from an immutable SecBuf.

Of course, the SecureBuffer doesn't require `&mut` access to be readable, but much of holochain-rust has not been upgraded from SecBuf to SecureBuffer.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
