### PR TITLE
Fix join space failures in app veyer

### DIFF
--- a/crates/lib3h/tests/utils/processor_harness.rs
+++ b/crates/lib3h/tests/utils/processor_harness.rs
@@ -41,9 +41,9 @@ pub const DEFAULT_TIMEOUT_MS: u64 = 1000;
 #[allow(dead_code)]
 pub const DEFAULT_SHOULD_ABORT: bool = true;
 #[allow(dead_code)]
-pub const DEFAULT_WAIT_DID_WORK_MAX_ITERS: u64 = 10;
+pub const DEFAULT_WAIT_DID_WORK_MAX_ITERS: u64 = 50;
 #[allow(dead_code)]
-pub const DEFAULT_WAIT_DID_WORK_TIMEOUT_MS: u64 = 10;
+pub const DEFAULT_WAIT_DID_WORK_TIMEOUT_MS: u64 = 50;
 
 /// All configurable parameters when processing an actor.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
## PR summary

Tunes processing harness options to resolve #438. In particular it bumps up the did work timeout and max iters.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
