### PR TITLE
fix restoring request-id when unwrapping messages

### DIFF
--- a/crates/lib3h/src/engine/ghost_engine_wrapper.rs
+++ b/crates/lib3h/src/engine/ghost_engine_wrapper.rs
@@ -115,7 +115,21 @@ where
                             ClientToLib3hResponse::LeaveSpaceResult => {
                                 server_success(request_id.clone(), space_addr, agent)
                             }
-                            _ => rsp.into(),
+                            ClientToLib3hResponse::SendDirectMessageResult(sent_data) => {
+                                let mut data = sent_data;
+                                data.request_id = request_id.clone();
+                                Lib3hServerProtocol::SendDirectMessageResult(data)
+                            }
+                            ClientToLib3hResponse::FetchEntryResult(sent_data) => {
+                                let mut data = sent_data;
+                                data.request_id = request_id.clone();
+                                Lib3hServerProtocol::FetchEntryResult(data)
+                            }
+                            ClientToLib3hResponse::QueryEntryResult(sent_data) => {
+                                let mut data = sent_data;
+                                data.request_id = request_id.clone();
+                                Lib3hServerProtocol::QueryEntryResult(data)
+                            }
                         };
                         me.client_request_responses.push(response)
                     }
@@ -468,7 +482,7 @@ mod tests {
         let data = ConnectData {
             request_id: "foo_request_id".into(),
             peer_location: Url::parse("mocknet://t1").expect("can parse url").into(),
-            network_id: "fake_id".to_string(),
+            network_id: "fake_id".into(),
         };
 
         assert!(legacy.post(Lib3hClientProtocol::Connect(data)).is_ok());


### PR DESCRIPTION
## PR summary

Lib3hServerProtocol::SendDirectMessageResult
Lib3hServerProtocol::FetchEntryResult
Lib3hServerProtocol::QueryEntryResult

were all failing to get the original request_id restored in their result data so core was unable to match the result.   This PR fixes that.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
