### PR TITLE
AgentPubKey & NodePubKey

### DIFF
--- a/crates/lib3h/src/bin/demo.rs
+++ b/crates/lib3h/src/bin/demo.rs
@@ -132,7 +132,7 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
                 ClientToLib3h::JoinSpace(SpaceData {
                     request_id: "".to_string(),
                     space_address: SPACE_ADDR.into(),
-                    agent_id: A_1_ID.to_string().into(),
+                    agent_id: A_1_ID.into(),
                 }),
                 Box::new(|_, r| {
                     println!("1 got: {:?}", r);
@@ -147,7 +147,7 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
                 ClientToLib3h::JoinSpace(SpaceData {
                     request_id: "".to_string(),
                     space_address: SPACE_ADDR.into(),
-                    agent_id: A_2_ID.to_string().into(),
+                    agent_id: A_2_ID.into(),
                 }),
                 Box::new(|_, r| {
                     println!("2 got: {:?}", r);
@@ -175,8 +175,8 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
                             space_address: SPACE_ADDR.into(),
                             entry_address: ENTRY_ADDR.into(),
                             request_id: "TEST_REQ_ID".to_string(),
-                            requester_agent_id: A_1_ID.to_string().into(),
-                            responder_agent_id: A_1_ID.to_string().into(),
+                            requester_agent_id: A_1_ID.into(),
+                            responder_agent_id: A_1_ID.into(),
                             query_result: format!(
                                 "echo: {}",
                                 String::from_utf8_lossy(&q_data.query)
@@ -230,8 +230,8 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
                 ClientToLib3h::SendDirectMessage(DirectMessageData {
                     space_address: SPACE_ADDR.into(),
                     request_id: "TEST_REQ_ID".to_string(),
-                    to_agent_id: A_2_ID.to_string().into(),
-                    from_agent_id: A_1_ID.to_string().into(),
+                    to_agent_id: A_2_ID.into(),
+                    from_agent_id: A_1_ID.into(),
                     content: b"bob".to_vec().into(),
                 }),
                 Box::new(|_, r| {
@@ -257,7 +257,7 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
                     space_address: SPACE_ADDR.into(),
                     entry_address: ENTRY_ADDR.into(),
                     request_id: "TEST_REQ_ID".to_string(),
-                    requester_agent_id: A_1_ID.to_string().into(),
+                    requester_agent_id: A_1_ID.into(),
                     query: b"bob".to_vec().into(),
                 }),
                 Box::new(|_, r| {
@@ -275,7 +275,7 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
                 Span::fixme(),
                 ClientToLib3h::PublishEntry(ProvidedEntryData {
                     space_address: SPACE_ADDR.into(),
-                    provider_agent_id: A_1_ID.to_string().into(),
+                    provider_agent_id: A_1_ID.into(),
                     entry: EntryData {
                         entry_address: ENTRY_ADDR.into(),
                         aspect_list: vec![EntryAspectData {

--- a/crates/lib3h/src/dht/dht_protocol.rs
+++ b/crates/lib3h/src/dht/dht_protocol.rs
@@ -6,6 +6,7 @@ use lib3h_protocol::{
 
 use crate::{dht::dht_config::DhtConfig, error::*};
 use lib3h_ghost_actor::prelude::*;
+use lib3h_protocol::uri::UriScheme;
 
 pub type FromPeerName = Lib3hUri;
 
@@ -146,6 +147,18 @@ pub struct PeerData {
     pub peer_name: Lib3hUri,
     pub peer_location: Lib3hUri,
     pub timestamp: u64,
+}
+
+impl PeerData {
+    pub fn get_uri(&self) -> Lib3hUri {
+        assert!(
+            self.peer_name.is_scheme(UriScheme::Node) || self.peer_name.is_scheme(UriScheme::Agent)
+        );
+        if self.peer_name.is_scheme(UriScheme::Node) {
+            return self.peer_location.clone();
+        }
+        Lib3hUri::with_node_and_agent_id(&self.peer_location.node_id(), &self.peer_name.agent_id())
+    }
 }
 
 #[derive(Debug, PartialEq, Clone, Deserialize, Serialize)]

--- a/crates/lib3h/src/dht/mod.rs
+++ b/crates/lib3h/src/dht/mod.rs
@@ -11,7 +11,6 @@ pub mod tests {
         tests::enable_logging_for_test,
     };
     use detach::prelude::*;
-    use holochain_persistence_api::hash::HashString;
     use holochain_tracing::test_span;
     use lib3h_ghost_actor::prelude::*;
     use lib3h_protocol::{
@@ -34,9 +33,9 @@ pub mod tests {
         pub static ref ASPECT_ADDRESS_2: AspectHash = "aspect_addr_2".into();
         pub static ref ASPECT_ADDRESS_3: AspectHash = "aspect_addr_3".into();
         /// Peers
-        pub static ref PEER_A: Lib3hUri = Lib3hUri::with_agent_id(&HashString::from(PEER_A_STR));
-        pub static ref PEER_B: Lib3hUri = Lib3hUri::with_agent_id(&HashString::from(PEER_B_STR));
-        pub static ref PEER_C: Lib3hUri = Lib3hUri::with_agent_id(&HashString::from(PEER_C_STR));
+        pub static ref PEER_A: Lib3hUri = Lib3hUri::with_agent_id(&PEER_A_STR.into());
+        pub static ref PEER_B: Lib3hUri = Lib3hUri::with_agent_id(&PEER_B_STR.into());
+        pub static ref PEER_C: Lib3hUri = Lib3hUri::with_agent_id(&PEER_C_STR.into());
     }
 
     const PEER_A_STR: &str = "alex";
@@ -72,7 +71,7 @@ pub mod tests {
     }
 
     fn create_test_uri() -> Lib3hUri {
-        Lib3hUri::with_transport_id(&HashString::from("test"))
+        Lib3hUri::with_node_id(&"test".into())
     }
 
     #[allow(non_snake_case)]
@@ -297,7 +296,7 @@ pub mod tests {
         // Should get self
         let maybe_peer = get_peer(&mut dht, &*PEER_A);
         assert_eq!(
-            "Lib3hUri(\"agentid:alex\")",
+            "Lib3hUri(\"agentpubkey:alex\")",
             format!("{:?}", maybe_peer.unwrap().peer_name)
         );
         // Should be empty

--- a/crates/lib3h/src/dht/rrdht.rs
+++ b/crates/lib3h/src/dht/rrdht.rs
@@ -1,5 +1,5 @@
 use crate::{
-    dht::{dht_protocol::*, dht_config::DhtConfig, Lib3hUri},
+    dht::{dht_config::DhtConfig, dht_protocol::*, Lib3hUri},
     error::Lib3hResult,
 };
 use lib3h_protocol::{Address, DidWork};
@@ -50,11 +50,11 @@ impl Dht for RrDht {
 
     // -- Entry -- //
 
-    fn get_entry_address_list(&self) -> Vec<&Address> {
+    fn get_entry_address_list(&self) -> Vec<&EntryHash> {
         // FIXME
         vec![]
     }
-    fn get_aspects_of(&self, _entry_address: &Address) -> Option<Vec<Address>> {
+    fn get_aspects_of(&self, _entry_address: &Address) -> Option<Vec<AspectHash>> {
         // FIXME
         None
     }

--- a/crates/lib3h/src/engine/ghost_engine_wrapper.rs
+++ b/crates/lib3h/src/engine/ghost_engine_wrapper.rs
@@ -17,7 +17,7 @@ use lib3h_protocol::{
     protocol_server::*,
     types::*,
     uri::Lib3hUri,
-    Address, DidWork,
+    DidWork,
 };
 pub type WrappedGhostLib3h = LegacyLib3h<GhostEngine<'static>, Lib3hError>;
 
@@ -46,7 +46,7 @@ fn server_failure(
     err: String,
     request_id: String,
     space_address: SpaceHash,
-    to_agent_id: Address,
+    to_agent_id: AgentPubKey,
 ) -> Lib3hServerProtocol {
     let failure_data = GenericResultData {
         request_id,
@@ -60,7 +60,7 @@ fn server_failure(
 fn server_success(
     request_id: String,
     space_address: SpaceHash,
-    to_agent_id: Address,
+    to_agent_id: AgentPubKey,
 ) -> Lib3hServerProtocol {
     let success_data = GenericResultData {
         request_id,
@@ -96,7 +96,7 @@ where
     fn make_callback(
         request_id: String,
         space_addr: SpaceHash,
-        agent: Address,
+        agent: AgentPubKey,
     ) -> GhostCallback<LegacyLib3h<Engine, EngineError>, ClientToLib3hResponse, EngineError> {
         Box::new(
             |me: &mut LegacyLib3h<Engine, EngineError>,
@@ -492,7 +492,7 @@ mod tests {
 
         // The mock engine allways returns failure on connect requests
         assert_eq!(
-            "Ok((true, [FailureResult(GenericResultData { request_id: \"foo_request_id\", space_address: SpaceHash(HashString(\"bogus_address\")), to_agent_id: HashString(\"bogus_agent\"), result_info: \"connection failed!\" })]))",
+            "Ok((true, [FailureResult(GenericResultData { request_id: \"foo_request_id\", space_address: SpaceHash(HashString(\"bogus_address\")), to_agent_id: AgentPubKey(HashString(\"bogus_agent\")), result_info: \"connection failed!\" })]))",
             format!("{:?}", result)
         );
 
@@ -507,7 +507,7 @@ mod tests {
 
         // The mock engine allways returns success on Join requests
         assert_eq!(
-            "Ok((true, [SuccessResult(GenericResultData { request_id: \"bar_request_id\", space_address: SpaceHash(HashString(\"fake_space_address\")), to_agent_id: HashString(\"fake_id\"), result_info: \"\" })]))",
+            "Ok((true, [SuccessResult(GenericResultData { request_id: \"bar_request_id\", space_address: SpaceHash(HashString(\"fake_space_address\")), to_agent_id: AgentPubKey(HashString(\"fake_id\")), result_info: \"\" })]))",
             format!("{:?}", result)
         );
 

--- a/crates/lib3h/src/engine/mod.rs
+++ b/crates/lib3h/src/engine/mod.rs
@@ -71,11 +71,11 @@ pub struct EngineConfig {
 }
 
 pub struct TransportKeys {
-    /// Our TransportId, i.e. Base32 encoded public key (e.g. "HcMyadayada")
+    /// Our nodeId, i.e. Base32 encoded public key (e.g. "HcMyadayada")
     pub node_id: NodePubKey,
-    /// The TransportId public key
+    /// The nodeId public key
     pub transport_public_key: Box<dyn Buffer>,
-    /// The TransportId secret key
+    /// The nodeId secret key
     pub transport_secret_key: Box<dyn Buffer>,
 }
 impl TransportKeys {

--- a/crates/lib3h/src/engine/mod.rs
+++ b/crates/lib3h/src/engine/mod.rs
@@ -16,14 +16,14 @@ use crate::{
 use detach::Detach;
 use lib3h_crypto_api::{Buffer, CryptoSystem};
 use lib3h_ghost_actor::{prelude::*, RequestId};
-use lib3h_protocol::{protocol::*, types::SpaceHash, uri::Lib3hUri, Address};
+use lib3h_protocol::{protocol::*, types::*, uri::Lib3hUri, Address};
 use std::{
     collections::{HashMap, HashSet},
     path::PathBuf,
 };
 
 /// Identifier of a source chain: SpaceAddress+AgentId
-pub type ChainId = (SpaceHash, Address);
+pub type ChainId = (SpaceHash, AgentPubKey);
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct GatewayId {
@@ -72,7 +72,7 @@ pub struct EngineConfig {
 
 pub struct TransportKeys {
     /// Our TransportId, i.e. Base32 encoded public key (e.g. "HcMyadayada")
-    pub transport_id: Address,
+    pub node_id: NodePubKey,
     /// The TransportId public key
     pub transport_public_key: Box<dyn Buffer>,
     /// The TransportId secret key
@@ -85,7 +85,7 @@ impl TransportKeys {
         let mut secret_key = crypto.buf_new_secure(crypto.sign_secret_key_bytes());
         crypto.sign_keypair(&mut public_key, &mut secret_key)?;
         Ok(Self {
-            transport_id: hcm0.encode(&public_key)?.into(),
+            node_id: hcm0.encode(&public_key)?.as_str().into(),
             transport_public_key: public_key,
             transport_secret_key: secret_key,
         })
@@ -119,7 +119,7 @@ pub struct GhostEngine<'engine> {
     /// crypto system to use
     crypto: Box<dyn CryptoSystem>,
     #[allow(dead_code)]
-    /// transport_id data, public/private keys, etc
+    /// transport data: node_id, public/private keys, etc
     transport_keys: TransportKeys,
     /// items we need to send on our multiplexer in another process loop
     multiplexer_defered_sends: Vec<(Lib3hUri, lib3h_protocol::data_types::Opaque)>,

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -200,7 +200,7 @@ impl<'engine> GhostEngine<'engine> {
                                 our_joined_space_list,
                                 net_location_copy,
                             );
-                            // we need a transportId, so search for it in the DHT
+                            // we need a nodeId, so search for it in the DHT
                             let maybe_peer_data = peer_list
                                 .iter()
                                 .find(|pd| pd.peer_location == net_location_copy);

--- a/crates/lib3h/src/engine/network_layer.rs
+++ b/crates/lib3h/src/engine/network_layer.rs
@@ -266,10 +266,9 @@ impl<'engine> GhostEngine<'engine> {
                     );
                 } else {
                     // otherwise should be for one of our space
-                    let maybe_space_gateway = self.space_gateway_map.get_mut(&(
-                        msg.space_address.to_owned(),
-                        msg.to_peer_name.clone().into(),
-                    ));
+                    let maybe_space_gateway = self
+                        .space_gateway_map
+                        .get_mut(&(msg.space_address.to_owned(), msg.to_peer_name.agent_id()));
                     if let Some(space_gateway) = maybe_space_gateway {
                         let _ = space_gateway.publish(
                             span.follower("TODO"),

--- a/crates/lib3h/src/engine/space_layer.rs
+++ b/crates/lib3h/src/engine/space_layer.rs
@@ -144,7 +144,7 @@ impl<'engine> GhostEngine<'engine> {
                             let lib3h_msg = StoreEntryAspectData {
                                 request_id: self.request_track.reserve(),
                                 space_address: chain_id.0.clone(),
-                                provider_agent_id: from_peer_name.clone().into(),
+                                provider_agent_id: from_peer_name.agent_id(),
                                 entry_address: entry.entry_address.clone(),
                                 entry_aspect: aspect,
                             };
@@ -338,8 +338,10 @@ impl<'engine> GhostEngine<'engine> {
                     from_peer_name: gossip_data.from_peer_name.clone(),
                     bundle: gossip_data.bundle.clone(),
                 };
-                let space_gateway =
-                    self.get_space(&gossip_data.space_address, &gossip_data.to_peer_name.into())?;
+                let space_gateway = self.get_space(
+                    &gossip_data.space_address,
+                    &gossip_data.to_peer_name.agent_id(),
+                )?;
                 space_gateway.publish(
                     span.follower("TODO"),
                     GatewayRequestToChild::Dht(DhtRequestToChild::HandleGossip(remote_gossip)),

--- a/crates/lib3h/src/gateway/gateway_actor.rs
+++ b/crates/lib3h/src/gateway/gateway_actor.rs
@@ -133,8 +133,7 @@ impl P2pGateway {
                                 DhtRequestToChildResponse::RequestPeerList(peer_list),
                             )) => {
                                 for peer in peer_list {
-                                    let mut uri = peer.peer_location.clone();
-                                    uri.set_agent_id(&peer.peer_name.lower_address());
+                                    let uri = peer.get_uri();
                                     me.send_with_full_low_uri(
                                         SendWithFullLowUri {
                                             span: Span::fixme(),

--- a/crates/lib3h/src/gateway/gateway_dht.rs
+++ b/crates/lib3h/src/gateway/gateway_dht.rs
@@ -80,8 +80,7 @@ impl P2pGateway {
                     P2pProtocol::CapnProtoMessage(P2pMessage::create_ping(None).into_bytes())
                         .into_bytes()
                         .into();
-                let mut uri = peer_data.peer_location.clone();
-                uri.set_agent_id(&peer_data.peer_name.lower_address());
+                let uri = peer_data.get_uri();
                 self.send_with_full_low_uri(
                     SendWithFullLowUri {
                         span: span.follower("DhtRequestToParent::HoldPeerRequested"),

--- a/crates/lib3h/src/gateway/gateway_transport_send.rs
+++ b/crates/lib3h/src/gateway/gateway_transport_send.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use holochain_tracing::Span;
 use lib3h_ghost_actor::prelude::*;
-use lib3h_protocol::data_types::*;
+use lib3h_protocol::{data_types::*, types::*};
 use rmp_serde::Serializer;
 use serde::Serialize;
 
@@ -135,8 +135,8 @@ impl P2pGateway {
                         Some(peer_data),
                     ))) => {
                         // hey, we got a low-level uri, let's process it
-                        let mut uri = peer_data.peer_location.clone();
-                        uri.set_agent_id(&peer_data.peer_name.lower_address());
+                        trace!("send to peer: {:?}", peer_data);
+                        let uri = peer_data.get_uri();
                         trace!("send to {}", uri);
                         me.priv_send_with_full_low_uri(
                             SendWithFullLowUri {
@@ -239,18 +239,18 @@ impl P2pGateway {
         expires_at: std::time::Instant,
         cb: SendCallback,
     ) -> GhostResult<()> {
-        let to_agent_id = match send_data.full_low_uri.agent_id() {
+        let to_agent_id = match send_data.full_low_uri.get_agent_id() {
             Some(agent_id) => agent_id,
-            None => "".to_string().into(), // TODO - is this correct?
+            None => AgentPubKey::new(), // TODO - is this correct?
         };
 
         let payload =
             if let GatewayOutputWrapType::WrapOutputWithP2pDirectMessage = self.wrap_output_type {
                 let dm_wrapper = DirectMessageData {
                     space_address: self.identifier.id.clone().into(),
-                    request_id: "".to_string(),
+                    request_id: String::new(),
                     to_agent_id,
-                    from_agent_id: self.this_peer.peer_name.clone().into(),
+                    from_agent_id: self.this_peer.peer_name.agent_id(),
                     content: encoded_payload,
                 };
                 let mut payload = Vec::new();

--- a/crates/lib3h/src/gateway/gateway_transport_send.rs
+++ b/crates/lib3h/src/gateway/gateway_transport_send.rs
@@ -135,7 +135,6 @@ impl P2pGateway {
                         Some(peer_data),
                     ))) => {
                         // hey, we got a low-level uri, let's process it
-                        trace!("send to peer: {:?}", peer_data);
                         let uri = peer_data.get_uri();
                         trace!("send to {}", uri);
                         me.priv_send_with_full_low_uri(

--- a/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
@@ -75,8 +75,8 @@ impl Discovery for GhostTransportMemory {
         Ok(())
     }
     fn discover(&mut self) -> DiscoveryResult<Vec<Lib3hUri>> {
-        let machines = self.network.lock().unwrap().discover();
-        Ok(machines.into_iter().map(|(uri, _)| uri).collect())
+        let nodes = self.network.lock().unwrap().discover();
+        Ok(nodes.into_iter().map(|(uri, _)| uri).collect())
     }
     fn release(&mut self) -> DiscoveryResult<()> {
         Ok(())
@@ -118,10 +118,10 @@ impl GhostTransportMemory {
             if self.maybe_my_address.is_some()
                 && t.elapsed().as_millis() > self.discover_interval_ms
             {
-                if let Ok(machines) = self.discover() {
-                    if machines.len() > 0 {
+                if let Ok(nodes) = self.discover() {
+                    if nodes.len() > 0 {
                         let my_addr = self.maybe_my_address.as_ref().expect("should have bound");
-                        for found_uri in machines {
+                        for found_uri in nodes {
                             if found_uri == *my_addr {
                                 continue;
                             }

--- a/crates/lib3h/src/transport/transport_multiplex/mod.rs
+++ b/crates/lib3h/src/transport/transport_multiplex/mod.rs
@@ -212,7 +212,10 @@ mod tests {
 
         let msg = msgs.remove(0).take_message().unwrap();
         if let RequestToParent::ReceivedData { uri, payload } = msg {
-            assert_eq!(&Lib3hUri::with_agent_id(&HashString::from("agent_x")), &uri);
+            assert_eq!(
+                &Lib3hUri::with_agent_id(&HashString::from("agent_x").into()),
+                &uri
+            );
             let expected: Opaque = "hello".into();
             assert_eq!(&expected, &payload);
         } else {

--- a/crates/lib3h/src/transport/transport_multiplex/mod.rs
+++ b/crates/lib3h/src/transport/transport_multiplex/mod.rs
@@ -1,6 +1,6 @@
 //! Let's say we have two agentIds: a1 and a2
-//! a1 is running on transportId: m1
-//! a2 is running on transportId: m2
+//! a1 is running on nodeId: m1
+//! a2 is running on nodeId: m2
 //!
 //! The AgentSpaceGateway will wrap messages in a p2p_proto direct message:
 //!   DirectMessage {
@@ -13,7 +13,7 @@
 //! Then send it to the transport id:
 //!   dest: "m2", payload: <above, but binary>
 //!
-//! When the multiplexer receives data (at the network/machine gateway),
+//! When the multiplexer receives data (at the network/node gateway),
 //! if it is any other p2p_proto message, it will be forwarded to
 //! the engine or network gateway. If it is a direct message, it will be
 //! sent to the appropriate Route / AgentSpaceGateway

--- a/crates/lib3h/src/transport/transport_multiplex/mplex.rs
+++ b/crates/lib3h/src/transport/transport_multiplex/mplex.rs
@@ -6,13 +6,13 @@ use crate::{
 use detach::prelude::*;
 use holochain_tracing::Span;
 use lib3h_ghost_actor::prelude::*;
-use lib3h_protocol::{data_types::Opaque, types::SpaceHash, uri::Lib3hUri, Address};
+use lib3h_protocol::{data_types::Opaque, types::*, uri::Lib3hUri};
 use std::collections::HashMap;
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 struct LocalRouteSpec {
     pub space_address: SpaceHash,
-    pub local_agent_id: Address,
+    pub local_agent_id: AgentPubKey,
 }
 
 pub struct TransportMultiplex<
@@ -74,7 +74,7 @@ impl<
     pub fn create_agent_space_route(
         &mut self,
         space_address: &SpaceHash,
-        local_agent_id: &Address,
+        local_agent_id: &AgentPubKey,
     ) -> TransportActorParentEndpoint {
         let (endpoint_parent, endpoint_self) = create_ghost_channel();
         let endpoint_self = endpoint_self
@@ -102,7 +102,7 @@ impl<
     pub fn remove_agent_space_route(
         &mut self,
         space_address: &SpaceHash,
-        local_agent_id: &Address,
+        local_agent_id: &AgentPubKey,
     ) -> Option<TransportActorSelfEndpoint<TransportMultiplex<G>>> {
         let route_spec = LocalRouteSpec {
             space_address: space_address.clone(),
@@ -118,8 +118,8 @@ impl<
     pub fn received_data_for_agent_space_route(
         &mut self,
         space_address: &SpaceHash,
-        local_agent_id: &Address,
-        remote_agent_id: &Address,
+        local_agent_id: &AgentPubKey,
+        remote_agent_id: &AgentPubKey,
         unpacked_payload: Opaque,
     ) -> Lib3hResult<()> {
         let route_spec = LocalRouteSpec {

--- a/crates/lib3h/src/transport/transport_multiplex/mplex.rs
+++ b/crates/lib3h/src/transport/transport_multiplex/mplex.rs
@@ -68,8 +68,8 @@ impl<
     }
 
     /// create a route for a specific agent_id + space_address combination
-    /// we are wrapping a network/machine-level gateway with a machine
-    /// space_address and machineId... the space_address + agent_id parameters
+    /// we are wrapping a network/node-level gateway with a machine
+    /// space_address and nodeId... the space_address + agent_id parameters
     /// for this function are the higher-level notions for the AgentSpaceGateway
     pub fn create_agent_space_route(
         &mut self,

--- a/crates/lib3h/src/transport/websocket/actor.rs
+++ b/crates/lib3h/src/transport/websocket/actor.rs
@@ -19,6 +19,7 @@ use lib3h_protocol::{
         error::{DiscoveryError, DiscoveryResult, ErrorKind as DiscoveryErrorKind},
         Discovery,
     },
+    types::*,
     uri::Lib3hUri,
     Address,
 };
@@ -31,7 +32,7 @@ pub type Message =
 
 pub struct GhostTransportWebsocket {
     #[allow(dead_code)]
-    transport_id: Address,
+    node_id: NodePubKey,
     network_id_address: Address,
     endpoint_parent: Option<GhostTransportWebsocketEndpoint>,
     endpoint_self: Detach<GhostTransportWebsocketEndpointContext>,
@@ -118,13 +119,13 @@ impl Drop for GhostTransportWebsocket {
 
 impl GhostTransportWebsocket {
     pub fn new(
-        transport_id: Address,
+        node_id: NodePubKey,
         tls_config: TlsConfig,
         networkid_address: Address,
     ) -> GhostTransportWebsocket {
         let (endpoint_parent, endpoint_self) = create_ghost_channel();
         GhostTransportWebsocket {
-            transport_id,
+            node_id,
             network_id_address: networkid_address,
             endpoint_parent: Some(endpoint_parent),
             endpoint_self: Detach::new(

--- a/crates/lib3h/src/transport/websocket/actor.rs
+++ b/crates/lib3h/src/transport/websocket/actor.rs
@@ -433,9 +433,9 @@ mod tests {
     fn test_websocket_transport_send_direct_msg() {
         let networkid_address: Address = "wss-bootstapping-network-id1.holo.host".into();
 
-        let machine_id1 = "fake_machine_id1".into();
+        let node_id_1 = "fake_node_id1".into();
         let mut transport1 = GhostTransportWebsocket::new(
-            machine_id1,
+            node_id_1,
             TlsConfig::Unencrypted,
             networkid_address.clone(),
         );
@@ -448,9 +448,9 @@ mod tests {
                 .request_id_prefix("twss_to_child1")
                 .build::<Option<String>>();
 
-        let machine_id2 = "fake_machine_id2".into();
+        let node_id_2 = "fake_node_id2".into();
         let mut transport2 = GhostTransportWebsocket::new(
-            machine_id2,
+            node_id_2,
             TlsConfig::Unencrypted,
             networkid_address.clone(),
         );
@@ -521,9 +521,9 @@ mod tests {
 
         let networkid_address: Address = "wss-bootstapping-network-id.holo.host".into();
 
-        let machine_id1 = "fake_machine_id1".into();
+        let node_id_1 = "fake_node_id1".into();
         let mut transport1 = GhostTransportWebsocket::new(
-            machine_id1,
+            node_id_1,
             TlsConfig::Unencrypted,
             networkid_address.clone(),
         );
@@ -556,9 +556,9 @@ mod tests {
         for index in 1..10 {
             wait_until_no_work!(transport1);
             {
-                let machine_id2 = "fake_machine_id2".into();
+                let node_id_2 = "fake_node_id2".into();
                 let mut transport2 = GhostTransportWebsocket::new(
-                    machine_id2,
+                    node_id_2,
                     TlsConfig::Unencrypted,
                     networkid_address.clone(),
                 );
@@ -624,9 +624,9 @@ mod tests {
         let networkid_address: Address =
             format!("wss-bootstapping-network-id-{}.holo.host", nanoid::simple()).into();
 
-        let machine_id1 = "fake_machine_id1".into();
+        let node_id_1 = "fake_node_id1".into();
         let mut transport1 = GhostTransportWebsocket::new(
-            machine_id1,
+            node_id_1,
             TlsConfig::Unencrypted,
             networkid_address.clone(),
         );
@@ -644,9 +644,9 @@ mod tests {
             format!("{:?}", transport1.discover())
         );
 
-        let machine_id2 = "fake_machine_id2".into();
+        let node_id_2 = "fake_node_id2".into();
         let mut transport2 = GhostTransportWebsocket::new(
-            machine_id2,
+            node_id_2,
             TlsConfig::Unencrypted,
             networkid_address.clone(),
         );

--- a/crates/lib3h/tests/engine_test.rs
+++ b/crates/lib3h/tests/engine_test.rs
@@ -166,10 +166,10 @@ fn basic_track_test<'engine>(mut engine: &mut GhostEngine<'engine>) {
         )
         .unwrap();
     let handle_get_gossip_entry_list_regex =
-        "HandleGetGossipingEntryList\\(GetListData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: HashString\\(\"alex\"\\), request_id: \"[\\w\\d_~]*\" \\}\\)";
+        "HandleGetGossipingEntryList\\(GetListData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), request_id: \"[\\w\\d_~]*\" \\}\\)";
 
     let handle_get_authoring_entry_list_regex =
-        "HandleGetAuthoringEntryList\\(GetListData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: HashString\\(\"alex\"\\), request_id: \"[\\w\\d_~]*\" \\}\\)";
+        "HandleGetAuthoringEntryList\\(GetListData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), request_id: \"[\\w\\d_~]*\" \\}\\)";
 
     let regexes = vec![
         handle_get_authoring_entry_list_regex,

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -25,7 +25,7 @@ use lib3h::{
     error::Lib3hResult,
     transport::websocket::tls::TlsConfig,
 };
-use lib3h_protocol::{uri::Lib3hUri, Address};
+use lib3h_protocol::{types::*, uri::Lib3hUri};
 use node_mock::NodeMock;
 use std::path::PathBuf;
 use test_suites::{
@@ -116,9 +116,9 @@ fn construct_wss_engine(config: &EngineConfig, name: &str) -> Lib3hResult<Wrappe
 // Node Setup
 //--------------------------------------------------------------------------------------------------
 
-pub type NodeFactory = fn(name: &str, agent_id_arg: Address) -> NodeMock;
+pub type NodeFactory = fn(name: &str, agent_id_arg: AgentPubKey) -> NodeMock;
 
-fn setup_memory_node(name: &str, agent_id_arg: Address, fn_name: &str) -> NodeMock {
+fn setup_memory_node(name: &str, agent_id_arg: AgentPubKey, fn_name: &str) -> NodeMock {
     let fn_name = fn_name.replace("::", "__");
     let config = EngineConfig {
         network_id: test_network_id(),
@@ -136,7 +136,7 @@ fn setup_memory_node(name: &str, agent_id_arg: Address, fn_name: &str) -> NodeMo
 
 fn setup_wss_node(
     name: &str,
-    agent_id_arg: Address,
+    agent_id_arg: AgentPubKey,
     tls_config: TlsConfig,
     fn_name: &str,
 ) -> NodeMock {

--- a/crates/lib3h/tests/node_mock/methods.rs
+++ b/crates/lib3h/tests/node_mock/methods.rs
@@ -13,7 +13,7 @@ use lib3h_protocol::{
     protocol_server::Lib3hServerProtocol,
     types::*,
     uri::Lib3hUri,
-    Address, DidWork,
+    DidWork,
 };
 use multihash::Hash;
 use rmp_serde::Serializer;
@@ -454,7 +454,7 @@ impl NodeMock {
 impl NodeMock {
     /// Send a DirectMessage on the network.
     /// Returns the generated request_id for this send
-    pub fn send_direct_message(&mut self, to_agent_id: &Address, content: Vec<u8>) -> String {
+    pub fn send_direct_message(&mut self, to_agent_id: &AgentPubKey, content: Vec<u8>) -> String {
         let current_space = self.current_space.clone().expect("Current Space not set");
         let request_id = self.generate_request_id();
         debug!("current_space: {:?}", self.current_space);
@@ -476,7 +476,7 @@ impl NodeMock {
     pub fn send_response(
         &mut self,
         request_id: &str,
-        to_agent_id: &Address,
+        to_agent_id: &AgentPubKey,
         response_content: Vec<u8>,
     ) {
         self.send_response_inner(request_id, to_agent_id, response_content)
@@ -487,7 +487,7 @@ impl NodeMock {
     pub fn send_response_inner(
         &mut self,
         request_id: &str,
-        to_agent_id: &Address,
+        to_agent_id: &AgentPubKey,
         response_content: Vec<u8>,
     ) -> Result<(), lib3h_protocol::error::Lib3hProtocolError> {
         let current_space = self.current_space.clone().expect("Current Space not set");
@@ -708,7 +708,7 @@ impl NodeMock {
         wait_engine_wrapper_until_no_work!(me)
     }
 
-    pub fn agent_id(&self) -> Address {
+    pub fn agent_id(&self) -> AgentPubKey {
         self.agent_id.clone()
     }
 }

--- a/crates/lib3h/tests/node_mock/mod.rs
+++ b/crates/lib3h/tests/node_mock/mod.rs
@@ -7,9 +7,7 @@ use lib3h::{
     engine::{ghost_engine_wrapper::WrappedGhostLib3h, EngineConfig},
     error::Lib3hResult,
 };
-use lib3h_protocol::{
-    protocol_server::Lib3hServerProtocol, types::SpaceHash, uri::Lib3hUri, Address,
-};
+use lib3h_protocol::{protocol_server::Lib3hServerProtocol, types::*, uri::Lib3hUri};
 use std::collections::{HashMap, HashSet};
 
 static TIMEOUT_MS: usize = 5000;
@@ -29,7 +27,7 @@ pub struct NodeMock {
     /// Factory used to create the engine
     engine_factory: EngineFactory,
     /// The node's simulated agentId
-    pub agent_id: Address,
+    pub agent_id: AgentPubKey,
     /// The node's uri
     my_advertise: Lib3hUri,
     /// This node's handle
@@ -56,7 +54,7 @@ pub struct NodeMock {
 impl NodeMock {
     pub fn new_with_config(
         name: &str,
-        agent_id_arg: Address,
+        agent_id_arg: AgentPubKey,
         config: EngineConfig,
         engine_factory: EngineFactory,
         //_maybe_temp_dir: Option<tempfile::TempDir>,

--- a/crates/lib3h/tests/test_suites/three_basic.rs
+++ b/crates/lib3h/tests/test_suites/three_basic.rs
@@ -75,7 +75,7 @@ fn test_send_message(alex: &mut NodeMock, billy: &mut NodeMock, camille: &mut No
     // A sends DM to B
     // ===============
     let _req_id = alex.send_direct_message(&BILLY_AGENT_ID, "wah".as_bytes().to_vec());
-    let expected = "HandleSendDirectMessage\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"billy\"\\), from_agent_id: HashString\\(\"alex\"\\), content: \"wah\" \\}\\)";
+    let expected = "HandleSendDirectMessage\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), from_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), content: \"wah\" \\}\\)";
     let results = assert2_msg_matches!(alex, billy, expected);
     let handle_send_direct_msg = results.first().unwrap();
     let event = handle_send_direct_msg.events.first().unwrap();
@@ -95,7 +95,7 @@ fn test_send_message(alex: &mut NodeMock, billy: &mut NodeMock, camille: &mut No
         msg.request_id
     );
     billy.send_response(&msg.request_id, &alex.agent_id(), response_content.clone());
-    let expected = "SendDirectMessageResult\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"alex\"\\), from_agent_id: HashString\\(\"billy\"\\), content: \"echo: wah\" \\}\\)";
+    let expected = "SendDirectMessageResult\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), from_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), content: \"echo: wah\" \\}\\)";
     assert2_msg_matches!(alex, billy, expected);
 
     // C sends DM to A
@@ -103,7 +103,7 @@ fn test_send_message(alex: &mut NodeMock, billy: &mut NodeMock, camille: &mut No
     println!("\nCamille sends DM to Alex...\n");
 
     let _req_id = camille.send_direct_message(&ALEX_AGENT_ID, "marco".as_bytes().to_vec());
-    let expected = "HandleSendDirectMessage\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"alex\"\\), from_agent_id: HashString\\(\"camille\"\\), content: \"marco\" \\}\\)";
+    let expected = "HandleSendDirectMessage\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), from_agent_id: AgentPubKey\\(HashString\\(\"camille\"\\)\\), content: \"marco\" \\}\\)";
     let results = assert2_msg_matches!(alex, camille, expected);
     let handle_send_direct_msg = results.first().unwrap();
     let event = handle_send_direct_msg.events.first().unwrap();
@@ -128,7 +128,7 @@ fn test_send_message(alex: &mut NodeMock, billy: &mut NodeMock, camille: &mut No
         &camille.agent_id(),
         response_content.clone(),
     );
-    let expected = "SendDirectMessageResult\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"camille\"\\), from_agent_id: HashString\\(\"alex\"\\), content: \"echo: marco\" \\}\\)";
+    let expected = "SendDirectMessageResult\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: AgentPubKey\\(HashString\\(\"camille\"\\)\\), from_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), content: \"echo: marco\" \\}\\)";
     assert2_msg_matches!(alex, camille, expected);
 }
 
@@ -144,7 +144,7 @@ fn test_author_and_hold(alex: &mut NodeMock, billy: &mut NodeMock, camille: &mut
     alex.reply_to_first_HandleGetGossipingEntryList();
 
     // Should receive a HandleFetchEntry request from network module after receiving list
-    let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: HashString\\(\"alex\"\\), aspect_address_list: None \\}\\)";
+    let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), aspect_address_list: None \\}\\)";
     let results = assert_msg_matches!(alex, expected);
     let fetch_event = &results[0].events[0];
     // extract msg data
@@ -158,9 +158,9 @@ fn test_author_and_hold(alex: &mut NodeMock, billy: &mut NodeMock, camille: &mut
         .expect("Reply to HandleFetchEntry should work");
 
     // Expect HandleStoreEntryAspect from receiving entry via gossip
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(alex, billy, expected);
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: HashString\\(\"camille\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"camille\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(alex, camille, expected);
 
     // Billy publish data on the network
@@ -170,10 +170,10 @@ fn test_author_and_hold(alex: &mut NodeMock, billy: &mut NodeMock, camille: &mut
         .unwrap();
     // let (did_work, _srv_msg_list) = billy.process().unwrap();
 
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: HashString\\(\"alex\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_2\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"l-2\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_2\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"l-2\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(alex, billy, expected);
 
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: HashString\\(\"camille\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_2\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"l-2\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"camille\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_2\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"l-2\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(camille, billy, expected);
 
     request_entry_ok(camille, &entry_1);

--- a/crates/lib3h/tests/test_suites/two_basic.rs
+++ b/crates/lib3h/tests/test_suites/two_basic.rs
@@ -53,7 +53,7 @@ pub fn request_entry_ok(node: &mut NodeMock, entry: &EntryData) {
     println!("\n{} requesting entry: {}\n", node.name(), enty_address_str);
     let mut query_data = node.request_entry(entry.entry_address.clone());
 
-    let expected = "HandleQueryEntry\\(QueryEntryData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), entry_address: EntryHash\\(HashString\\(\"[\\w\\d_~]+\"\\)\\), request_id: \"[\\w\\d_~]+\", requester_agent_id: HashString\\(\"[\\w\\d]+\"\\), query: \"test_query\" \\}\\)";
+    let expected = "HandleQueryEntry\\(QueryEntryData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), entry_address: EntryHash\\(HashString\\(\"[\\w\\d_~]+\"\\)\\), request_id: \"[\\w\\d_~]+\", requester_agent_id: AgentPubKey\\(HashString\\(\"[\\w\\d]+\"\\)\\), query: \"test_query\" \\}\\)";
     let results = assert_msg_matches!(node, expected);
     println!("\n results: {:?}\n", results);
     let handle_query = &results[0].events[0];
@@ -68,7 +68,7 @@ pub fn request_entry_ok(node: &mut NodeMock, entry: &EntryData) {
     println!("\n{} reply to own request: {:?}\n", node.name(), query_data);
     let _ = node.reply_to_HandleQueryEntry(&query_data).unwrap();
 
-    let expected = "QueryEntryResult\\(QueryEntryResultData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), entry_address: EntryHash\\(HashString\\(\"[\\w\\d_~]+\"\\)\\), request_id: \"[\\w\\d_~]+\", requester_agent_id: HashString\\(\"[\\w\\d]+\"\\), responder_agent_id: HashString\\(\"[\\w\\d]+\"\\), query_result: ";
+    let expected = "QueryEntryResult\\(QueryEntryResultData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), entry_address: EntryHash\\(HashString\\(\"[\\w\\d_~]+\"\\)\\), request_id: \"[\\w\\d_~]+\", requester_agent_id: AgentPubKey\\(HashString\\(\"[\\w\\d]+\"\\)\\), responder_agent_id: AgentPubKey\\(HashString\\(\"[\\w\\d]+\"\\)\\), query_result: ";
 
     let results = assert_msg_matches!(node, expected);
     println!("\n results: {:?}\n", results);
@@ -124,7 +124,7 @@ pub fn test_send_message(alex: &mut NodeMock, billy: &mut NodeMock, options: &Pr
     // Send DM
     let _req_id = alex.send_direct_message(&BILLY_AGENT_ID, "wah".as_bytes().to_vec());
 
-    let expected = "HandleSendDirectMessage\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"billy\"\\), from_agent_id: HashString\\(\"alex\"\\), content: \"wah\" \\}\\)";
+    let expected = "HandleSendDirectMessage\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), from_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), content: \"wah\" \\}\\)";
     let results = assert2_msg_matches!(alex, billy, expected, options);
     let handle_send_direct_msg = results.first().unwrap();
     let event = handle_send_direct_msg.events.first().unwrap();
@@ -138,7 +138,7 @@ pub fn test_send_message(alex: &mut NodeMock, billy: &mut NodeMock, options: &Pr
     );
     billy.send_response(&msg.request_id, &alex.agent_id(), response_content.clone());
 
-    let expected = "SendDirectMessageResult\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"alex\"\\), from_agent_id: HashString\\(\"billy\"\\), content: \"echo: wah\" \\}\\)";
+    let expected = "SendDirectMessageResult\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), from_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), content: \"echo: wah\" \\}\\)";
     assert2_msg_matches!(alex, billy, expected, options);
 }
 
@@ -149,7 +149,7 @@ fn test_send_message_fail(alex: &mut NodeMock, _billy: &mut NodeMock, options: &
     // Send to unknown
     let _req_id = alex.send_direct_message(&CAMILLE_AGENT_ID, "wah".as_bytes().to_vec());
 
-    let expected = "FailureResult\\(GenericResultData \\{ request_id: \"req_alex_3\", space_address: SpaceHash\\(HashString\\(\"appA\"\\), to_agent_id: HashString\\(\"camille\"\\), result_info: ";
+    let expected = "FailureResult\\(GenericResultData \\{ request_id: \"req_alex_3\", space_address: SpaceHash\\(HashString\\(\"appA\"\\), to_agent_id: AgentPubKey\\(HashString\\(\"camille\"\\)\\), result_info: ";
     assert_msg_matches!(alex, expected, options);
 }
 
@@ -162,7 +162,7 @@ pub fn test_send_message_self(
     // Send DM
     let _req_id = alex.send_direct_message(&ALEX_AGENT_ID, "wah".as_bytes().to_vec());
 
-    let expected = "HandleSendDirectMessage\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"alex\"\\), from_agent_id: HashString\\(\"alex\"\\), content: \"wah\" \\}\\)";
+    let expected = "HandleSendDirectMessage\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), from_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), content: \"wah\" \\}\\)";
 
     let results = assert_msg_matches!(alex, expected, options);
 
@@ -181,7 +181,7 @@ pub fn test_send_message_self(
     alex.send_response(&msg.request_id, &alex.agent_id(), response_content.clone());
 
     // TODO Set this to correct value once test passes
-    let expected = "SendDirectMessageResult\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: HashString\\(\"alex\"\\), from_agent_id: HashString\\(\"alex\"\\), content: \"echo: wah\" \\}\\)";
+    let expected = "SendDirectMessageResult\\(DirectMessageData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), request_id: \"[\\w\\d_~]+\", to_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), from_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), content: \"echo: wah\" \\}\\)";
 
     assert_msg_matches!(alex, expected, options);
 }
@@ -198,7 +198,7 @@ pub fn test_author_one_aspect(
         .author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
         .unwrap();
 
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Billy asks for that entry
@@ -208,7 +208,7 @@ pub fn test_author_one_aspect(
     // Billy asks for unknown entry
     // ============================
     let mut query_data = billy.request_entry(ENTRY_ADDRESS_2.clone());
-    let expected = "HandleQueryEntry\\(QueryEntryData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_2\"\\)\\), request_id: \"[\\w\\d_~]+\", requester_agent_id: HashString\\(\"billy\"\\), query: \"test_query\" \\}\\)";
+    let expected = "HandleQueryEntry\\(QueryEntryData \\{ space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_2\"\\)\\), request_id: \"[\\w\\d_~]+\", requester_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), query: \"test_query\" \\}\\)";
     let results = assert2_msg_matches!(alex, billy, expected, options);
     println!("\n results: {:?}\n", results);
     let handle_query = &results[0].events[0];
@@ -266,7 +266,7 @@ fn test_author_two_aspects(alex: &mut NodeMock, billy: &mut NodeMock, options: &
     let (_did_work, srv_msg_list) = alex.process().unwrap();
     assert_eq!(srv_msg_list.len(), 2);
 
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"[\\w\\d\\-]+\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"[\\w\\d\\-]+\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(alex, billy, expected, options);
     let mut entry = billy.get_entry(&ENTRY_ADDRESS_1).unwrap();
     entry.aspect_list.sort();
@@ -287,7 +287,7 @@ fn test_two_authors(alex: &mut NodeMock, billy: &mut NodeMock, options: &Process
     let (_did_work, srv_msg_list) = alex.process().unwrap();
     assert_eq!(srv_msg_list.len(), 1);
 
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"[\\w\\d\\-]+\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"[\\w\\d\\-]+\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Billy authors and broadcast second aspect
@@ -298,7 +298,7 @@ fn test_two_authors(alex: &mut NodeMock, billy: &mut NodeMock, options: &Process
     let (_did_work, srv_msg_list) = billy.process().unwrap();
     assert_eq!(srv_msg_list.len(), 1);
 
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: HashString\\(\"[\\w\\d]+\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"[\\w\\d\\-]+\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"[\\w\\d]+\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"[\\w\\d\\-]+\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Alex asks for that entry

--- a/crates/lib3h/tests/test_suites/two_get_lists.rs
+++ b/crates/lib3h/tests/test_suites/two_get_lists.rs
@@ -29,7 +29,7 @@ pub fn author_list_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &Pro
     alex.reply_to_first_HandleGetAuthoringEntryList();
 
     // Should receive a HandleFetchEntry request from network module after receiving list
-    let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: HashString\\(\"alex\"\\), aspect_address_list: None \\}\\)";
+    let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), aspect_address_list: None \\}\\)";
     let results = assert2_msg_matches!(alex, billy, expected, options);
     let fetch_event = &results[0].events[0];
     // extract msg data
@@ -40,7 +40,7 @@ pub fn author_list_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &Pro
         .expect("Reply to HandleFetchEntry should work");
 
     // Expecting a HandleStoreEntryAspect
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Billy asks for that entry
@@ -57,7 +57,7 @@ pub fn hold_list_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &Proce
     alex.reply_to_first_HandleGetGossipingEntryList();
 
     // Should receive a HandleFetchEntry request from network module after receiving list
-    let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: HashString\\(\"alex\"\\), aspect_address_list: None \\}\\)";
+    let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), aspect_address_list: None \\}\\)";
     let results = assert2_msg_matches!(alex, billy, expected, options);
     let fetch_event = &results[0].events[0];
     // extract msg data
@@ -71,7 +71,7 @@ pub fn hold_list_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &Proce
         .expect("Reply to HandleFetchEntry should work");
 
     // Expect HandleStoreEntryAspect from receiving entry via gossip
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Billy asks for that entry
@@ -95,7 +95,7 @@ pub fn empty_author_list_test(
     let _query_data = billy.request_entry(ENTRY_ADDRESS_1.clone());
 
     // Receives back the HandleQuery
-    let expected = "HandleQueryEntry\\(QueryEntryData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), request_id: \"[\\w\\d_~]+\", requester_agent_id: HashString\\(\"billy\"\\), query: \"test_query\" \\}\\)";
+    let expected = "HandleQueryEntry\\(QueryEntryData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), request_id: \"[\\w\\d_~]+\", requester_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), query: \"test_query\" \\}\\)";
     let results = assert2_msg_matches!(alex, billy, expected, options);
     let query_event = &results[0].events[0];
     // extract msg data
@@ -126,7 +126,7 @@ pub fn author_list_known_entry_test(
     let entry = alex
         .author_entry(&ENTRY_ADDRESS_1, vec![ASPECT_CONTENT_1.clone()], true)
         .unwrap();
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     alex.reply_to_first_HandleGetAuthoringEntryList();
@@ -157,7 +157,7 @@ pub fn many_aspects_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &Pr
         .unwrap();
     println!("\nAlex authored and stored Aspects \n");
 
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"[\\w\\d\\-]+\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"[\\w\\d\\-]+\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // TODO figure out something to explicit wait for
@@ -170,7 +170,7 @@ pub fn many_aspects_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &Pr
     alex.reply_to_first_HandleGetAuthoringEntryList();
 
     // Should receive a HandleFetchEntry request from network module after receiving authoring list
-    let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: HashString\\(\"alex\"\\), aspect_address_list: None \\}\\)";
+    let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), aspect_address_list: None \\}\\)";
     let results = assert2_msg_matches!(alex, billy, expected, options);
     let fetch_event = &results[0].events[0];
     // extract msg data
@@ -180,7 +180,7 @@ pub fn many_aspects_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &Pr
     alex.reply_to_HandleFetchEntry(&fetch_data)
         .expect("Reply to HandleFetchEntry should work");
 
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_1\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"hello-1\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(alex, billy, expected, options);
     let mut entry = billy.get_entry(&ENTRY_ADDRESS_1).unwrap();
     entry.aspect_list.sort();
@@ -192,7 +192,7 @@ pub fn many_aspects_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &Pr
     alex.reply_to_first_HandleGetGossipingEntryList();
 
     // Should receive a HandleFetchEntry request from network module after receiving list
-    let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_2\"\\)\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: HashString\\(\"alex\"\\), aspect_address_list: None \\}\\)";
+    let expected = "HandleFetchEntry\\(FetchEntryData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_2\"\\)\\), request_id: \"[\\w\\d_~]+\", provider_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), aspect_address_list: None \\}\\)";
     let results = assert2_msg_matches!(alex, billy, expected, options);
     trace!("results: {:?}", results);
     // Get FetchEntryData for ENTRY_ADDRESS_2
@@ -216,7 +216,7 @@ pub fn many_aspects_test(alex: &mut NodeMock, billy: &mut NodeMock, options: &Pr
         .expect("Reply to HandleFetchEntry should work");
     debug!("Waiting for HandleStoreEntryAspect... ");
     // Expect HandleStoreEntryAspect from receiving entry via gossip
-    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: HashString\\(\"billy\"\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_2\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"other-4\", publish_ts: \\d+ \\} \\}\\)";
+    let expected = "HandleStoreEntryAspect\\(StoreEntryAspectData \\{ request_id: \"[\\w\\d_~]+\", space_address: SpaceHash\\(HashString\\(\"\\w+\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), entry_address: EntryHash\\(HashString\\(\"entry_addr_2\"\\)\\), entry_aspect: EntryAspectData \\{ aspect_address: AspectHash\\(HashString\\(\"[\\w\\d]+\"\\)\\), type_hint: \"NodeMock\", aspect: \"other-4\", publish_ts: \\d+ \\} \\}\\)";
     let _results = assert2_msg_matches!(alex, billy, expected, options);
 
     // Billy asks for that entry

--- a/crates/lib3h/tests/test_suites/two_spaces.rs
+++ b/crates/lib3h/tests/test_suites/two_spaces.rs
@@ -135,7 +135,7 @@ pub fn test_multispace_send(
     alex.set_current_space(&SPACE_ADDRESS_A);
     billy.set_current_space(&SPACE_ADDRESS_A);
     let _req_id = alex.send_direct_message(&BILLY_AGENT_ID, "marco".as_bytes().to_vec());
-    let expected = "FailureResult\\(GenericResultData \\{ request_id: \"req_alex_8\", space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), to_agent_id: HashString\\(\"billy\"\\), result_info: ";
+    let expected = "FailureResult\\(GenericResultData \\{ request_id: \"req_alex_8\", space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), to_agent_id: AgentPubKey\\(HashString\\(\"billy\"\\)\\), result_info: ";
 
     let _results = assert2_msg_matches!(alex, billy, expected, options);
 }

--- a/crates/lib3h/tests/utils/constants.rs
+++ b/crates/lib3h/tests/utils/constants.rs
@@ -1,5 +1,5 @@
 use holochain_persistence_api::hash::HashString;
-use lib3h_protocol::{types::*, Address};
+use lib3h_protocol::types::*;
 use multihash::Hash;
 use std::sync::{Arc, Mutex};
 
@@ -7,9 +7,9 @@ lazy_static! {
     /// Networks
     pub static ref NETWORK_A_ID: String = "net_A".to_string();
     /// Agents
-    pub static ref ALEX_AGENT_ID: Address = "alex".into();
-    pub static ref BILLY_AGENT_ID: Address = "billy".into();
-    pub static ref CAMILLE_AGENT_ID: Address = "camille".into();
+    pub static ref ALEX_AGENT_ID: AgentPubKey = "alex".into();
+    pub static ref BILLY_AGENT_ID: AgentPubKey = "billy".into();
+    pub static ref CAMILLE_AGENT_ID: AgentPubKey = "camille".into();
     /// Spaces
     pub static ref SPACE_ADDRESS_A: SpaceHash = "appA".into();
     pub static ref SPACE_ADDRESS_B: SpaceHash = "appB".into();

--- a/crates/lib3h/tests/utils/processor_harness.rs
+++ b/crates/lib3h/tests/utils/processor_harness.rs
@@ -742,7 +742,7 @@ macro_rules! wait_connect {
     ) => {{
         let _connect_data = $connect_data;
         $crate::assert2_msg_matches!($me, $other,
-            "Connected\\(ConnectedData \\{ request_id: \"client_to_lib3_response_.*\", uri: Lib3hUri\\(\"transportid:Hc.*\"\\) \\}\\)")
+            "Connected\\(ConnectedData \\{ request_id: \"client_to_lib3_response_.*\", uri: Lib3hUri\\(\"nodepubkey:HcM.*\"\\) \\}\\)")
     }};
 }
 

--- a/crates/lib3h_protocol/src/data_types.rs
+++ b/crates/lib3h_protocol/src/data_types.rs
@@ -1,4 +1,4 @@
-use crate::{types::*, uri::Lib3hUri, Address};
+use crate::{types::*, uri::Lib3hUri};
 use std::cmp::Ordering;
 
 /// Represents an opaque vector of bytes. Lib3h will
@@ -146,7 +146,7 @@ impl EntryData {
 pub struct GenericResultData {
     pub request_id: String,
     pub space_address: SpaceHash,
-    pub to_agent_id: Address,
+    pub to_agent_id: AgentPubKey,
     pub result_info: Opaque,
 }
 
@@ -177,7 +177,7 @@ pub struct BootstrapData {
     pub space_address: SpaceHash,
     /// connection uri, such as
     ///   `wss://1.2.3.4:55888?a=HcMyada`
-    ///   `transportid:HcMyada?a=HcSagent`
+    ///   `nodepubkey:HcMyada?a=HcSagent`
     pub bootstrap_uri: Lib3hUri,
 }
 
@@ -229,7 +229,7 @@ pub struct SpaceData {
     /// Identifier of this request
     pub request_id: String,
     pub space_address: SpaceHash,
-    pub agent_id: Address,
+    pub agent_id: AgentPubKey,
 }
 
 //--------------------------------------------------------------------------------------------------
@@ -240,8 +240,8 @@ pub struct SpaceData {
 pub struct DirectMessageData {
     pub space_address: SpaceHash,
     pub request_id: String,
-    pub to_agent_id: Address,
-    pub from_agent_id: Address,
+    pub to_agent_id: AgentPubKey,
+    pub from_agent_id: AgentPubKey,
     pub content: Opaque,
 }
 
@@ -254,7 +254,7 @@ pub struct QueryEntryData {
     pub space_address: SpaceHash,
     pub entry_address: EntryHash,
     pub request_id: String,
-    pub requester_agent_id: Address,
+    pub requester_agent_id: AgentPubKey,
     pub query: Opaque,
 }
 
@@ -263,8 +263,8 @@ pub struct QueryEntryResultData {
     pub space_address: SpaceHash,
     pub entry_address: EntryHash,
     pub request_id: String,
-    pub requester_agent_id: Address,
-    pub responder_agent_id: Address,
+    pub requester_agent_id: AgentPubKey,
+    pub responder_agent_id: AgentPubKey,
     pub query_result: Opaque, // opaque query-result struct
 }
 
@@ -276,7 +276,7 @@ pub struct QueryEntryResultData {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct ProvidedEntryData {
     pub space_address: SpaceHash,
-    pub provider_agent_id: Address,
+    pub provider_agent_id: AgentPubKey,
     pub entry: EntryData,
 }
 
@@ -284,7 +284,7 @@ pub struct ProvidedEntryData {
 pub struct StoreEntryAspectData {
     pub request_id: String,
     pub space_address: SpaceHash,
-    pub provider_agent_id: Address,
+    pub provider_agent_id: AgentPubKey,
     pub entry_address: EntryHash,
     pub entry_aspect: EntryAspectData,
 }
@@ -307,7 +307,7 @@ pub struct FetchEntryData {
     pub space_address: SpaceHash,
     pub entry_address: EntryHash,
     pub request_id: String,
-    pub provider_agent_id: Address,
+    pub provider_agent_id: AgentPubKey,
     pub aspect_address_list: Option<Vec<AspectHash>>, // None -> Get all, otherwise get specified aspects
 }
 
@@ -315,7 +315,7 @@ pub struct FetchEntryData {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct FetchEntryResultData {
     pub space_address: SpaceHash,
-    pub provider_agent_id: Address,
+    pub provider_agent_id: AgentPubKey,
     pub request_id: String,
     pub entry: EntryData,
 }
@@ -328,14 +328,14 @@ pub struct FetchEntryResultData {
 pub struct GetListData {
     pub space_address: SpaceHash,
     /// Request List from a specific Agent
-    pub provider_agent_id: Address,
+    pub provider_agent_id: AgentPubKey,
     pub request_id: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
 pub struct EntryListData {
     pub space_address: SpaceHash,
-    pub provider_agent_id: Address,
+    pub provider_agent_id: AgentPubKey,
     pub request_id: String,
     // Aspect addresses per entry
     pub address_map: std::collections::HashMap<EntryHash, Vec<AspectHash>>,

--- a/crates/lib3h_protocol/src/types.rs
+++ b/crates/lib3h_protocol/src/types.rs
@@ -135,3 +135,93 @@ impl AspectHash {
         AspectHash(HashString::new())
     }
 }
+
+//--------------------------------------------------------------------------------------------------
+// AgentPubKey: newtype for HashString
+//--------------------------------------------------------------------------------------------------
+
+#[derive(
+    Shrinkwrap, PartialOrd, PartialEq, Eq, Ord, Clone, Debug, Serialize, Deserialize, Default, Hash,
+)]
+pub struct AgentPubKey(HashString);
+
+impl fmt::Display for AgentPubKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<HashString> for AgentPubKey {
+    fn from(s: HashString) -> AgentPubKey {
+        AgentPubKey(s)
+    }
+}
+
+impl From<AgentPubKey> for HashString {
+    fn from(h: AgentPubKey) -> HashString {
+        h.0
+    }
+}
+
+impl<'a> From<&'a HashString> for AgentPubKey {
+    fn from(s: &HashString) -> AgentPubKey {
+        AgentPubKey::from(s.to_owned())
+    }
+}
+
+impl<'a> From<&'a str> for AgentPubKey {
+    fn from(s: &str) -> AgentPubKey {
+        HashString::from(s.to_owned()).into()
+    }
+}
+
+impl AgentPubKey {
+    pub fn new() -> AgentPubKey {
+        AgentPubKey(HashString::new())
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// NodePubKey: newtype for HashString
+//--------------------------------------------------------------------------------------------------
+
+#[derive(
+    Shrinkwrap, PartialOrd, PartialEq, Eq, Ord, Clone, Debug, Serialize, Deserialize, Default, Hash,
+)]
+pub struct NodePubKey(HashString);
+
+impl fmt::Display for NodePubKey {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<HashString> for NodePubKey {
+    fn from(s: HashString) -> NodePubKey {
+        NodePubKey(s)
+    }
+}
+
+impl From<NodePubKey> for HashString {
+    fn from(h: NodePubKey) -> HashString {
+        h.0
+    }
+}
+
+impl<'a> From<&'a HashString> for NodePubKey {
+    fn from(s: &HashString) -> NodePubKey {
+        NodePubKey::from(s.to_owned())
+    }
+}
+
+impl<'a> From<&'a str> for NodePubKey {
+    fn from(s: &str) -> NodePubKey {
+        HashString::from(s.to_owned()).into()
+    }
+}
+
+impl NodePubKey {
+    pub fn new() -> NodePubKey {
+        NodePubKey(HashString::new())
+    }
+}

--- a/crates/lib3h_protocol/src/uri.rs
+++ b/crates/lib3h_protocol/src/uri.rs
@@ -1,4 +1,4 @@
-use crate::{error::Lib3hProtocolError, Address};
+use crate::{error::Lib3hProtocolError, types::*};
 use std::convert::{TryFrom, TryInto};
 use url::Url;
 
@@ -6,26 +6,26 @@ use url::Url;
 // UriScheme
 //--------------------------------------------------------------------------------------------------
 
-static AGENT_SCHEME: &'static str = "agentid";
-static TRANSPORT_SCHEME: &'static str = "transportid";
+static AGENT_SCHEME: &'static str = "agentpubkey";
+static NODE_SCHEME: &'static str = "nodepubkey";
 static MEMORY_SCHEME: &'static str = "mem";
 static UNDEFINED_SCHEME: &'static str = "none";
 
 pub enum UriScheme {
-    Agent,
-    Transport,
-    Memory,
     Undefined,
+    Agent,
+    Node,
+    Memory,
     Other(String),
 }
 
 impl From<UriScheme> for &str {
     fn from(scheme: UriScheme) -> &'static str {
         match scheme {
-            UriScheme::Agent => AGENT_SCHEME,
-            UriScheme::Transport => TRANSPORT_SCHEME,
-            UriScheme::Memory => MEMORY_SCHEME,
             UriScheme::Undefined => UNDEFINED_SCHEME,
+            UriScheme::Agent => AGENT_SCHEME,
+            UriScheme::Node => NODE_SCHEME,
+            UriScheme::Memory => MEMORY_SCHEME,
             UriScheme::Other(_) => "",
         }
     }
@@ -34,10 +34,10 @@ impl From<UriScheme> for &str {
 impl From<UriScheme> for String {
     fn from(scheme: UriScheme) -> String {
         match scheme {
-            UriScheme::Agent => AGENT_SCHEME.into(),
-            UriScheme::Transport => TRANSPORT_SCHEME.into(),
-            UriScheme::Memory => MEMORY_SCHEME.into(),
             UriScheme::Undefined => UNDEFINED_SCHEME.into(),
+            UriScheme::Agent => AGENT_SCHEME.into(),
+            UriScheme::Node => NODE_SCHEME.into(),
+            UriScheme::Memory => MEMORY_SCHEME.into(),
             UriScheme::Other(s) => s.clone(),
         }
     }
@@ -54,19 +54,15 @@ pub struct Lib3hUri(pub Url);
 impl Lib3hUri {
     // -- Constructors -- //
 
-    #[allow(dead_code)]
-    pub fn with_transport_and_agent_id(transport_id: &Address, agent_id: &Address) -> Self {
-        let url = Self::parse(&format!(
-            "{}:{}?a={}",
-            TRANSPORT_SCHEME, transport_id, agent_id
-        ));
+    pub fn with_node_and_agent_id(node_id: &NodePubKey, agent_id: &AgentPubKey) -> Self {
+        let url = Self::parse(&format!("{}:{}?a={}", NODE_SCHEME, node_id, agent_id));
         Lib3hUri(url)
     }
-    pub fn with_transport_id(transport_id: &Address) -> Self {
-        let url = Self::parse(&format!("{}:{}", TRANSPORT_SCHEME, transport_id));
+    pub fn with_node_id(node_id: &NodePubKey) -> Self {
+        let url = Self::parse(&format!("{}:{}", NODE_SCHEME, node_id));
         Lib3hUri(url)
     }
-    pub fn with_agent_id(agent_id: &Address) -> Self {
+    pub fn with_agent_id(agent_id: &AgentPubKey) -> Self {
         let url = Self::parse(&format!("{}:{}", AGENT_SCHEME, agent_id));
         Lib3hUri(url)
     }
@@ -85,6 +81,12 @@ impl Lib3hUri {
     pub fn is_scheme(&self, scheme: UriScheme) -> bool {
         let s: String = scheme.into();
         self.scheme() == s
+    }
+
+    /// True if its a TransportUri
+    pub fn is_transport(&self) -> bool {
+        let this_scheme = self.scheme();
+        this_scheme != UNDEFINED_SCHEME && this_scheme != NODE_SCHEME && this_scheme != AGENT_SCHEME
     }
 
     /// new uri from &str
@@ -119,7 +121,8 @@ impl Lib3hUri {
     }
 
     /// set a higher-level agent_id i.e. ?a=agent_id
-    pub fn set_agent_id(&mut self, agent_id: &Address) {
+    pub fn set_agent_id(&mut self, agent_id: &AgentPubKey) {
+        assert!(self.is_scheme(UriScheme::Node));
         self.0
             .query_pairs_mut()
             .clear()
@@ -128,22 +131,30 @@ impl Lib3hUri {
 
     /// clear any higher-level agent_id
     pub fn clear_agent_id(&mut self) {
+        //assert!(self.is_scheme(UriScheme::Node), "{:?}", self);
         self.0.set_query(None);
     }
 
     /// do we have a higher-level agent_id? i.e. ?a=agent_id
-    pub fn agent_id(&self) -> Option<Address> {
+    pub fn get_agent_id(&self) -> Option<AgentPubKey> {
+        if !self.is_scheme(UriScheme::Node) {
+            return None;
+        }
         for (n, v) in self.0.query_pairs() {
             if &n == "a" {
-                return Some(v.to_string().into());
+                return Some(v.to_string().as_str().into());
             }
         }
         None
     }
 
-    /// get our lower component as an address
-    /// i.e. transportid:HcMyada would return HcMyada
-    pub fn lower_address(&self) -> Address {
+    pub fn node_id(&self) -> NodePubKey {
+        assert!(self.is_scheme(UriScheme::Node), "{:?}", self);
+        self.0.path().into()
+    }
+
+    pub fn agent_id(&self) -> AgentPubKey {
+        assert!(self.is_scheme(UriScheme::Agent), "{:?}", self);
         self.0.path().into()
     }
 }
@@ -203,15 +214,6 @@ impl Builder {
 
 // -- Converters -- //
 
-impl From<Lib3hUri> for Address {
-    fn from(u: Lib3hUri) -> Address {
-        if !(u.is_scheme(UriScheme::Agent) || u.is_scheme(UriScheme::Transport)) {
-            panic!("Can't convert a non *Id Lib3hUri into an address")
-        }
-        u.path().into()
-    }
-}
-
 impl TryFrom<&str> for Lib3hUri {
     type Error = Lib3hProtocolError;
     fn try_from(s: &str) -> Result<Self, Self::Error> {
@@ -245,8 +247,8 @@ mod tests {
     fn test_uri_scheme_convert_str() {
         let s: &str = UriScheme::Agent.into();
         assert_eq!(s, AGENT_SCHEME);
-        let s: &str = UriScheme::Transport.into();
-        assert_eq!(s, TRANSPORT_SCHEME);
+        let s: &str = UriScheme::Node.into();
+        assert_eq!(s, NODE_SCHEME);
         let s: &str = UriScheme::Memory.into();
         assert_eq!(s, MEMORY_SCHEME);
         let s: &str = UriScheme::Undefined.into();
@@ -256,8 +258,8 @@ mod tests {
     fn test_uri_scheme_convert_string() {
         let s: String = UriScheme::Agent.into();
         assert_eq!(s, AGENT_SCHEME.to_string());
-        let s: String = UriScheme::Transport.into();
-        assert_eq!(s, TRANSPORT_SCHEME.to_string());
+        let s: String = UriScheme::Node.into();
+        assert_eq!(s, NODE_SCHEME.to_string());
         let s: String = UriScheme::Memory.into();
         assert_eq!(s, MEMORY_SCHEME.to_string());
         let s: String = UriScheme::Undefined.into();
@@ -283,20 +285,21 @@ mod tests {
 
     #[test]
     fn test_address_from_uri() {
-        let id: Address = "HcAsdkfjsdflkjsdf".into();
+        let id: AgentPubKey = "HcAsdkfjsdflkjsdf".into();
         let uri = Lib3hUri::with_agent_id(&id);
-        let roundtrip: Address = uri.into();
+        let roundtrip: AgentPubKey = uri.agent_id();
         assert_eq!(roundtrip, id);
-        let uri = Lib3hUri::with_transport_id(&id);
-        let roundtrip: Address = uri.into();
+        let id: NodePubKey = "HcAsdkfjsdflkjsdf".into();
+        let uri = Lib3hUri::with_node_id(&id);
+        let roundtrip: NodePubKey = uri.node_id();
         assert_eq!(roundtrip, id);
     }
 
     #[test]
     fn test_uri_is_scheme() {
-        let uri = Lib3hUri::try_from("agentid:HcAsdkfjsdflkjsdf").unwrap();
+        let uri = Lib3hUri::try_from("agentpubkey:HcAsdkfjsdflkjsdf").unwrap();
         assert!(uri.is_scheme(UriScheme::Agent));
-        assert!(!uri.is_scheme(UriScheme::Transport));
+        assert!(!uri.is_scheme(UriScheme::Node));
         let uri = Lib3hUri::try_from("ws:x").unwrap();
         assert!(!uri.is_scheme(UriScheme::Agent));
         assert!(uri.is_scheme(UriScheme::Other("ws".to_string())));
@@ -305,22 +308,19 @@ mod tests {
 
     #[test]
     fn test_uri_create_transport() {
-        let transport_id: Address = "fake_transport_id".into();
-        let agent_id: Address = "HcAfake_agent_id".into();
-        let mut uri = Lib3hUri::with_transport_and_agent_id(&transport_id, &agent_id);
+        let node_id: NodePubKey = "fake_node_id".into();
+        let agent_id: AgentPubKey = "HcAfake_agent_id".into();
+        let mut uri = Lib3hUri::with_node_and_agent_id(&node_id, &agent_id);
         assert_eq!(
-            "Lib3hUri(\"transportid:fake_transport_id?a=HcAfake_agent_id\")",
+            "Lib3hUri(\"nodepubkey:fake_node_id?a=HcAfake_agent_id\")",
             format!("{:?}", uri)
         );
-        assert_eq!(
-            Some(Address::from("HcAfake_agent_id".to_string())),
-            uri.agent_id(),
-        );
-        uri.set_agent_id(&"bla".to_string().into());
-        assert_eq!(Some(Address::from("bla".to_string())), uri.agent_id());
-        assert_eq!(Address::from("fake_transport_id"), uri.lower_address());
+        assert_eq!(Some("HcAfake_agent_id".into()), uri.get_agent_id());
+        uri.set_agent_id(&"bla".into());
+        assert_eq!(Some("bla".into()), uri.get_agent_id());
+        assert_eq!(NodePubKey::from("fake_node_id"), uri.node_id());
         uri.clear_agent_id();
-        assert_eq!(None, uri.agent_id());
+        assert_eq!(None, uri.get_agent_id());
     }
 
     #[test]

--- a/crates/mdns/src/record.rs
+++ b/crates/mdns/src/record.rs
@@ -286,7 +286,7 @@ fn convert_to_mdns_hostname(hostname: &str) -> String {
 #[test]
 fn map_record_update_test() {
     let networkid = "hcnmynetworkid.hc-mdns-discovery.holo.host";
-    let url = "wss://1.2.3.4:12345?a=HcMmymachineid";
+    let url = "wss://1.2.3.4:12345?a=HcMmynodeid";
     let record_to_prune1 = Record::new(networkid, url, 255);
     let record_to_prune2 = Record::new(networkid, url, 200);
     // Because this record has the smallest ttl, it's the one that supposed to be kept during the dedup


### PR DESCRIPTION
added `Lib3hUri::is_transport()` and helper for making a Lib3hUri out of a dht PeerData.