### PR TITLE
Make streams api public

### DIFF
--- a/crates/lib3h/src/transport/websocket/mod.rs
+++ b/crates/lib3h/src/transport/websocket/mod.rs
@@ -6,7 +6,7 @@
 /// The connection pool implemented abstractly based on any rust io Read/Write Stream.
 /// Module tcp implements a concrete type based on std::net::TcpStream.
 pub mod actor;
-mod streams;
+pub mod streams;
 mod tcp;
 pub mod tls;
 mod wss_info;


### PR DESCRIPTION
## PR summary
This exposes the streams api so hc-rust crates can use it rather than going over the ghost actor api. The sim2h related crates will take advantage of it in https://github.com/holochain/holochain-rust/pull/1784.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
