### PR TITLE
allow error cloning for ghost actor 2.0

### DIFF
--- a/crates/lib3h/src/error.rs
+++ b/crates/lib3h/src/error.rs
@@ -12,7 +12,7 @@ use std::{error::Error as StdError, fmt, io, result};
 pub type Lib3hResult<T> = result::Result<T, Lib3hError>;
 
 /// An error that can occur when interacting with the algorithm.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Lib3hError(Box<ErrorKind>);
 
 impl Lib3hError {
@@ -71,6 +71,23 @@ pub enum ErrorKind {
     /// could break existing code.)
     #[doc(hidden)]
     __Nonexhaustive,
+}
+
+impl Clone for ErrorKind {
+    fn clone(&self) -> Self {
+        match self {
+            ErrorKind::GhostError(e) => ErrorKind::GhostError(e.clone()),
+            ErrorKind::Io(e) => ErrorKind::Io(e.kind().into()),
+            ErrorKind::TransportError(e) => ErrorKind::TransportError(e.clone()),
+            ErrorKind::Lib3hProtocolError(e) => ErrorKind::Lib3hProtocolError(e.clone()),
+            ErrorKind::HcId(e) => ErrorKind::HcId(e.clone()),
+            ErrorKind::RmpSerdeDecodeError(e) => ErrorKind::Other(format!("{:?}", e)),
+            ErrorKind::CryptoApiError(e) => ErrorKind::CryptoApiError(e.clone()),
+            ErrorKind::KeyNotFound(e) => ErrorKind::KeyNotFound(e.clone()),
+            ErrorKind::Other(e) => ErrorKind::Other(e.clone()),
+            _ => ErrorKind::Other(format!("error cloning error: {:?}", self)),
+        }
+    }
 }
 
 impl StdError for Lib3hError {

--- a/crates/lib3h_protocol/src/error.rs
+++ b/crates/lib3h_protocol/src/error.rs
@@ -8,7 +8,7 @@ use url::ParseError;
 pub type Lib3hProtocolResult<T> = result::Result<T, Lib3hProtocolError>;
 
 /// An error that can occur when interacting with the algorithm.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Lib3hProtocolError(Box<ErrorKind>);
 
 impl Lib3hProtocolError {
@@ -51,6 +51,20 @@ pub enum ErrorKind {
     /// could break existing code.)
     #[doc(hidden)]
     __Nonexhaustive,
+}
+
+impl Clone for ErrorKind {
+    fn clone(&self) -> Self {
+        match self {
+            ErrorKind::Io(e) => ErrorKind::Io(e.kind().into()),
+            ErrorKind::TransportError(e) => ErrorKind::TransportError(e.clone()),
+            ErrorKind::DeserializeError(e) => ErrorKind::DeserializeError(e.clone()),
+            ErrorKind::Lib3hError(e, bt) => ErrorKind::Lib3hError(e.clone(), bt.clone()),
+            ErrorKind::UrlError(e) => ErrorKind::UrlError(*e),
+            ErrorKind::Other(e) => ErrorKind::Other(e.clone()),
+            _ => ErrorKind::Other(format!("error cloning error: {:?}", self)),
+        }
+    }
 }
 
 impl StdError for Lib3hProtocolError {


### PR DESCRIPTION
## PR summary

GhostActor 2.0 depends on Protocols being clone-able. This makes Lib3h Error types clone-able.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
