### PR TITLE
Use processing options in processor harness

### DIFF
--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -32,22 +32,22 @@ use test_suites::{
     three_basic::*, two_basic::*, two_connection::*, two_get_lists::*, two_spaces::*,
 };
 use url::Url;
-use utils::{constants::*, test_network_id, processor_harness::ProcessingOptions};
+use utils::{constants::*, processor_harness::ProcessingOptions, test_network_id};
 
-const TWO_MEMORY_NODES_PROCESSING_OPTIONS : ProcessingOptions = ProcessingOptions {
-    max_iters:10000,
-    delay_interval_ms:1,
-    timeout_ms:1000,
-    max_retries:3,
-    should_abort:true
+const TWO_MEMORY_NODES_PROCESSING_OPTIONS: ProcessingOptions = ProcessingOptions {
+    max_iters: 10000,
+    delay_interval_ms: 1,
+    timeout_ms: 1000,
+    max_retries: 3,
+    should_abort: true,
 };
 
-const TWO_WSS_NODES_PROCESSING_OPTIONS : ProcessingOptions = ProcessingOptions {
-    max_iters:10000,
-    delay_interval_ms:5,
-    timeout_ms:5000,
-    max_retries:3,
-    should_abort:true
+const TWO_WSS_NODES_PROCESSING_OPTIONS: ProcessingOptions = ProcessingOptions {
+    max_iters: 10000,
+    delay_interval_ms: 5,
+    timeout_ms: 5000,
+    max_retries: 3,
+    should_abort: true,
 };
 
 //--------------------------------------------------------------------------------------------------

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -32,7 +32,23 @@ use test_suites::{
     three_basic::*, two_basic::*, two_connection::*, two_get_lists::*, two_spaces::*,
 };
 use url::Url;
-use utils::{constants::*, test_network_id};
+use utils::{constants::*, test_network_id, processor_harness::ProcessingOptions};
+
+const TWO_MEMORY_NODES_PROCESSING_OPTIONS : ProcessingOptions = ProcessingOptions {
+    max_iters:20000,
+    delay_interval_ms:1,
+    timeout_ms:20000,
+    max_retries:3,
+    should_abort:true
+};
+
+const TWO_WSS_NODES_PROCESSING_OPTIONS : ProcessingOptions = ProcessingOptions {
+    max_iters:10000,
+    delay_interval_ms:5,
+    timeout_ms:10000,
+    max_retries:3,
+    should_abort:true
+};
 
 //--------------------------------------------------------------------------------------------------
 // Logging
@@ -230,7 +246,7 @@ fn launch_two_memory_nodes_test(test_fn: TwoNodesTestFn, can_setup: bool) -> Res
     }
 
     // Execute test
-    test_fn(&mut alex, &mut billy);
+    test_fn(&mut alex, &mut billy, &TWO_MEMORY_NODES_PROCESSING_OPTIONS);
 
     // Wrap-up test
     println!("========================");
@@ -391,7 +407,7 @@ fn launch_two_wss_nodes_test(
     }
 
     // Execute test
-    test_fn(&mut alex, &mut billy);
+    test_fn(&mut alex, &mut billy, &TWO_WSS_NODES_PROCESSING_OPTIONS);
 
     // Wrap-up test
     println!("========================");

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -35,9 +35,9 @@ use url::Url;
 use utils::{constants::*, test_network_id, processor_harness::ProcessingOptions};
 
 const TWO_MEMORY_NODES_PROCESSING_OPTIONS : ProcessingOptions = ProcessingOptions {
-    max_iters:20000,
+    max_iters:10000,
     delay_interval_ms:1,
-    timeout_ms:20000,
+    timeout_ms:1000,
     max_retries:3,
     should_abort:true
 };
@@ -45,7 +45,7 @@ const TWO_MEMORY_NODES_PROCESSING_OPTIONS : ProcessingOptions = ProcessingOption
 const TWO_WSS_NODES_PROCESSING_OPTIONS : ProcessingOptions = ProcessingOptions {
     max_iters:10000,
     delay_interval_ms:5,
-    timeout_ms:10000,
+    timeout_ms:5000,
     max_retries:3,
     should_abort:true
 };

--- a/crates/lib3h/tests/node_mock/methods.rs
+++ b/crates/lib3h/tests/node_mock/methods.rs
@@ -692,9 +692,9 @@ impl NodeMock {
     }
 
     /// Waits for work to be done
-    pub fn wait_did_work(&mut self, should_abort: bool) -> bool {
+    pub fn wait_did_work(&mut self) -> bool {
         let me = self;
-        wait_engine_wrapper_did_work!(me, should_abort)
+        wait_engine_wrapper_did_work!(me)
     }
 
     /// Continues processing the engine until no work is being done.

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -139,7 +139,7 @@ pub fn test_send_message(alex: &mut NodeMock, billy: &mut NodeMock, options: &Pr
     billy.send_response(&msg.request_id, &alex.agent_id(), response_content.clone());
 
     let expected = "SendDirectMessageResult\\(DirectMessageData \\{ space_address: HashString\\(\"\\w+\"\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"alex\"\\), from_agent_id: HashString\\(\"billy\"\\), content: \"echo: wah\" \\}\\)";
-    assert2_msg_matches!(alex, billy, expected);
+    assert2_msg_matches!(alex, billy, expected, options);
 }
 
 /// Test SendDirectMessage and response failure

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -1,12 +1,13 @@
 use crate::{
     node_mock::{test_join_space, NodeMock},
     utils::constants::*,
+    utils::processor_harness::ProcessingOptions
 };
 use lib3h_protocol::{data_types::*, protocol_server::Lib3hServerProtocol, Address};
 use rmp_serde::Deserializer;
 use serde::Deserialize;
 
-pub type TwoNodesTestFn = fn(alex: &mut NodeMock, billy: &mut NodeMock);
+pub type TwoNodesTestFn = fn(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions);
 
 lazy_static! {
     pub static ref TWO_NODES_BASIC_TEST_FNS: Vec<(TwoNodesTestFn, bool)> = vec![
@@ -101,6 +102,7 @@ pub fn two_join_space(alex: &mut NodeMock, billy: &mut NodeMock, space_address: 
     test_join_space(billy, space_address);
 
     // Extra processing required for auto-handshaking
+    // TODO figure out something to explicitly wait on (eg. a drained message)
     wait_engine_wrapper_until_no_work!(alex);
     wait_engine_wrapper_until_no_work!(billy);
     wait_engine_wrapper_until_no_work!(alex);
@@ -113,17 +115,17 @@ pub fn two_join_space(alex: &mut NodeMock, billy: &mut NodeMock, space_address: 
 
 /// Empty function that triggers the test suite
 #[allow(dead_code)]
-fn test_setup_only(_alex: &mut NodeMock, _billy: &mut NodeMock) {
+fn test_setup_only(_alex: &mut NodeMock, _billy: &mut NodeMock, _options: &ProcessingOptions) {
     // n/a
 }
 
 /// Test SendDirectMessage and response
-pub fn test_send_message(alex: &mut NodeMock, billy: &mut NodeMock) {
+pub fn test_send_message(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     // Send DM
     let _req_id = alex.send_direct_message(&BILLY_AGENT_ID, "wah".as_bytes().to_vec());
 
     let expected = "HandleSendDirectMessage\\(DirectMessageData \\{ space_address: HashString\\(\"\\w+\"\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"billy\"\\), from_agent_id: HashString\\(\"alex\"\\), content: \"wah\" \\}\\)";
-    let results = assert2_msg_matches!(alex, billy, expected);
+    let results = assert2_msg_matches!(alex, billy, expected, options);
     let handle_send_direct_msg = results.first().unwrap();
     let event = handle_send_direct_msg.events.first().unwrap();
     let msg = unwrap_to!(event => Lib3hServerProtocol::HandleSendDirectMessage);
@@ -142,23 +144,23 @@ pub fn test_send_message(alex: &mut NodeMock, billy: &mut NodeMock) {
 
 /// Test SendDirectMessage and response failure
 #[allow(dead_code)]
-fn test_send_message_fail(alex: &mut NodeMock, _billy: &mut NodeMock) {
+fn test_send_message_fail(alex: &mut NodeMock, _billy: &mut NodeMock, options: &ProcessingOptions) {
     trace!("[test_send_message_fail] alex send to camille");
     // Send to unknown
     let _req_id = alex.send_direct_message(&CAMILLE_AGENT_ID, "wah".as_bytes().to_vec());
 
     let expected = "FailureResult\\(GenericResultData \\{ request_id: \"req_alex_3\", space_address: HashString\\(\"appA\"\\), to_agent_id: HashString\\(\"camille\"\\), result_info: ";
-    assert_msg_matches!(alex, expected);
+    assert_msg_matches!(alex, expected, options);
 }
 
 /// Test SendDirectMessage and response to self
-pub fn test_send_message_self(alex: &mut NodeMock, _billy: &mut NodeMock) {
+pub fn test_send_message_self(alex: &mut NodeMock, _billy: &mut NodeMock, options: &ProcessingOptions) {
     // Send DM
     let _req_id = alex.send_direct_message(&ALEX_AGENT_ID, "wah".as_bytes().to_vec());
 
     let expected = "HandleSendDirectMessage\\(DirectMessageData \\{ space_address: HashString\\(\"appA\"\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"alex\"\\), from_agent_id: HashString\\(\"alex\"\\), content: \"wah\" \\}\\)";
 
-    let results = assert_msg_matches!(alex, expected);
+    let results = assert_msg_matches!(alex, expected, options);
 
     let handle_send_direct_msg = results.first().unwrap();
 
@@ -177,19 +179,19 @@ pub fn test_send_message_self(alex: &mut NodeMock, _billy: &mut NodeMock) {
     // TODO Set this to correct value once test passes
     let expected = "SendDirectMessageResult\\(DirectMessageData \\{ space_address: HashString\\(\"appA\"\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"alex\"\\), from_agent_id: HashString\\(\"alex\"\\), content: \"echo: wah\" \\}\\)";
 
-    assert_msg_matches!(alex, expected);
+    assert_msg_matches!(alex, expected, options);
 }
 
 /// Test publish, Store, Query
 #[allow(dead_code)]
-pub fn test_author_one_aspect(alex: &mut NodeMock, billy: &mut NodeMock) {
+pub fn test_author_one_aspect(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     // Alex publish data on the network
     let entry = alex
         .author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
         .unwrap();
 
     let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: HashString\\(\"\\w+\"\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), entry_aspect: EntryAspectData \\{ aspect_address: HashString\\(\"[\\w\\d]+\"\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Billy asks for that entry
     // =========================
@@ -199,7 +201,7 @@ pub fn test_author_one_aspect(alex: &mut NodeMock, billy: &mut NodeMock) {
     // ============================
     let mut query_data = billy.request_entry(ENTRY_ADDRESS_2.clone());
     let expected = "HandleQueryEntry\\(QueryEntryData \\{ space_address: HashString\\(\"\\w+\"\\), entry_address: HashString\\(\"entry_addr_2\"\\), request_id: \"[\\w\\d_~]+\", requester_agent_id: HashString\\(\"billy\"\\), query: \"test_query\" \\}\\)";
-    let results = assert2_msg_matches!(alex, billy, expected);
+    let results = assert2_msg_matches!(alex, billy, expected, options);
     println!("\n results: {:?}\n", results);
     let handle_query = &results[0].events[0];
     println!("\n query_data: {:?}\n", query_data);
@@ -224,7 +226,7 @@ pub fn test_author_one_aspect(alex: &mut NodeMock, billy: &mut NodeMock) {
 
 /// Entry with no Aspect case: Should no-op
 #[allow(dead_code)]
-fn test_author_no_aspect(alex: &mut NodeMock, billy: &mut NodeMock) {
+fn test_author_no_aspect(alex: &mut NodeMock, billy: &mut NodeMock, _options: &ProcessingOptions) {
     // Alex publish data on the network
     alex.author_entry(&ENTRY_ADDRESS_1, vec![], true).unwrap();
     let (did_work, srv_msg_list) = alex.process().unwrap();
@@ -244,7 +246,7 @@ fn test_author_no_aspect(alex: &mut NodeMock, billy: &mut NodeMock) {
 
 /// Entry with two aspects case
 #[allow(dead_code)]
-fn test_author_two_aspects(alex: &mut NodeMock, billy: &mut NodeMock) {
+fn test_author_two_aspects(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     // Alex authors and broadcast an entry on the space
     let _entry = alex
         .author_entry(
@@ -257,7 +259,7 @@ fn test_author_two_aspects(alex: &mut NodeMock, billy: &mut NodeMock) {
     assert_eq!(srv_msg_list.len(), 2);
 
     let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: HashString\\(\"appA\"\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), entry_aspect: EntryAspectData \\{ aspect_address: HashString\\(\"[\\w\\d]+\"\\), type_hint: \"NodeMock\", aspect: \"[\\w\\d\\-]+\", publish_ts: \\d+ \\} \\}\\)";
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let _results = assert2_msg_matches!(alex, billy, expected, options);
     let mut entry = billy.get_entry(&ENTRY_ADDRESS_1).unwrap();
     entry.aspect_list.sort();
     assert_eq!(entry.aspect_list.len(), 2);
@@ -268,7 +270,7 @@ fn test_author_two_aspects(alex: &mut NodeMock, billy: &mut NodeMock) {
 
 /// Entry with two aspects case
 #[allow(dead_code)]
-fn test_two_authors(alex: &mut NodeMock, billy: &mut NodeMock) {
+fn test_two_authors(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     // Alex authors and broadcast first aspect
     // =======================================
     let _ = alex
@@ -278,7 +280,7 @@ fn test_two_authors(alex: &mut NodeMock, billy: &mut NodeMock) {
     assert_eq!(srv_msg_list.len(), 1);
 
     let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: HashString\\(\"appA\"\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), entry_aspect: EntryAspectData \\{ aspect_address: HashString\\(\"[\\w\\d]+\"\\), type_hint: \"NodeMock\", aspect: \"[\\w\\d\\-]+\", publish_ts: \\d+ \\} \\}\\)";
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Billy authors and broadcast second aspect
     // =========================================
@@ -289,7 +291,7 @@ fn test_two_authors(alex: &mut NodeMock, billy: &mut NodeMock) {
     assert_eq!(srv_msg_list.len(), 1);
 
     let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: HashString\\(\"appA\"\\), provider_agent_id: HashString\\(\"[\\w\\d]+\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), entry_aspect: EntryAspectData \\{ aspect_address: HashString\\(\"[\\w\\d]+\"\\), type_hint: \"NodeMock\", aspect: \"[\\w\\d\\-]+\", publish_ts: \\d+ \\} \\}\\)";
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Alex asks for that entry
     let entry = NodeMock::form_EntryData(

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -1,13 +1,13 @@
 use crate::{
     node_mock::{test_join_space, NodeMock},
-    utils::constants::*,
-    utils::processor_harness::ProcessingOptions
+    utils::{constants::*, processor_harness::ProcessingOptions},
 };
 use lib3h_protocol::{data_types::*, protocol_server::Lib3hServerProtocol, Address};
 use rmp_serde::Deserializer;
 use serde::Deserialize;
 
-pub type TwoNodesTestFn = fn(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions);
+pub type TwoNodesTestFn =
+    fn(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions);
 
 lazy_static! {
     pub static ref TWO_NODES_BASIC_TEST_FNS: Vec<(TwoNodesTestFn, bool)> = vec![
@@ -154,7 +154,11 @@ fn test_send_message_fail(alex: &mut NodeMock, _billy: &mut NodeMock, options: &
 }
 
 /// Test SendDirectMessage and response to self
-pub fn test_send_message_self(alex: &mut NodeMock, _billy: &mut NodeMock, options: &ProcessingOptions) {
+pub fn test_send_message_self(
+    alex: &mut NodeMock,
+    _billy: &mut NodeMock,
+    options: &ProcessingOptions,
+) {
     // Send DM
     let _req_id = alex.send_direct_message(&ALEX_AGENT_ID, "wah".as_bytes().to_vec());
 
@@ -184,7 +188,11 @@ pub fn test_send_message_self(alex: &mut NodeMock, _billy: &mut NodeMock, option
 
 /// Test publish, Store, Query
 #[allow(dead_code)]
-pub fn test_author_one_aspect(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
+pub fn test_author_one_aspect(
+    alex: &mut NodeMock,
+    billy: &mut NodeMock,
+    options: &ProcessingOptions,
+) {
     // Alex publish data on the network
     let entry = alex
         .author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)

--- a/crates/lib3h/tests/test_suites/two_connection.rs
+++ b/crates/lib3h/tests/test_suites/two_connection.rs
@@ -22,7 +22,7 @@ lazy_static! {
 //--------------------------------------------------------------------------------------------------
 
 /// Have Alex disconnect and reconnect TODO Issue #236
-fn test_two_disconnect(alex: &mut NodeMock, billy: &mut NodeMock) {
+fn test_two_disconnect(alex: &mut NodeMock, billy: &mut NodeMock, _options: &ProcessingOptions) {
     alex.disconnect();
     let (did_work, srv_msg_list) = alex.process().unwrap();
     assert_eq!(srv_msg_list.len(), 0);
@@ -39,8 +39,9 @@ fn test_two_disconnect(alex: &mut NodeMock, billy: &mut NodeMock) {
 }
 
 /// Wait for peer timeout
-fn test_two_gossip_self(alex: &mut NodeMock, billy: &mut NodeMock) {
+fn test_two_gossip_self(alex: &mut NodeMock, billy: &mut NodeMock, _options: &ProcessingOptions) {
     // Wait before peer Timeout threshold
+    // TODO make a faster way to test this, such as reducing the time out value in the config
     std::thread::sleep(std::time::Duration::from_millis(1000));
     // Billy should send a PeerTimedOut message
     let (did_work, srv_msg_list) = billy.process().unwrap();
@@ -59,6 +60,7 @@ fn test_two_gossip_self(alex: &mut NodeMock, billy: &mut NodeMock) {
     let (_did_work, _srv_msg_list) = alex.process().unwrap();
 
     // Wait past peer Timeout threshold
+    // TODO make a faster way to test this
     std::thread::sleep(std::time::Duration::from_millis(2100));
     // Billy should not see a PeerTimedOut message
     let (did_work, srv_msg_list) = billy.process().unwrap();
@@ -69,7 +71,7 @@ fn test_two_gossip_self(alex: &mut NodeMock, billy: &mut NodeMock) {
 
 /// Wait for peer timeout
 #[allow(dead_code)]
-fn test_two_peer_timeout(alex: &mut NodeMock, billy: &mut NodeMock) {
+fn test_two_peer_timeout(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     // Wait before peer Timeout threshold
     std::thread::sleep(std::time::Duration::from_millis(1000));
     // Billy should NOT send a PeerTimedOut message
@@ -79,19 +81,20 @@ fn test_two_peer_timeout(alex: &mut NodeMock, billy: &mut NodeMock) {
     // Wait past peer Timeout threshold
     std::thread::sleep(std::time::Duration::from_millis(2100));
     // Billy SHOULD send a PeerTimedOut message ...
-    let processor = Box::new(Lib3hServerProtocolEquals(
-        Lib3hServerProtocol::Disconnected(lib3h_protocol::data_types::DisconnectedData {
-            network_id: "FIXME".into(), // TODO
-        }),
-    ));
-    assert2_processed!(alex, billy, processor);
+
+    let equal_to = Lib3hServerProtocol::Disconnected(lib3h_protocol::data_types::DisconnectedData {
+        network_id: "FIXME".into(), // TODO
+    });
+
+    assert2_msg_eq!(alex, billy, equal_to, options);
 }
 
 /// Wait for peer timeout than reconnect
 #[allow(dead_code)]
 fn test_two_peer_timeout_reconnect(
-    /*mut*/ alex: &mut NodeMock,
-    /*mut */ billy: &mut NodeMock,
+    alex: &mut NodeMock,
+    billy: &mut NodeMock,
+    options: &ProcessingOptions
 ) {
     // Wait past peer Timeout threshold
     // TODO make this timeout much faster or mock time
@@ -115,13 +118,13 @@ fn test_two_peer_timeout_reconnect(
 
     alex.wait_until_no_work();
     billy.wait_until_no_work();
-    test_send_message(alex, billy);
-    test_author_one_aspect(alex, billy);
+    test_send_message(alex, billy, options);
+    test_author_one_aspect(alex, billy, options);
 }
 
 /// Have Alex disconnect and reconnect
 #[allow(dead_code)]
-fn test_two_reconnect(alex: &mut NodeMock, billy: &mut NodeMock) {
+fn test_two_reconnect(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     alex.disconnect();
     let (did_work, srv_msg_list) = alex.process().unwrap();
     assert_eq!(srv_msg_list.len(), 0);
@@ -144,10 +147,11 @@ fn test_two_reconnect(alex: &mut NodeMock, billy: &mut NodeMock) {
 
     wait_connect!(billy, connect_data, alex);
 
+    // TODO wait for an explicit message instead
     alex.wait_until_no_work();
     billy.wait_until_no_work();
     alex.wait_until_no_work();
 
-    test_send_message(alex, billy);
-    test_author_one_aspect(alex, billy);
+    test_send_message(alex, billy, options);
+    test_author_one_aspect(alex, billy, options);
 }

--- a/crates/lib3h/tests/test_suites/two_connection.rs
+++ b/crates/lib3h/tests/test_suites/two_connection.rs
@@ -82,9 +82,10 @@ fn test_two_peer_timeout(alex: &mut NodeMock, billy: &mut NodeMock, options: &Pr
     std::thread::sleep(std::time::Duration::from_millis(2100));
     // Billy SHOULD send a PeerTimedOut message ...
 
-    let equal_to = Lib3hServerProtocol::Disconnected(lib3h_protocol::data_types::DisconnectedData {
-        network_id: "FIXME".into(), // TODO
-    });
+    let equal_to =
+        Lib3hServerProtocol::Disconnected(lib3h_protocol::data_types::DisconnectedData {
+            network_id: "FIXME".into(), // TODO
+        });
 
     assert2_msg_eq!(alex, billy, equal_to, options);
 }
@@ -94,7 +95,7 @@ fn test_two_peer_timeout(alex: &mut NodeMock, billy: &mut NodeMock, options: &Pr
 fn test_two_peer_timeout_reconnect(
     alex: &mut NodeMock,
     billy: &mut NodeMock,
-    options: &ProcessingOptions
+    options: &ProcessingOptions,
 ) {
     // Wait past peer Timeout threshold
     // TODO make this timeout much faster or mock time

--- a/crates/lib3h/tests/test_suites/two_get_lists.rs
+++ b/crates/lib3h/tests/test_suites/two_get_lists.rs
@@ -1,7 +1,7 @@
 use crate::{
     node_mock::NodeMock,
     test_suites::two_basic::{request_entry_ok, TwoNodesTestFn},
-    utils::{processor_harness::ProcessingOptions, constants::*},
+    utils::{constants::*, processor_harness::ProcessingOptions},
 };
 use lib3h_protocol::protocol_server::Lib3hServerProtocol;
 
@@ -79,7 +79,11 @@ pub fn hold_list_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &Proce
 }
 
 ///
-pub fn empty_author_list_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
+pub fn empty_author_list_test(
+    alex: &mut NodeMock,
+    billy: &mut NodeMock,
+    options: &ProcessingOptions,
+) {
     // Alex replies an empty list to the initial HandleGetAuthoringEntryList
     alex.reply_to_first_HandleGetAuthoringEntryList();
 
@@ -114,7 +118,11 @@ pub fn empty_author_list_test(alex: &mut NodeMock, billy: &mut NodeMock, options
 }
 
 /// Return author_list with already known entry
-pub fn author_list_known_entry_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
+pub fn author_list_known_entry_test(
+    alex: &mut NodeMock,
+    billy: &mut NodeMock,
+    options: &ProcessingOptions,
+) {
     let entry = alex
         .author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
         .unwrap();
@@ -124,7 +132,11 @@ pub fn author_list_known_entry_test(alex: &mut NodeMock, billy: &mut NodeMock, o
     alex.reply_to_first_HandleGetAuthoringEntryList();
     // Should not receive a HandleFetchEntry request from network module after receiving list
     let expected = "None";
-    let fast_timeout_options = ProcessingOptions { max_iters:5, timeout_ms:5, ..options.clone() };
+    let fast_timeout_options = ProcessingOptions {
+        max_iters: 5,
+        timeout_ms: 5,
+        ..options.clone()
+    };
     let _results = assert2_msg_matches!(alex, billy, expected, fast_timeout_options);
 
     // Billy asks for that entry

--- a/crates/lib3h/tests/test_suites/two_get_lists.rs
+++ b/crates/lib3h/tests/test_suites/two_get_lists.rs
@@ -1,7 +1,7 @@
 use crate::{
     node_mock::NodeMock,
     test_suites::two_basic::{request_entry_ok, TwoNodesTestFn},
-    utils::constants::*,
+    utils::{processor_harness::ProcessingOptions, constants::*},
 };
 use lib3h_protocol::protocol_server::Lib3hServerProtocol;
 
@@ -20,7 +20,7 @@ lazy_static! {
 //--------------------------------------------------------------------------------------------------
 
 /// Return some entry in authoring_list request
-pub fn author_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
+pub fn author_list_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     // author an entry without publishing it
     let entry = alex
         .author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], false)
@@ -30,7 +30,7 @@ pub fn author_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
 
     // Should receive a HandleFetchEntry request from network module after receiving list
     let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: HashString\\(\"appA\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: HashString\\(\"alex\"\\), aspect_address_list: None \\}\\)";
-    let results = assert2_msg_matches!(alex, billy, expected);
+    let results = assert2_msg_matches!(alex, billy, expected, options);
     let fetch_event = &results[0].events[0];
     // extract msg data
     let fetch_data = unwrap_to!(fetch_event => Lib3hServerProtocol::HandleFetchEntry);
@@ -41,14 +41,14 @@ pub fn author_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
 
     // Expecting a HandleStoreEntryAspect
     let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: HashString\\(\"\\w+\"\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), entry_aspect: EntryAspectData \\{ aspect_address: HashString\\(\"[\\w\\d]+\"\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Billy asks for that entry
     request_entry_ok(billy, &entry);
 }
 
 /// Return some entry in gossiping_list request
-pub fn hold_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
+pub fn hold_list_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     // Have alex hold some data
     let entry = alex
         .hold_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()])
@@ -58,7 +58,7 @@ pub fn hold_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
 
     // Should receive a HandleFetchEntry request from network module after receiving list
     let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: HashString\\(\"appA\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: HashString\\(\"alex\"\\), aspect_address_list: None \\}\\)";
-    let results = assert2_msg_matches!(alex, billy, expected);
+    let results = assert2_msg_matches!(alex, billy, expected, options);
     let fetch_event = &results[0].events[0];
     // extract msg data
     let fetch_data = unwrap_to!(fetch_event => Lib3hServerProtocol::HandleFetchEntry);
@@ -72,19 +72,19 @@ pub fn hold_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
 
     // Expect HandleStoreEntryAspect from receiving entry via gossip
     let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: HashString\\(\"\\w+\"\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), entry_aspect: EntryAspectData \\{ aspect_address: HashString\\(\"[\\w\\d]+\"\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Billy asks for that entry
     request_entry_ok(billy, &entry);
 }
 
 ///
-pub fn empty_author_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
+pub fn empty_author_list_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     // Alex replies an empty list to the initial HandleGetAuthoringEntryList
     alex.reply_to_first_HandleGetAuthoringEntryList();
 
     let expected = "None";
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Billy asks for unpublished data.
     println!("\n{} requesting entry: ENTRY_ADDRESS_1\n", billy.name());
@@ -92,7 +92,7 @@ pub fn empty_author_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
 
     // Receives back the HandleQuery
     let expected = "HandleQueryEntry\\(QueryEntryData \\{ space_address: HashString\\(\"appA\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), request_id: \"[\\w\\d_~]+\", requester_agent_id: HashString\\(\"billy\"\\), query: \"test_query\" \\}\\)";
-    let results = assert2_msg_matches!(alex, billy, expected);
+    let results = assert2_msg_matches!(alex, billy, expected, options);
     let query_event = &results[0].events[0];
     // extract msg data
     let query_data = unwrap_to!(query_event => Lib3hServerProtocol::HandleQueryEntry);
@@ -114,24 +114,25 @@ pub fn empty_author_list_test(alex: &mut NodeMock, billy: &mut NodeMock) {
 }
 
 /// Return author_list with already known entry
-pub fn author_list_known_entry_test(alex: &mut NodeMock, billy: &mut NodeMock) {
+pub fn author_list_known_entry_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     let entry = alex
         .author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
         .unwrap();
     let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: HashString\\(\"\\w+\"\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), entry_aspect: EntryAspectData \\{ aspect_address: HashString\\(\"[\\w\\d]+\"\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     alex.reply_to_first_HandleGetAuthoringEntryList();
     // Should not receive a HandleFetchEntry request from network module after receiving list
     let expected = "None";
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let fast_timeout_options = ProcessingOptions { max_iters:5, timeout_ms:5, ..options.clone() };
+    let _results = assert2_msg_matches!(alex, billy, expected, fast_timeout_options);
 
     // Billy asks for that entry
     request_entry_ok(billy, &entry);
 }
 
 /// Return lots of entries
-pub fn many_aspects_test(alex: &mut NodeMock, billy: &mut NodeMock) {
+pub fn many_aspects_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     // Author & hold several aspects on same address
     alex.author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
         .unwrap();
@@ -145,7 +146,9 @@ pub fn many_aspects_test(alex: &mut NodeMock, billy: &mut NodeMock) {
     println!("\nAlex authored and stored Aspects \n");
 
     let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: HashString\\(\"appA\"\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), entry_aspect: EntryAspectData \\{ aspect_address: HashString\\(\"[\\w\\d]+\"\\), type_hint: \"NodeMock\", aspect: \"[\\w\\d\\-]+\", publish_ts: \\d+ \\} \\}\\)";
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let _results = assert2_msg_matches!(alex, billy, expected, options);
+
+    // TODO figure out something to explicit wait for
     wait_engine_wrapper_until_no_work!(alex);
     wait_engine_wrapper_until_no_work!(billy);
 
@@ -156,7 +159,7 @@ pub fn many_aspects_test(alex: &mut NodeMock, billy: &mut NodeMock) {
 
     // Should receive a HandleFetchEntry request from network module after receiving authoring list
     let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: HashString\\(\"appA\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: HashString\\(\"alex\"\\), aspect_address_list: None \\}\\)";
-    let results = assert2_msg_matches!(alex, billy, expected);
+    let results = assert2_msg_matches!(alex, billy, expected, options);
     let fetch_event = &results[0].events[0];
     // extract msg data
     let fetch_data = unwrap_to!(fetch_event => Lib3hServerProtocol::HandleFetchEntry);
@@ -166,7 +169,7 @@ pub fn many_aspects_test(alex: &mut NodeMock, billy: &mut NodeMock) {
         .expect("Reply to HandleFetchEntry should work");
 
     let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: HashString\\(\"\\w+\"\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: HashString\\(\"entry_addr_1\"\\), entry_aspect: EntryAspectData \\{ aspect_address: HashString\\(\"[\\w\\d]+\"\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let _results = assert2_msg_matches!(alex, billy, expected, options);
     let mut entry = billy.get_entry(&ENTRY_ADDRESS_1).unwrap();
     entry.aspect_list.sort();
     assert_eq!(entry.aspect_list.len(), 3);
@@ -178,8 +181,8 @@ pub fn many_aspects_test(alex: &mut NodeMock, billy: &mut NodeMock) {
 
     // Should receive a HandleFetchEntry request from network module after receiving list
     let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: HashString\\(\"appA\"\\), entry_address: HashString\\(\"entry_addr_2\"\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: HashString\\(\"alex\"\\), aspect_address_list: None \\}\\)";
-    let results = assert2_msg_matches!(alex, billy, expected);
-    println!("results: {:?}", results);
+    let results = assert2_msg_matches!(alex, billy, expected, options);
+    trace!("results: {:?}", results);
     // Get FetchEntryData for ENTRY_ADDRESS_2
     let mut maybe_fetch_data = None;
     for process_result in results {
@@ -192,17 +195,17 @@ pub fn many_aspects_test(alex: &mut NodeMock, billy: &mut NodeMock) {
         }
     }
     let fetch_data = maybe_fetch_data.unwrap();
-    println!("fetch_data: {:?}", fetch_data);
+    debug!("fetch_data: {:?}", fetch_data);
 
     // #fullsync - mirrorDht will ask for content right away
     // Respond to fetch
-    println!("Respond to fetch... ");
+    debug!("Respond to fetch... ");
     alex.reply_to_HandleFetchEntry(&fetch_data)
         .expect("Reply to HandleFetchEntry should work");
-    println!("Waiting for HandleStoreEntryAspect... ");
+    debug!("Waiting for HandleStoreEntryAspect... ");
     // Expect HandleStoreEntryAspect from receiving entry via gossip
     let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: HashString\\(\"\\w+\"\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: HashString\\(\"entry_addr_2\"\\), entry_aspect: EntryAspectData \\{ aspect_address: HashString\\(\"[\\w\\d]+\"\\), type_hint: \"NodeMock\", aspect: \"other-4\", publish_ts: \\d+ \\} \\}\\)";
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Billy asks for that entry
     request_entry_ok(billy, &entry_2);

--- a/crates/lib3h/tests/test_suites/two_spaces.rs
+++ b/crates/lib3h/tests/test_suites/two_spaces.rs
@@ -3,7 +3,7 @@ use crate::{
     test_suites::two_basic::{
         test_author_one_aspect, test_send_message, two_join_space, TwoNodesTestFn,
     },
-    utils::constants::*,
+    utils::{processor_harness::ProcessingOptions, constants::*},
 };
 use lib3h_protocol::protocol_server::Lib3hServerProtocol;
 
@@ -17,7 +17,7 @@ lazy_static! {
 }
 
 /// Sending a Message before doing a 'TrackDna' should fail
-pub fn test_leave_space(alex: &mut NodeMock, billy: &mut NodeMock) {
+pub fn test_leave_space(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     // LeaveSpace
     let req_id = alex
         .leave_current_space()
@@ -49,7 +49,7 @@ pub fn test_leave_space(alex: &mut NodeMock, billy: &mut NodeMock) {
     println!("\n Billy trying to send DirectMessage...\n");
     let _req_id = billy.send_direct_message(&ALEX_AGENT_ID, ASPECT_CONTENT_1.clone());
     let expected = "None";
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Alex sends a message to self
     // ============================
@@ -63,7 +63,7 @@ pub fn test_leave_space(alex: &mut NodeMock, billy: &mut NodeMock) {
 }
 
 /// Sending a Message before doing a 'TrackDna' should fail
-pub fn test_rejoining(alex: &mut NodeMock, billy: &mut NodeMock) {
+pub fn test_rejoining(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     // Alex LeaveSpace
     let req_id = alex
         .leave_current_space()
@@ -79,7 +79,7 @@ pub fn test_rejoining(alex: &mut NodeMock, billy: &mut NodeMock) {
     two_join_space(alex, billy, &SPACE_ADDRESS_A);
     // Do some test
     println!("\nTest send DirectMessage...\n");
-    test_send_message(alex, billy);
+    test_send_message(alex, billy, options);
 
     // Alex re-joins again
     println!("\nAlex re-joins again...\n");
@@ -94,7 +94,7 @@ pub fn test_rejoining(alex: &mut NodeMock, billy: &mut NodeMock) {
 }
 
 /// Sending a Message before doing a 'TrackDna' should fail
-pub fn test_multispace_send(alex: &mut NodeMock, billy: &mut NodeMock) {
+pub fn test_multispace_send(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     // Alex LeaveSpace
     let req_id = alex
         .leave_current_space()
@@ -112,7 +112,7 @@ pub fn test_multispace_send(alex: &mut NodeMock, billy: &mut NodeMock) {
     println!("\n Test send DirectMessage in space B...\n");
     alex.set_current_space(&SPACE_ADDRESS_B);
     billy.set_current_space(&SPACE_ADDRESS_B);
-    test_send_message(alex, billy);
+    test_send_message(alex, billy, options);
     wait_engine_wrapper_until_no_work!(alex);
     wait_engine_wrapper_until_no_work!(billy);
 
@@ -121,7 +121,7 @@ pub fn test_multispace_send(alex: &mut NodeMock, billy: &mut NodeMock) {
     println!("\n Test send DirectMessage in space C...\n");
     alex.set_current_space(&SPACE_ADDRESS_C);
     billy.set_current_space(&SPACE_ADDRESS_C);
-    test_send_message(alex, billy);
+    test_send_message(alex, billy, options);
     wait_engine_wrapper_until_no_work!(alex);
     wait_engine_wrapper_until_no_work!(billy);
 
@@ -133,11 +133,11 @@ pub fn test_multispace_send(alex: &mut NodeMock, billy: &mut NodeMock) {
     let _req_id = alex.send_direct_message(&BILLY_AGENT_ID, "marco".as_bytes().to_vec());
     let expected = "FailureResult\\(GenericResultData \\{ request_id: \"req_alex_8\", space_address: HashString\\(\"appA\"\\), to_agent_id: HashString\\(\"billy\"\\), result_info: ";
 
-    let _results = assert2_msg_matches!(alex, billy, expected);
+    let _results = assert2_msg_matches!(alex, billy, expected, options);
 }
 
 /// Sending a Message before doing a 'TrackDna' should fail
-pub fn test_multispace_dht(alex: &mut NodeMock, billy: &mut NodeMock) {
+pub fn test_multispace_dht(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
     // Alex LeaveSpace
     let req_id = alex
         .leave_current_space()
@@ -153,12 +153,12 @@ pub fn test_multispace_dht(alex: &mut NodeMock, billy: &mut NodeMock) {
     println!("\nTest send DirectMessage in space B...\n");
     alex.set_current_space(&SPACE_ADDRESS_B);
     billy.set_current_space(&SPACE_ADDRESS_B);
-    test_author_one_aspect(alex, billy);
+    test_author_one_aspect(alex, billy, options);
 
     // Author entry on SPACE C
     // =======================
     println!("\nTest send DirectMessage in space C...\n");
     alex.set_current_space(&SPACE_ADDRESS_C);
     billy.set_current_space(&SPACE_ADDRESS_C);
-    test_author_one_aspect(alex, billy);
+    test_author_one_aspect(alex, billy, options);
 }

--- a/crates/lib3h/tests/test_suites/two_spaces.rs
+++ b/crates/lib3h/tests/test_suites/two_spaces.rs
@@ -3,7 +3,7 @@ use crate::{
     test_suites::two_basic::{
         test_author_one_aspect, test_send_message, two_join_space, TwoNodesTestFn,
     },
-    utils::{processor_harness::ProcessingOptions, constants::*},
+    utils::{constants::*, processor_harness::ProcessingOptions},
 };
 use lib3h_protocol::protocol_server::Lib3hServerProtocol;
 
@@ -94,7 +94,11 @@ pub fn test_rejoining(alex: &mut NodeMock, billy: &mut NodeMock, options: &Proce
 }
 
 /// Sending a Message before doing a 'TrackDna' should fail
-pub fn test_multispace_send(alex: &mut NodeMock, billy: &mut NodeMock, options: &ProcessingOptions) {
+pub fn test_multispace_send(
+    alex: &mut NodeMock,
+    billy: &mut NodeMock,
+    options: &ProcessingOptions,
+) {
     // Alex LeaveSpace
     let req_id = alex
         .leave_current_space()

--- a/crates/lib3h/tests/utils/processor_harness.rs
+++ b/crates/lib3h/tests/utils/processor_harness.rs
@@ -649,7 +649,7 @@ macro_rules! assert2_processed {
 ///
 /// Multiple calls to process() will be made as needed for
 /// the passed in processors to pass. It will failure after
-/// MAX_PROCESSING_LOOPS iterations regardless.
+/// ``$options.max_iters` iterations regardless.
 ///
 /// Returns all observed processor results for use by
 /// subsequent tests.
@@ -677,7 +677,7 @@ macro_rules! assert_processed_all {
 ///
 /// Multiple calls to process() will be made as needed for
 /// the passed in processors to pass. It will failure after
-/// MAX_PROCESSING_LOOPS iterations regardless.
+/// `$options.max_iters` iterations regardless.
 ///
 /// Returns all observed processor results for use by
 /// subsequent tests.
@@ -730,6 +730,8 @@ macro_rules! wait_engine_wrapper_did_work {
         let mut did_work = false;
         let clock = std::time::SystemTime::now();
         let timeout = std::time::Duration::from_millis($options.timeout_ms);
+        let delay_interval = std::time::Duration::from_millis($options.delay_interval_ms);
+
         for epoc in 0..$options.max_iters {
             let (did_work_now, results) = $engine
                 .process()
@@ -750,7 +752,7 @@ macro_rules! wait_engine_wrapper_did_work {
                 break;
             }
             trace!("[{}] wait_engine_wrapper_did_work: {:?}", epoc, results);
-            std::thread::sleep(std::time::Duration::from_millis($options.delay_interval_ms))
+            std::thread::sleep(delay_interval)
         }
         if $options.should_abort {
             assert!(did_work);
@@ -771,6 +773,7 @@ macro_rules! wait_engine_wrapper_until_no_work {
         let mut did_work = false;
         let clock = std::time::SystemTime::now();
         let timeout = std::time::Duration::from_millis($options.timeout_ms);
+        let delay_interval = std::time::Duration::from_millis($options.delay_interval_ms);
 
         let did_work_options = $crate::utils::processor_harness::ProcessingOptions {
             should_abort: false,
@@ -791,7 +794,7 @@ macro_rules! wait_engine_wrapper_until_no_work {
                 );
                 break;
             }
-            std::thread::sleep(std::time::Duration::from_millis($options.delay_interval_ms))
+            std::thread::sleep(delay_interval)
         }
         did_work
     }};
@@ -837,6 +840,7 @@ macro_rules! wait2_engine_wrapper_until_no_work {
         let mut did_work;
         let clock = SystemTime::now();
         let timeout = std::time::Duration::from_millis($options.timeout_ms);
+        let delay_interval = std::time::Duration::from_millis($options.delay_interval_ms);
         for i in 0..$options.max_iters {
             let did_work_options = ProcessingOptions {
                 should_abort: false,
@@ -857,7 +861,7 @@ macro_rules! wait2_engine_wrapper_until_no_work {
                 );
                 break;
             }
-            std::thread::sleep(std::time::Duration::from_millis($options.delay_interval_ms))
+            std::thread::sleep(delay_interval)
         }
         did_work
     }};

--- a/crates/lib3h/tests/utils/processor_harness.rs
+++ b/crates/lib3h/tests/utils/processor_harness.rs
@@ -441,7 +441,7 @@ macro_rules! assert2_msg_matches {
      $options: expr
     ) => {{
         let p = Box::new($crate::utils::processor_harness::Lib3hServerProtocolRegex(
-                regex::Regex::new($regex)
+            regex::Regex::new($regex)
                 .expect(format!("[assert2_msg_matches] Invalid regex: {:?}", $regex).as_str()),
         ));
         $crate::assert2_processed!($engine1, $engine2, p, $options)
@@ -499,15 +499,15 @@ macro_rules! assert_msg_matches_all {
     ($engine: ident,
      $regexes: expr
     ) => {
-        $crate:utils::processor_harness::assert2_msg_matches_all!($engine, $engine, $regexes)
+        $crate: utils::processor_harness::assert2_msg_matches_all!($engine, $engine, $regexes)
     };
     ($engine: ident,
      $regexes: expr,
      $options: expr
     ) => {
-        $crate:utils::processor_harness::assert2_msg_matches_all!($engine, $engine, $regexes, $options)
+        $crate:
+            utils::processor_harness::assert2_msg_matches_all!($engine, $engine, $regexes, $options)
     };
-
 }
 
 /// Internal function to process one engine of a possibly
@@ -539,7 +539,7 @@ macro_rules! process_one_engine {
                 if result {
                     // Simulate the succesful assertion behavior
                     processor.test(&processor_result.clone());
-                    // processor passed!
+                // processor passed!
                 } else {
                     // Cache the assertion error and trigger it later if we never
                     // end up passing

--- a/crates/lib3h/tests/utils/processor_harness.rs
+++ b/crates/lib3h/tests/utils/processor_harness.rs
@@ -31,19 +31,19 @@ pub static ref BOOLEAN_PRNG: Mutex<SeededBooleanPrng> = {
 }
 
 #[allow(dead_code)]
-pub const DEFAULT_MAX_ITERS: u64 = 100;
+pub const DEFAULT_MAX_ITERS: u64 = 1000;
 #[allow(dead_code)]
 pub const DEFAULT_MAX_RETRIES: u64 = 5;
 #[allow(dead_code)]
 pub const DEFAULT_DELAY_INTERVAL_MS: u64 = 1;
 #[allow(dead_code)]
-pub const DEFAULT_TIMEOUT_MS: u64 = 2000;
+pub const DEFAULT_TIMEOUT_MS: u64 = 1000;
 #[allow(dead_code)]
 pub const DEFAULT_SHOULD_ABORT: bool = true;
 #[allow(dead_code)]
-pub const DEFAULT_WAIT_DID_WORK_MAX_ITERS: u64 = 5;
+pub const DEFAULT_WAIT_DID_WORK_MAX_ITERS: u64 = 1;
 #[allow(dead_code)]
-pub const DEFAULT_WAIT_DID_WORK_TIMEOUT_MS: u64 = 5;
+pub const DEFAULT_WAIT_DID_WORK_TIMEOUT_MS: u64 = 1;
 
 /// All configurable parameters when processing an actor.
 #[derive(Clone, Debug)]

--- a/crates/lib3h/tests/utils/processor_harness.rs
+++ b/crates/lib3h/tests/utils/processor_harness.rs
@@ -9,7 +9,6 @@ use crate::utils::seeded_prng::SeededBooleanPrng;
 
 use std::sync::Mutex;
 
-
 lazy_static! {
 pub static ref BOOLEAN_PRNG: Mutex<SeededBooleanPrng> = {
 
@@ -587,8 +586,11 @@ macro_rules! assert2_processed_all {
             }
             let elapsed = clock.elapsed().unwrap();
             if elapsed > timeout {
-                trace!("[process_harness] epoc:{:?} timed out, elapsed {:?} ", epoc,
-                    elapsed.as_millis());
+                trace!(
+                    "[process_harness] epoc:{:?} timed out, elapsed {:?} ",
+                    epoc,
+                    elapsed.as_millis()
+                );
                 break;
             }
             std::thread::sleep(delay_interval)
@@ -666,8 +668,7 @@ macro_rules! assert_processed_all {
     ) => {{
         let options = $crate::utils::processor_harness::ProcessingOptions::default();
         $crate::assert_processed_all!($engine, $processors, options)
-    }}
- 
+    }};
 }
 
 /// Asserts that one engine produces events
@@ -695,8 +696,7 @@ macro_rules! assert_processed {
     ) => {{
         let options = $crate::utils::processor_harness::ProcessingOptions::default();
         $crate::assert_processed!($engine, $processor, options)
-     
-    }}
+    }};
 }
 
 /// `wait_connect!(a, connect_data, b)` waits until engine w4rapper `a` connects
@@ -741,8 +741,12 @@ macro_rules! wait_engine_wrapper_did_work {
             }
             let elapsed = clock.elapsed().unwrap();
             if elapsed > timeout {
-                trace!("[{}] wait_engine_wrapper_did_work: timeout elapsed={:?}, results={:?}", epoc,
-                    elapsed.as_millis(), results);
+                trace!(
+                    "[{}] wait_engine_wrapper_did_work: timeout elapsed={:?}, results={:?}",
+                    epoc,
+                    elapsed.as_millis(),
+                    results
+                );
                 break;
             }
             trace!("[{}] wait_engine_wrapper_did_work: {:?}", epoc, results);
@@ -780,8 +784,11 @@ macro_rules! wait_engine_wrapper_until_no_work {
             }
             let elapsed = clock.elapsed().unwrap();
             if elapsed > timeout {
-                trace!("[{:?}] wait_engine_wrapper_until_no_work timeout elapsed = {:?}",
-                    i, elapsed.as_millis());
+                trace!(
+                    "[{:?}] wait_engine_wrapper_until_no_work timeout elapsed = {:?}",
+                    i,
+                    elapsed.as_millis()
+                );
                 break;
             }
             std::thread::sleep(std::time::Duration::from_millis($options.delay_interval_ms))
@@ -844,7 +851,10 @@ macro_rules! wait2_engine_wrapper_until_no_work {
             }
             let elapsed = clock.elapsed().unwrap();
             if elapsed > timeout {
-                trace!("wait2_engine_Wrapper_until_no_work: timed out (over {:?} ms)", $options.timeout_ms);
+                trace!(
+                    "wait2_engine_Wrapper_until_no_work: timed out (over {:?} ms)",
+                    $options.timeout_ms
+                );
                 break;
             }
             std::thread::sleep(std::time::Duration::from_millis($options.delay_interval_ms))

--- a/crates/lib3h/tests/utils/processor_harness.rs
+++ b/crates/lib3h/tests/utils/processor_harness.rs
@@ -41,9 +41,9 @@ pub const DEFAULT_TIMEOUT_MS: u64 = 1000;
 #[allow(dead_code)]
 pub const DEFAULT_SHOULD_ABORT: bool = true;
 #[allow(dead_code)]
-pub const DEFAULT_WAIT_DID_WORK_MAX_ITERS: u64 = 1;
+pub const DEFAULT_WAIT_DID_WORK_MAX_ITERS: u64 = 10;
 #[allow(dead_code)]
-pub const DEFAULT_WAIT_DID_WORK_TIMEOUT_MS: u64 = 1;
+pub const DEFAULT_WAIT_DID_WORK_TIMEOUT_MS: u64 = 10;
 
 /// All configurable parameters when processing an actor.
 #[derive(Clone, Debug)]

--- a/crates/zombie_actor/src/ghost_test_harness.rs
+++ b/crates/zombie_actor/src/ghost_test_harness.rs
@@ -10,10 +10,10 @@
 pub const DEFAULT_MAX_ITERS: u64 = 100;
 pub const DEFAULT_MAX_RETRIES: u64 = 5;
 pub const DEFAULT_DELAY_INTERVAL_MS: u64 = 1;
-pub const DEFAULT_TIMEOUT_MS: u64 = 2000;
+pub const DEFAULT_TIMEOUT_MS: u64 = 10;
 pub const DEFAULT_SHOULD_ABORT: bool = true;
-pub const DEFAULT_WAIT_DID_WORK_MAX_ITERS: u64 = 5;
-pub const DEFAULT_WAIT_DID_WORK_TIMEOUT_MS: u64 = 5;
+pub const DEFAULT_WAIT_DID_WORK_MAX_ITERS: u64 = 1;
+pub const DEFAULT_WAIT_DID_WORK_TIMEOUT_MS: u64 = 1;
 
 /// All configurable parameters when processing an actor.
 #[derive(Clone, Debug)]
@@ -77,6 +77,7 @@ macro_rules! wait_did_work {
                 .map(|work_was_done| work_was_done.into())
                 .unwrap_or(did_work);
             if did_work {
+                trace!("[epoch {:?}] wait_did_work returning true", i);
                 break;
             }
             let elapsed = clock.elapsed().unwrap();
@@ -89,7 +90,6 @@ macro_rules! wait_did_work {
         if $options.should_abort {
             assert!(did_work);
         }
-        trace!("wait_did_work returning: {:?}", did_work);
 
         did_work
     }};
@@ -119,6 +119,7 @@ macro_rules! wait_can_track_did_work {
                 .map(|work_was_done| work_was_done.into())
                 .unwrap_or(did_work);
             if did_work {
+                trace!("[{}] wait_can_track_did_work returning true", i);
                 break;
             }
             let elapsed = clock.elapsed().unwrap();
@@ -131,8 +132,6 @@ macro_rules! wait_can_track_did_work {
         if $options.should_abort {
             assert!(did_work);
         }
-        trace!("wait_can_track_did_work returning {:?}", did_work);
-
         did_work
     }};
 }
@@ -327,6 +326,8 @@ macro_rules! wait1_for_callback {
     ($actor: ident, $ghost_can_track: ident, $request: expr, $re: expr, $options: expr) => {{
         let regex = regex::Regex::new($re.clone())
             .expect(format!("[wait1_for_callback] invalid regex: {:?}", $re).as_str());
+
+        trace!("wait1_for_callback: regex={:?}", regex);
 
         let mut user_data = None;
 


### PR DESCRIPTION
## PR summary

This PR adds configurable processing options, similar to work done for #437 on the `ghost_test_harness`. Contributes to issue #440 and flaky test issues such as #438 and a circleci error within the three basic test suite.
   
## Review checklist 
- [x] The story has unit or integration tests
- [x] No new bugs, and any tech-debt is identified and justified
- [x] There is enough API documentation (how to use)
- [x] There is enough code documentation (how the code works)
