### PR TITLE
setup ghost endpoint seed/plant/regress

### DIFF
--- a/crates/ghost_actor/Cargo.toml
+++ b/crates/ghost_actor/Cargo.toml
@@ -16,7 +16,7 @@ crossbeam-channel = "=0.3.8"
 holochain_tracing = { version = "=0.0.1", git = "https://github.com/holochain/holochain-tracing" }
 Inflector = "=0.11.4"
 lazy_static = "=1.2.0"
-lib3h_zombie_actor = { version = "=0.0.13", path = "../zombie_actor" }
+lib3h_zombie_actor = { version = "=0.0.15", path = "../zombie_actor" }
 lock_api = "=0.1.5"
 log = "=0.4.8"
 nanoid = "=0.2.0"

--- a/crates/ghost_actor/src/ghost_actor.rs
+++ b/crates/ghost_actor/src/ghost_actor.rs
@@ -2,26 +2,119 @@ use crate::*;
 use holochain_tracing::Span;
 use std::sync::{Arc, Weak};
 
+pub type GhostEndpointFullFinalizeCb<'lt, X> =
+    Box<dyn FnOnce(Weak<GhostMutex<X>>) -> GhostResult<()> + 'lt>;
+
+pub struct GhostEndpointSeed<'lt, P: GhostProtocol, D: 'lt> {
+    sys_ref: GhostSystemRef<'lt>,
+    send: crossbeam_channel::Sender<(Option<RequestId>, P)>,
+    recv: crossbeam_channel::Receiver<(Option<RequestId>, P)>,
+    d_ref: Arc<GhostMutex<D>>,
+}
+
+impl<'lt, P: GhostProtocol, D: 'lt> GhostEndpointSeed<'lt, P, D> {
+    pub fn new(
+        sys_ref: GhostSystemRef<'lt>,
+        send: crossbeam_channel::Sender<(Option<RequestId>, P)>,
+        recv: crossbeam_channel::Receiver<(Option<RequestId>, P)>,
+        d_ref: Arc<GhostMutex<D>>,
+    ) -> Self {
+        Self {
+            sys_ref,
+            send,
+            recv,
+            d_ref,
+        }
+    }
+
+    pub fn plant<X: 'lt + Send + Sync, H: 'lt + GhostHandler<'lt, X, P>>(
+        self,
+        weak_user_data: Weak<GhostMutex<X>>,
+        handler: H,
+    ) -> GhostResult<GhostEndpointFull<'lt, P, D, X, H>> {
+        let (out, finalize_cb) = self.plant_later(handler)?;
+        finalize_cb(weak_user_data)?;
+        Ok(out)
+    }
+
+    #[allow(clippy::complexity)]
+    pub fn plant_later<X: 'lt + Send + Sync, H: 'lt + GhostHandler<'lt, X, P>>(
+        self,
+        handler: H,
+    ) -> GhostResult<(
+        GhostEndpointFull<'lt, P, D, X, H>,
+        GhostEndpointFullFinalizeCb<'lt, X>,
+    )> {
+        let (send_inner, recv_inner) = crossbeam_channel::unbounded();
+
+        let inner = Arc::new(GhostMutex::new(GhostEndpointFullInner {
+            sys_ref: self.sys_ref.clone(),
+            weak_user_data: Weak::new(),
+            send: self.send,
+            recv: self.recv,
+            recv_inner,
+            pending_callbacks: GhostTracker::new(self.sys_ref, Weak::new()),
+            handler,
+        }));
+
+        let weak_inner = Arc::downgrade(&inner);
+        let finalize_cb =
+            Box::new(
+                move |user_data: Weak<GhostMutex<X>>| match weak_inner.upgrade() {
+                    Some(strong_inner) => {
+                        let mut strong_inner = strong_inner.lock();
+                        strong_inner.weak_user_data = user_data.clone();
+                        strong_inner.pending_callbacks.set_user_data(user_data)?;
+                        strong_inner.pending_callbacks.periodic_task(
+                            0,
+                            Box::new(move |user_data| match weak_inner.upgrade() {
+                                Some(strong_inner) => {
+                                    let mut strong_inner = strong_inner.lock();
+                                    strong_inner.priv_process(user_data)?;
+                                    Ok(GhostProcessInstructions::default()
+                                        .set_should_continue(true))
+                                }
+                                None => Ok(GhostProcessInstructions::default()),
+                            }),
+                        )?;
+                        Ok(())
+                    }
+                    None => Ok(()),
+                },
+            );
+
+        Ok((
+            GhostEndpointFull {
+                inner,
+                send_inner,
+                d_ref: self.d_ref,
+            },
+            finalize_cb,
+        ))
+    }
+}
+
 enum GhostEndpointToInner<'lt, X: 'lt + Send + Sync, P: GhostProtocol> {
     IncomingRequest(P, Option<GhostResponseCb<'lt, X, P>>),
 }
 
-struct GhostEndpointRefInner<
+pub struct GhostEndpointFullInner<
     'lt,
-    X: 'lt + Send + Sync,
     P: GhostProtocol,
+    X: 'lt + Send + Sync,
     H: GhostHandler<'lt, X, P>,
 > {
+    sys_ref: GhostSystemRef<'lt>,
     weak_user_data: Weak<GhostMutex<X>>,
-    sender: crossbeam_channel::Sender<(Option<RequestId>, P)>,
-    handle_receiver: crossbeam_channel::Receiver<(Option<RequestId>, P)>,
+    send: crossbeam_channel::Sender<(Option<RequestId>, P)>,
+    recv: crossbeam_channel::Receiver<(Option<RequestId>, P)>,
     recv_inner: crossbeam_channel::Receiver<GhostEndpointToInner<'lt, X, P>>,
     pending_callbacks: GhostTracker<'lt, X, P>,
     handler: H,
 }
 
-impl<'lt, X: 'lt + Send + Sync, P: GhostProtocol, H: GhostHandler<'lt, X, P>>
-    GhostEndpointRefInner<'lt, X, P, H>
+impl<'lt, P: GhostProtocol, X: 'lt + Send + Sync, H: GhostHandler<'lt, X, P>>
+    GhostEndpointFullInner<'lt, P, X, H>
 {
     fn priv_process(&mut self, user_data: &mut X) -> GhostResult<()> {
         if self.priv_process_inner()? {
@@ -53,15 +146,15 @@ impl<'lt, X: 'lt + Send + Sync, P: GhostProtocol, H: GhostHandler<'lt, X, P>>
             Some(cb) => {
                 let request_id = self.pending_callbacks.bookmark(Span::fixme(), cb)?;
 
-                self.sender.send((Some(request_id), message))?;
+                self.send.send((Some(request_id), message))?;
             }
-            None => self.sender.send((None, message))?,
+            None => self.send.send((None, message))?,
         }
         Ok(())
     }
 
     fn priv_process_handle_requests(&mut self, user_data: &mut X) -> GhostResult<()> {
-        while let Ok((maybe_id, message)) = self.handle_receiver.try_recv() {
+        while let Ok((maybe_id, message)) = self.recv.try_recv() {
             if let GhostProtocolVariantType::Response = message.discriminant().variant_type() {
                 let request_id = match maybe_id {
                     None => panic!("response with no request_id: {:?}", message),
@@ -72,7 +165,7 @@ impl<'lt, X: 'lt + Send + Sync, P: GhostProtocol, H: GhostHandler<'lt, X, P>>
                 let cb: Option<GhostHandlerCb<'lt, P>> = match maybe_id {
                     None => None,
                     Some(request_id) => {
-                        let resp_sender = self.sender.clone();
+                        let resp_sender = self.send.clone();
                         Some(Box::new(move |message| {
                             resp_sender.send((Some(request_id), message))?;
                             Ok(())
@@ -86,84 +179,48 @@ impl<'lt, X: 'lt + Send + Sync, P: GhostProtocol, H: GhostHandler<'lt, X, P>>
     }
 }
 
-pub struct GhostEndpointRef<
+pub struct GhostEndpointFull<
     'lt,
-    X: 'lt + Send + Sync,
-    A: 'lt,
     P: GhostProtocol,
+    D: 'lt,
+    X: 'lt + Send + Sync,
     H: GhostHandler<'lt, X, P>,
 > {
-    _inner: Arc<GhostMutex<GhostEndpointRefInner<'lt, X, P, H>>>,
+    inner: Arc<GhostMutex<GhostEndpointFullInner<'lt, P, X, H>>>,
     send_inner: crossbeam_channel::Sender<GhostEndpointToInner<'lt, X, P>>,
-    a_ref: Arc<GhostMutex<A>>,
+    d_ref: Arc<GhostMutex<D>>,
 }
 
-type GhostEndpointRefFinalizeCb<'lt, X> =
-    Box<dyn FnOnce(Weak<GhostMutex<X>>) -> GhostResult<()> + 'lt>;
-
-impl<'lt, X: 'lt + Send + Sync, A: 'lt, P: GhostProtocol, H: 'lt + GhostHandler<'lt, X, P>>
-    GhostEndpointRef<'lt, X, A, P, H>
+impl<'lt, P: GhostProtocol, D: 'lt, X: 'lt + Send + Sync, H: GhostHandler<'lt, X, P>>
+    GhostEndpointFull<'lt, P, D, X, H>
 {
-    fn new_partial(
-        sys_ref: &mut GhostSystemRef<'lt>,
-        sender: crossbeam_channel::Sender<(Option<RequestId>, P)>,
-        receiver: crossbeam_channel::Receiver<(Option<RequestId>, P)>,
-        a_ref: Arc<GhostMutex<A>>,
-        handler: H,
-    ) -> GhostResult<(Self, GhostEndpointRefFinalizeCb<'lt, X>)> {
-        let (send_inner, recv_inner) = crossbeam_channel::unbounded();
-        let inner = Arc::new(GhostMutex::new(GhostEndpointRefInner {
-            weak_user_data: Weak::new(),
-            sender,
-            handle_receiver: receiver,
-            recv_inner,
-            pending_callbacks: GhostTracker::new(sys_ref.clone(), Weak::new()),
-            handler,
-        }));
-
-        let weak_inner = Arc::downgrade(&inner);
-        let finalize_cb =
-            Box::new(
-                move |user_data: Weak<GhostMutex<X>>| match weak_inner.upgrade() {
-                    Some(strong_inner) => {
-                        let mut strong_inner = strong_inner.lock();
-                        strong_inner.weak_user_data = user_data.clone();
-                        strong_inner.pending_callbacks.set_user_data(user_data)?;
-                        strong_inner.pending_callbacks.periodic_task(
-                            0,
-                            Box::new(move |user_data| match weak_inner.upgrade() {
-                                Some(strong_inner) => {
-                                    let mut strong_inner = strong_inner.lock();
-                                    strong_inner.priv_process(user_data)?;
-                                    Ok(GhostProcessInstructions::default()
-                                        .set_should_continue(true))
-                                }
-                                None => Ok(GhostProcessInstructions::default()),
-                            }),
-                        )?;
-                        Ok(())
-                    }
-                    None => Ok(()),
-                },
-            );
-
-        Ok((
-            Self {
-                _inner: inner,
-                send_inner,
-                a_ref,
-            },
-            finalize_cb,
+    pub fn regress(mut self) -> Result<GhostEndpointSeed<'lt, P, D>, Self> {
+        // unwrapping Arc-s is weird...
+        // if there is an error, put ourself back together and return
+        let inner = match Arc::try_unwrap(self.inner) {
+            Ok(inner) => inner,
+            Err(inner) => {
+                self.inner = inner;
+                return Err(self);
+            }
+        }
+        .into_inner();
+        // TODO - do we want to panic! if there are pending_callbacks?
+        Ok(GhostEndpointSeed::new(
+            inner.sys_ref,
+            inner.send,
+            inner.recv,
+            self.d_ref,
         ))
     }
 
-    pub fn as_mut(&mut self) -> GhostMutexGuard<'_, A> {
-        self.a_ref.lock()
+    pub fn as_mut(&mut self) -> GhostMutexGuard<'_, D> {
+        self.d_ref.lock()
     }
 }
 
-impl<'lt, X: 'lt + Send + Sync, A: 'lt, P: GhostProtocol, H: GhostHandler<'lt, X, P>>
-    GhostEndpoint<'lt, X, P> for GhostEndpointRef<'lt, X, A, P, H>
+impl<'lt, P: GhostProtocol, D: 'lt, X: 'lt + Send + Sync, H: GhostHandler<'lt, X, P>>
+    GhostEndpoint<'lt, X, P> for GhostEndpointFull<'lt, P, D, X, H>
 {
     fn send_protocol(
         &mut self,
@@ -189,7 +246,7 @@ pub trait GhostActor<'lt, P: GhostProtocol, A: GhostActor<'lt, P, A>>: Send + Sy
 }
 
 pub struct GhostInflator<'lt, P: GhostProtocol, A: 'lt + GhostActor<'lt, P, A>> {
-    finalize: Arc<GhostMutex<Option<GhostEndpointRefFinalizeCb<'lt, A>>>>,
+    finalize: Arc<GhostMutex<Option<GhostEndpointFullFinalizeCb<'lt, A>>>>,
     sys_ref: GhostSystemRef<'lt>,
     sender: crossbeam_channel::Sender<(Option<RequestId>, P)>,
     receiver: crossbeam_channel::Receiver<(Option<RequestId>, P)>,
@@ -197,19 +254,19 @@ pub struct GhostInflator<'lt, P: GhostProtocol, A: 'lt + GhostActor<'lt, P, A>> 
 
 impl<'lt, P: GhostProtocol, A: 'lt + GhostActor<'lt, P, A>> GhostInflator<'lt, P, A> {
     pub fn inflate<H: 'lt + GhostHandler<'lt, A, P>>(
-        mut self,
+        self,
         handler: H,
-    ) -> GhostResult<GhostEndpointRef<'lt, A, (), P, H>> {
-        let (owner_ref, finalize) = GhostEndpointRef::new_partial(
-            &mut self.sys_ref,
+    ) -> GhostResult<GhostEndpointFull<'lt, P, (), A, H>> {
+        let seed = GhostEndpointSeed::new(
+            self.sys_ref,
             self.sender,
             self.receiver,
             // this is the deref/refcount object... but on the actor side
             // we don't give actors direct access to their owners,
             // and we certainly don't refcount them ;p
             Arc::new(GhostMutex::new(())),
-            handler,
-        )?;
+        );
+        let (owner_ref, finalize) = seed.plant_later(handler)?;
         std::mem::replace(&mut *self.finalize.lock(), Some(finalize));
 
         Ok(owner_ref)
@@ -230,11 +287,11 @@ pub fn ghost_actor_spawn<
     user_data: Weak<GhostMutex<X>>,
     spawn_cb: GhostActorSpawnCb<'lt, A, P>,
     handler: H,
-) -> GhostResult<GhostEndpointRef<'lt, X, A, P, H>> {
+) -> GhostResult<GhostEndpointFull<'lt, P, A, X, H>> {
     let (s1, r1) = crossbeam_channel::unbounded();
     let (s2, r2) = crossbeam_channel::unbounded();
 
-    let finalize: Arc<GhostMutex<Option<GhostEndpointRefFinalizeCb<'lt, A>>>> =
+    let finalize: Arc<GhostMutex<Option<GhostEndpointFullFinalizeCb<'lt, A>>>> =
         Arc::new(GhostMutex::new(None));
 
     let inflator: GhostInflator<'lt, P, A> = GhostInflator {
@@ -265,8 +322,7 @@ pub fn ghost_actor_spawn<
         }),
     )?;
 
-    let (ep, finalize) =
-        GhostEndpointRef::new_partial(&mut sys_ref, s1, r2, strong_actor, handler)?;
-    finalize(user_data)?;
+    let seed = GhostEndpointSeed::new(sys_ref, s1, r2, strong_actor);
+    let ep = seed.plant(user_data, handler)?;
     Ok(ep)
 }

--- a/crates/ghost_actor/tests/manual_example_mod/test_actor.rs
+++ b/crates/ghost_actor/tests/manual_example_mod/test_actor.rs
@@ -6,7 +6,7 @@ use super::test_protocol::*;
 use ghost_actor::prelude::*;
 
 pub struct TestActor<'lt> {
-    owner_ref: GhostEndpointRef<'lt, Self, (), TestProtocol, TestActorHandler<'lt, Self>>,
+    owner_ref: GhostEndpointFull<'lt, TestProtocol, (), Self, TestActorHandler<'lt, Self>>,
 }
 
 impl<'lt> TestActor<'lt> {

--- a/crates/ghost_actor/tests/manual_example_mod/test_protocol.rs
+++ b/crates/ghost_actor/tests/manual_example_mod/test_protocol.rs
@@ -170,7 +170,7 @@ pub trait TestActorRef<'lt, X: 'lt + Send + Sync>: GhostEndpoint<'lt, X, TestPro
 }
 
 impl<'lt, X: 'lt + Send + Sync, A: 'lt, H: GhostHandler<'lt, X, TestProtocol>> TestActorRef<'lt, X>
-    for GhostEndpointRef<'lt, X, A, TestProtocol, H>
+    for GhostEndpointFull<'lt, TestProtocol, A, X, H>
 {
 }
 
@@ -202,6 +202,6 @@ pub trait TestOwnerRef<'lt, X: 'lt + Send + Sync>: GhostEndpoint<'lt, X, TestPro
 }
 
 impl<'lt, X: 'lt + Send + Sync, A: 'lt, H: GhostHandler<'lt, X, TestProtocol>> TestOwnerRef<'lt, X>
-    for GhostEndpointRef<'lt, X, A, TestProtocol, H>
+    for GhostEndpointFull<'lt, TestProtocol, A, X, H>
 {
 }


### PR DESCRIPTION
## PR summary

Preparation for being able to pass actors around / use them as child actors.

- adds an EndpointSeed concept that can be `plant`ed : )
- renames EndpointRef which I was never super happy with to EndpointFull ... happy for other suggestions
- EndpointFull instances can be `regress`ed back into seeds if you want to move it to another actor

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
