### PR TITLE
Switch to a wrapper around parking_lot::Mutex for Mutex

### DIFF
--- a/crates/ghost_actor/Cargo.toml
+++ b/crates/ghost_actor/Cargo.toml
@@ -17,8 +17,10 @@ holochain_tracing = { version = "=0.0.1", git = "https://github.com/holochain/ho
 Inflector = "=0.11.4"
 lazy_static = "=1.2.0"
 lib3h_zombie_actor = { version = "=0.0.13", path = "../zombie_actor" }
+lock_api = "=0.1.5"
 log = "=0.4.8"
 nanoid = "=0.2.0"
+parking_lot = "=0.7.1"
 proc-macro2 = "=1.0.3"
 quote = "=1.0.2"
 shrinkwraprs = "=0.2.1"

--- a/crates/ghost_actor/src/ghost_mutex.rs
+++ b/crates/ghost_actor/src/ghost_mutex.rs
@@ -1,0 +1,197 @@
+extern crate lock_api;
+extern crate parking_lot;
+
+use std::{
+    borrow::{Borrow, BorrowMut},
+    convert::{AsMut, AsRef},
+    ops::{Deref, DerefMut},
+};
+
+#[must_use]
+pub struct GhostMutexGuard<'lt, T: ?Sized + 'lt> {
+    guard: Option<parking_lot::MutexGuard<'lt, T>>,
+}
+
+impl<'lt, T: ?Sized + 'lt> Drop for GhostMutexGuard<'lt, T> {
+    fn drop(&mut self) {
+        match std::mem::replace(&mut self.guard, None) {
+            Some(guard) => {
+                parking_lot::MutexGuard::unlock_fair(guard);
+            }
+            None => (),
+        }
+    }
+}
+
+impl<'lt, T: ?Sized + 'lt> Deref for GhostMutexGuard<'lt, T> {
+    type Target = T;
+
+    fn deref(&self) -> &T {
+        &*self.guard.as_ref().expect("exists")
+    }
+}
+
+impl<'lt, T: ?Sized + 'lt> DerefMut for GhostMutexGuard<'lt, T> {
+    fn deref_mut(&mut self) -> &mut T {
+        &mut *self.guard.as_mut().expect("exists")
+    }
+}
+
+impl<'lt, T: ?Sized + 'lt> AsRef<T> for GhostMutexGuard<'lt, T> {
+    fn as_ref(&self) -> &T {
+        self.deref()
+    }
+}
+
+impl<'lt, T: ?Sized + 'lt> AsMut<T> for GhostMutexGuard<'lt, T> {
+    fn as_mut(&mut self) -> &mut T {
+        self.deref_mut()
+    }
+}
+
+impl<'lt, T: ?Sized + 'lt> Borrow<T> for GhostMutexGuard<'lt, T> {
+    fn borrow(&self) -> &T {
+        self.deref()
+    }
+}
+
+impl<'lt, T: ?Sized + 'lt> BorrowMut<T> for GhostMutexGuard<'lt, T> {
+    fn borrow_mut(&mut self) -> &mut T {
+        self.deref_mut()
+    }
+}
+
+impl<'lt, T: ?Sized + 'lt + std::fmt::Debug> std::fmt::Debug for GhostMutexGuard<'lt, T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        if f.alternate() {
+            write!(f, "{:#?}", self.deref())
+        } else {
+            write!(f, "{:?}", self.deref())
+        }
+    }
+}
+
+pub struct GhostMutex<T: ?Sized> {
+    mutex: parking_lot::Mutex<T>,
+}
+
+impl<T> GhostMutex<T> {
+    pub fn new(t: T) -> Self {
+        Self {
+            mutex: parking_lot::Mutex::new(t),
+        }
+    }
+
+    pub fn into_inner(self) -> T {
+        self.mutex.into_inner()
+    }
+}
+
+impl<T: ?Sized> GhostMutex<T> {
+    pub fn lock(&self) -> GhostMutexGuard<'_, T> {
+        match self
+            .mutex
+            .try_lock_for(std::time::Duration::from_millis(10))
+        {
+            None => panic!("failed to obtain lock within timeout"),
+            Some(g) => GhostMutexGuard { guard: Some(g) },
+        }
+    }
+
+    pub fn get_mut(&mut self) -> &mut T {
+        self.mutex.get_mut()
+    }
+}
+
+impl<T> From<T> for GhostMutex<T> {
+    fn from(t: T) -> Self {
+        GhostMutex::new(t)
+    }
+}
+
+impl<T: ?Sized + Default> Default for GhostMutex<T> {
+    fn default() -> Self {
+        GhostMutex::new(Default::default())
+    }
+}
+
+impl<T: ?Sized + std::fmt::Debug> std::fmt::Debug for GhostMutex<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        let mut f = f.debug_struct("GhostMutex");
+        let f = match self.mutex.try_lock() {
+            Some(guard) => f.field("inner", &&*guard),
+            None => f.field("inner", &"<locked>".to_string()),
+        };
+
+        f.finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn it_should_debug() {
+        let a = GhostMutex::new(true);
+        assert_eq!("GhostMutex { inner: true }", &format!("{:?}", a));
+    }
+
+    #[test]
+    fn it_should_be_fair_ish() {
+        let tally: Vec<u64> = vec![0, 0, 0, 0, 0];
+        let tally_count = tally.len();
+        let tally = Arc::new(GhostMutex::new(tally));
+
+        let cont = Arc::new(GhostMutex::new(true));
+
+        let mut threads = Vec::new();
+
+        for i in 0..tally_count {
+            let my_tally = tally.clone();
+            let my_cont = cont.clone();
+            threads.push(std::thread::spawn(move || loop {
+                {
+                    let mut my_tally = my_tally.lock();
+                    let my_tally = &mut *my_tally;
+                    *my_tally.get_mut(i).unwrap() += 1;
+                }
+                {
+                    if !*my_cont.lock() {
+                        break;
+                    }
+                }
+                std::thread::sleep(std::time::Duration::from_micros(1));
+            }));
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(20));
+        *cont.lock() = false;
+
+        for t in threads.drain(..) {
+            t.join().unwrap();
+        }
+
+        let tally = Arc::try_unwrap(tally).unwrap().into_inner();
+        let mut max = *tally.get(0).unwrap();
+        let mut min = *tally.get(0).unwrap();
+        for t in tally.iter() {
+            if *t > max {
+                max = *t;
+            }
+            if *t < min {
+                min = *t;
+            }
+        }
+
+        let min_pct = min * 100 / max;
+
+        println!(
+            "got: min {} max {} min % {} out of {:?}",
+            min, max, min_pct, tally
+        );
+        // make sure our min is at least 20% of our max
+        assert!(min_pct > 20);
+    }
+}

--- a/crates/ghost_actor/src/ghost_mutex.rs
+++ b/crates/ghost_actor/src/ghost_mutex.rs
@@ -166,7 +166,7 @@ mod tests {
             }));
         }
 
-        std::thread::sleep(std::time::Duration::from_millis(20));
+        std::thread::sleep(std::time::Duration::from_millis(100));
         *cont.lock() = false;
 
         for t in threads.drain(..) {
@@ -191,7 +191,7 @@ mod tests {
             "got: min {} max {} min % {} out of {:?}",
             min, max, min_pct, tally
         );
-        // make sure our min is at least 20% of our max
-        assert!(min_pct > 20);
+        // make sure our min is at least 10% of our max
+        assert!(min_pct > 10);
     }
 }

--- a/crates/ghost_actor/src/ghost_mutex.rs
+++ b/crates/ghost_actor/src/ghost_mutex.rs
@@ -91,7 +91,7 @@ impl<T: ?Sized> GhostMutex<T> {
     pub fn lock(&self) -> GhostMutexGuard<'_, T> {
         match self
             .mutex
-            .try_lock_for(std::time::Duration::from_millis(10))
+            .try_lock_for(std::time::Duration::from_millis(1000))
         {
             None => panic!("failed to obtain lock within timeout"),
             Some(g) => GhostMutexGuard { guard: Some(g) },

--- a/crates/ghost_actor/src/ghost_system.rs
+++ b/crates/ghost_actor/src/ghost_system.rs
@@ -253,7 +253,7 @@ mod tests {
                     test_clone.lock().delayed_count += 1;
                     Ok(GhostProcessInstructions::default()
                         .set_should_continue(true)
-                        .set_next_run_delay_ms(30))
+                        .set_next_run_delay_ms(40))
                 }),
             )
             .unwrap();

--- a/crates/ghost_actor/src/ghost_tracker.rs
+++ b/crates/ghost_actor/src/ghost_tracker.rs
@@ -1,13 +1,10 @@
 use holochain_tracing::Span;
 use std::{
     collections::HashMap,
-    sync::{Arc, Mutex, Weak},
+    sync::{Arc, Weak},
 };
 
-use crate::{
-    ghost_try_lock, GhostErrorKind, GhostProcessInstructions, GhostResult, GhostSystemRef,
-    RequestId,
-};
+use crate::*;
 
 // TODO - should be 2000 or less but tests currently fail if below that
 const DEFAULT_TIMEOUT_MS: u64 = 20000;
@@ -33,7 +30,7 @@ enum GhostTrackerToInner<'lt, X: 'lt + Send + Sync, T: 'lt + Send + Sync> {
 
 struct GhostTrackerInner<'lt, X: 'lt + Send + Sync, T: 'lt + Send + Sync> {
     sys_ref: GhostSystemRef<'lt>,
-    weak_user_data: Weak<Mutex<X>>,
+    weak_user_data: Weak<GhostMutex<X>>,
     pending: HashMap<RequestId, GhostTrackerEntry<'lt, X, T>>,
     recv_inner: crossbeam_channel::Receiver<GhostTrackerToInner<'lt, X, T>>,
 }
@@ -41,7 +38,7 @@ struct GhostTrackerInner<'lt, X: 'lt + Send + Sync, T: 'lt + Send + Sync> {
 impl<'lt, X: 'lt + Send + Sync, T: 'lt + Send + Sync> GhostTrackerInner<'lt, X, T> {
     fn new(
         sys_ref: GhostSystemRef<'lt>,
-        weak_user_data: Weak<Mutex<X>>,
+        weak_user_data: Weak<GhostMutex<X>>,
         recv_inner: crossbeam_channel::Receiver<GhostTrackerToInner<'lt, X, T>>,
     ) -> Self {
         Self {
@@ -117,8 +114,8 @@ impl<'lt, X: 'lt + Send + Sync, T: 'lt + Send + Sync> GhostTrackerInner<'lt, X, 
         self.sys_ref.enqueue_processor(
             start_delay_ms,
             Box::new(move || match weak_user_data_clone.upgrade() {
-                Some(mut strong_user_data) => {
-                    let mut strong_user_data = ghost_try_lock(&mut strong_user_data);
+                Some(strong_user_data) => {
+                    let mut strong_user_data = strong_user_data.lock();
                     cb(&mut *strong_user_data)
                 }
                 None => Ok(GhostProcessInstructions::default()),
@@ -173,15 +170,15 @@ impl GhostTrackerBookmarkOptions {
 /// that can be triggered later when a response comes back indicating that id
 pub struct GhostTracker<'lt, X: 'lt + Send + Sync, T: 'lt + Send + Sync> {
     // just for ref count
-    _inner: Arc<Mutex<GhostTrackerInner<'lt, X, T>>>,
+    _inner: Arc<GhostMutex<GhostTrackerInner<'lt, X, T>>>,
     send_inner: crossbeam_channel::Sender<GhostTrackerToInner<'lt, X, T>>,
 }
 
 impl<'lt, X: 'lt + Send + Sync, T: 'lt + Send + Sync> GhostTracker<'lt, X, T> {
-    pub fn new(mut sys_ref: GhostSystemRef<'lt>, weak_user_data: Weak<Mutex<X>>) -> Self {
+    pub fn new(mut sys_ref: GhostSystemRef<'lt>, weak_user_data: Weak<GhostMutex<X>>) -> Self {
         let (send_inner, recv_inner) = crossbeam_channel::unbounded();
 
-        let inner = Arc::new(Mutex::new(GhostTrackerInner::new(
+        let inner = Arc::new(GhostMutex::new(GhostTrackerInner::new(
             sys_ref.clone(),
             weak_user_data,
             recv_inner,
@@ -192,11 +189,11 @@ impl<'lt, X: 'lt + Send + Sync, T: 'lt + Send + Sync> GhostTracker<'lt, X, T> {
             .enqueue_processor(
                 0,
                 Box::new(move || match weak_inner.upgrade() {
-                    Some(mut strong_inner) => {
-                        let mut strong_inner = ghost_try_lock(&mut strong_inner);
+                    Some(strong_inner) => {
+                        let mut strong_inner = strong_inner.lock();
                         match strong_inner.weak_user_data.upgrade() {
-                            Some(mut strong_user_data) => {
-                                let mut strong_user_data = ghost_try_lock(&mut strong_user_data);
+                            Some(strong_user_data) => {
+                                let mut strong_user_data = strong_user_data.lock();
 
                                 strong_inner
                                     .process(&mut *strong_user_data)
@@ -276,8 +273,8 @@ impl<'lt, X: 'lt + Send + Sync, T: 'lt + Send + Sync> GhostTracker<'lt, X, T> {
     }
 
     /// replace user data
-    pub fn set_user_data(&mut self, user_data: Weak<Mutex<X>>) -> GhostResult<()> {
-        ghost_try_lock(&mut self._inner).weak_user_data = user_data;
+    pub fn set_user_data(&mut self, user_data: Weak<GhostMutex<X>>) -> GhostResult<()> {
+        self._inner.lock().weak_user_data = user_data;
         Ok(())
     }
 }
@@ -286,6 +283,7 @@ impl<'lt, X: 'lt + Send + Sync, T: 'lt + Send + Sync> GhostTracker<'lt, X, T> {
 mod tests {
     use crate::*;
     use holochain_tracing::Span;
+    use std::sync::Arc;
 
     #[test]
     fn it_can_schedule_periodic() {
@@ -294,7 +292,7 @@ mod tests {
             ticks: i32,
         }
 
-        let test = Arc::new(Mutex::new(Test { ticks: 0 }));
+        let test = Arc::new(GhostMutex::new(Test { ticks: 0 }));
 
         let mut sys = GhostSystem::new();
 
@@ -318,7 +316,7 @@ mod tests {
             sys.process().unwrap();
         }
 
-        let test = test.lock().unwrap();
+        let test = test.lock();
         println!("got {:?}", *test);
         assert!(test.ticks > 0);
         assert!(test.ticks < 9);
@@ -331,7 +329,7 @@ mod tests {
             got_timeout: bool,
         }
 
-        let test = Arc::new(Mutex::new(Test { got_timeout: false }));
+        let test = Arc::new(GhostMutex::new(Test { got_timeout: false }));
 
         let mut sys = GhostSystem::new();
 
@@ -357,7 +355,7 @@ mod tests {
 
         sys.process().unwrap();
 
-        assert!(test.lock().unwrap().got_timeout);
+        assert!(test.lock().got_timeout);
     }
 
     #[test]
@@ -367,7 +365,7 @@ mod tests {
             got_response: String,
         }
 
-        let test = Arc::new(Mutex::new(Test {
+        let test = Arc::new(GhostMutex::new(Test {
             got_response: "".to_string(),
         }));
 
@@ -390,6 +388,6 @@ mod tests {
 
         sys.process().unwrap();
 
-        assert_eq!("Ok(\"test-response\")", &test.lock().unwrap().got_response);
+        assert_eq!("Ok(\"test-response\")", &test.lock().got_response);
     }
 }

--- a/crates/ghost_actor/src/ghost_tracker.rs
+++ b/crates/ghost_actor/src/ghost_tracker.rs
@@ -306,7 +306,7 @@ mod tests {
                     me.ticks += 1;
                     Ok(GhostProcessInstructions::default()
                         .set_should_continue(true)
-                        .set_next_run_delay_ms(20))
+                        .set_next_run_delay_ms(40))
                 }),
             )
             .unwrap();

--- a/crates/ghost_actor/src/lib.rs
+++ b/crates/ghost_actor/src/lib.rs
@@ -5,6 +5,8 @@ extern crate inflector;
 //#[macro_use]
 extern crate lazy_static;
 extern crate lib3h_zombie_actor;
+extern crate lock_api;
+extern crate parking_lot;
 extern crate proc_macro2;
 #[macro_use]
 extern crate shrinkwraprs;
@@ -14,23 +16,10 @@ extern crate syn;
 #[macro_use]
 extern crate quote;
 
-use std::sync::{Arc, Mutex, MutexGuard};
-
 pub use lib3h_zombie_actor::{ErrorKind as GhostErrorKind, GhostError, GhostResult};
 
-fn ghost_try_lock<'a, M>(m: &'a Arc<Mutex<M>>) -> MutexGuard<'a, M> {
-    let mut wait_ms = 0;
-    for _ in 0..100 {
-        match m.try_lock() {
-            Ok(g) => return g,
-            Err(_) => {
-                std::thread::sleep(std::time::Duration::from_millis(wait_ms));
-                wait_ms += 1;
-            }
-        }
-    }
-    panic!("failed to obtain mutex lock");
-}
+mod ghost_mutex;
+pub use ghost_mutex::*;
 
 #[derive(Shrinkwrap, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[shrinkwrap(mutable)]

--- a/crates/ghost_actor/tests/manual_example.rs
+++ b/crates/ghost_actor/tests/manual_example.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use ghost_actor::prelude::*;
 
@@ -17,7 +17,7 @@ fn manual_example() {
         to_actor_add_resp: Vec<String>,
     }
 
-    let my_context = Arc::new(Mutex::new(MyContext {
+    let my_context = Arc::new(GhostMutex::new(MyContext {
         to_owner_prints: Vec::new(),
         to_actor_add_resp: Vec::new(),
     }));
@@ -59,7 +59,7 @@ fn manual_example() {
     system.process().unwrap();
     system.process().unwrap();
 
-    assert_eq!("MyContext { to_owner_prints: [\"message from actor\", \"echo: \\\"zombies\\\"\", \"echo: Ok(Ok(41))\"], to_actor_add_resp: [\"Ok(Ok(43))\"] }", &format!("{:?}", my_context.lock().unwrap()));
+    assert_eq!("MyContext { to_owner_prints: [\"message from actor\", \"echo: \\\"zombies\\\"\", \"echo: Ok(Ok(41))\"], to_actor_add_resp: [\"Ok(Ok(43))\"] }", &format!("{:?}", my_context.lock()));
     println!("{:#?}", my_context);
 
     // can we access it directly?


### PR DESCRIPTION
## PR summary

No actual functionality changes here, just switching Mutex -> GhostMutex which is a wrapper around parking_lot::Mutex which gives us much better control of timeouts when attempting to lock.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
