### PR TITLE
fix struct name in comment of GhostTransportWebsocket

### DIFF
--- a/crates/lib3h/src/transport/websocket/actor.rs
+++ b/crates/lib3h/src/transport/websocket/actor.rs
@@ -272,7 +272,7 @@ impl GhostTransportWebsocket {
             match event {
                 StreamEvent::ErrorOccured(uri, error) => {
                     warn!(
-                        "Error in GhostWebsocketTransport stream connection to {:?}: {:?}",
+                        "Error in GhostTransportWebsocket stream connection to {:?}: {:?}",
                         uri, error
                     );
                     self.endpoint_self.publish(
@@ -332,7 +332,7 @@ impl GhostTransportWebsocket {
                     temp.push(msg);
                 }
             } else {
-                panic!("Found a non-SendMessage message in GhostWebsocketTransport::pending!");
+                panic!("Found a non-SendMessage message in GhostTransportWebsocket::pending!");
             }
         }
         self.pending = temp;


### PR DESCRIPTION
## PR summary
I was reading over/through this a bit, searching for this struct by the wrong name and found this

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
