### PR TITLE
Ghost actor v2 tracing upgrade

### DIFF
--- a/crates/ghost_actor/src/ghost_actor.rs
+++ b/crates/ghost_actor/src/ghost_actor.rs
@@ -338,7 +338,14 @@ impl<
         message: P,
         cb: Option<GhostResponseCb<'lt, X, P>>,
     ) -> GhostResult<()> {
-        let span = maybe_span.unwrap_or_else(|| Span::todo("send_protocol"));
+        let span = maybe_span.unwrap_or_else(|| {
+            if let Ok(tracer) = TRACER_SINGLETON.lock() {
+                tracer.span("send_protocol").start().into()
+            } else {
+                Span::todo("send_protocol")
+            }
+        });
+        //let span = maybe_span.unwrap_or_else(|| Span::todo("send_protocol"));
         self.send_inner
             .send(GhostEndpointToInner::IncomingRequest(span, message, cb))?;
         Ok(())

--- a/crates/ghost_actor/src/ghost_system.rs
+++ b/crates/ghost_actor/src/ghost_system.rs
@@ -1,5 +1,4 @@
 use crate::*;
-use holochain_tracing::*;
 use std::sync::{Arc, Weak};
 
 /// struct used for hinting on whether / when to next run this process fn
@@ -213,7 +212,7 @@ mod tests {
             non_start_delay: false,
         }));
 
-        let mut sys = SingleThreadedGhostSystem::default();
+        let mut sys = SingleThreadedGhostSystem::new();
 
         let test_clone = test.clone();
         sys.create_ref()
@@ -270,7 +269,7 @@ mod tests {
             non_delayed_count: 0,
         }));
 
-        let mut sys = SingleThreadedGhostSystem::default();
+        let mut sys = SingleThreadedGhostSystem::new();
 
         let test_clone = test.clone();
         sys.create_ref()

--- a/crates/ghost_actor/src/ghost_system.rs
+++ b/crates/ghost_actor/src/ghost_system.rs
@@ -1,4 +1,5 @@
 use crate::*;
+use holochain_tracing::*;
 use std::sync::{Arc, Weak};
 
 /// struct used for hinting on whether / when to next run this process fn
@@ -124,6 +125,12 @@ impl<'lt> GhostSystemInner<'lt> {
         }
     }
 }
+pub type FinalizeExternalSystemRefCb<'lt, X> =
+    Box<dyn FnOnce(Weak<GhostMutex<X>>) -> GhostResult<()> + 'lt>;
+
+//--------------------------------------------------------------------------------------------------
+// SingleThreadedGhostSystem
+//--------------------------------------------------------------------------------------------------
 
 /// Ref that allows queueing of new process functions
 /// but does not have the ability to actually run process
@@ -156,9 +163,6 @@ impl<'lt> GhostSystemRef<'lt> for SingleThreadedGhostSystemRef<'lt> {
         Ok(())
     }
 }
-
-pub type FinalizeExternalSystemRefCb<'lt, X> =
-    Box<dyn FnOnce(Weak<GhostMutex<X>>) -> GhostResult<()> + 'lt>;
 
 /// the main ghost system struct. Allows queueing new processor functions
 /// and provides a process() function to actually execute them
@@ -209,7 +213,7 @@ mod tests {
             non_start_delay: false,
         }));
 
-        let mut sys = SingleThreadedGhostSystem::new();
+        let mut sys = SingleThreadedGhostSystem::default();
 
         let test_clone = test.clone();
         sys.create_ref()
@@ -266,7 +270,7 @@ mod tests {
             non_delayed_count: 0,
         }));
 
-        let mut sys = SingleThreadedGhostSystem::new();
+        let mut sys = SingleThreadedGhostSystem::default();
 
         let test_clone = test.clone();
         sys.create_ref()

--- a/crates/ghost_actor/src/ghost_tracker.rs
+++ b/crates/ghost_actor/src/ghost_tracker.rs
@@ -246,7 +246,7 @@ mod tests {
         let mut deep = DeepRef::new();
         deep.set(Arc::downgrade(&test)).unwrap();
 
-        let mut sys = SingleThreadedGhostSystem::new();
+        let mut sys = SingleThreadedGhostSystem::default();
         let (_sys_ref, finalize) = sys.create_external_system_ref();
         finalize(Arc::downgrade(&test)).unwrap();
 
@@ -287,7 +287,7 @@ mod tests {
         let mut deep = DeepRef::new();
         deep.set(Arc::downgrade(&test)).unwrap();
 
-        let mut sys = SingleThreadedGhostSystem::new();
+        let mut sys = SingleThreadedGhostSystem::default();
         let (_sys_ref, finalize) = sys.create_external_system_ref();
         finalize(Arc::downgrade(&test)).unwrap();
 

--- a/crates/ghost_actor/src/ghost_tracker.rs
+++ b/crates/ghost_actor/src/ghost_tracker.rs
@@ -246,7 +246,7 @@ mod tests {
         let mut deep = DeepRef::new();
         deep.set(Arc::downgrade(&test)).unwrap();
 
-        let mut sys = SingleThreadedGhostSystem::default();
+        let mut sys = SingleThreadedGhostSystem::new();
         let (_sys_ref, finalize) = sys.create_external_system_ref();
         finalize(Arc::downgrade(&test)).unwrap();
 
@@ -287,7 +287,7 @@ mod tests {
         let mut deep = DeepRef::new();
         deep.set(Arc::downgrade(&test)).unwrap();
 
-        let mut sys = SingleThreadedGhostSystem::default();
+        let mut sys = SingleThreadedGhostSystem::new();
         let (_sys_ref, finalize) = sys.create_external_system_ref();
         finalize(Arc::downgrade(&test)).unwrap();
 

--- a/crates/ghost_actor/src/lib.rs
+++ b/crates/ghost_actor/src/lib.rs
@@ -2,7 +2,7 @@
 extern crate crossbeam_channel;
 extern crate holochain_tracing;
 extern crate inflector;
-//#[macro_use]
+#[macro_use]
 extern crate lazy_static;
 extern crate lib3h_zombie_actor;
 extern crate lock_api;
@@ -23,6 +23,14 @@ pub use ghost_mutex::*;
 
 mod ghost_deep_ref;
 pub(crate) use ghost_deep_ref::*;
+
+use holochain_tracing::{tracer_console::ConsoleTracer, Tracer};
+use std::sync::Mutex;
+/// Tracer used by the Ghost actor system
+lazy_static! {
+    // pub static ref NULL_TRACER: Tracer = holochain_tracing::null_tracer();
+    pub static ref TRACER_SINGLETON: Mutex<ConsoleTracer> = Mutex::new(ConsoleTracer::new());
+}
 
 /// Keep track of pending requests using unique request identifiers
 #[derive(Shrinkwrap, Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]

--- a/crates/ghost_actor/src/lib.rs
+++ b/crates/ghost_actor/src/lib.rs
@@ -24,11 +24,12 @@ pub use ghost_mutex::*;
 mod ghost_deep_ref;
 pub(crate) use ghost_deep_ref::*;
 
-use holochain_tracing::{tracer_console::ConsoleTracer, Tracer};
+use holochain_tracing::tracer_console::ConsoleTracer;
 use std::sync::Mutex;
-/// Tracer used by the Ghost actor system
+
+// Tracer used by the Ghost actor system
 lazy_static! {
-    // pub static ref NULL_TRACER: Tracer = holochain_tracing::null_tracer();
+    // TODO change to a more genereic Tracer instead
     pub static ref TRACER_SINGLETON: Mutex<ConsoleTracer> = Mutex::new(ConsoleTracer::new());
 }
 

--- a/crates/ghost_actor/tests/manual_example.rs
+++ b/crates/ghost_actor/tests/manual_example.rs
@@ -1,88 +1,72 @@
+#[macro_use]
+extern crate lazy_static;
+
 use std::sync::Arc;
 
 use ghost_actor::prelude::*;
-use holochain_tracing::*;
+use holochain_tracing::{tracer_console::ConsoleTracer, *};
 
 mod manual_example_mod;
 #[allow(unused_imports)]
 use manual_example_mod::*;
 
-use rustracing::tag::Tag;
 use std::{thread, time::Duration};
 
-#[test]
-fn trace_test() {
-    // Creates a tracer
-    let (span_tx, span_rx) = crossbeam_channel::bounded(10);
-    let tracer = Tracer::with_sender(AllSampler, span_tx);
-    {
-        // Starts "parent" span
-        let parent_span = tracer.span("parent").start();
-        thread::sleep(Duration::from_millis(10));
-        {
-            // Starts "child" span
-            let mut child_span = tracer
-                .span("child_span")
-                .child_of(&parent_span)
-                .tag(Tag::new("key", "value"))
-                .start();
-
-            child_span.log(|log| {
-                log.error().message("a log message");
-            });
-        } // The "child" span dropped and will be sent to `span_rx`
-    } // The "parent" span dropped and will be sent to `span_rx`
-
-    // Outputs finished spans to the standard output
-    while let Ok(span) = span_rx.try_recv() {
-        println!("# SPAN: {:?}", span);
-    }
-}
-
+//lazy_static! {
+//    pub static ref CONSOLE_TRACER: ConsoleTracer = ConsoleTracer::new();
+//}
 #[test]
 fn manual_example() {
-    let mut actor_system = SingleThreadedGhostSystem::new();
-
-    #[derive(Debug)]
-    struct MyContext {
-        to_owner_prints: Vec<String>,
-        to_actor_add_resp: Vec<String>,
-    }
-
-    let my_context = Arc::new(GhostMutex::new(MyContext {
-        to_owner_prints: Vec::new(),
-        to_actor_add_resp: Vec::new(),
-    }));
-
-    let my_context_weak = Arc::downgrade(&my_context);
-
-    let (mut system_ref, finalize) = actor_system.create_external_system_ref();
-    finalize(my_context_weak).unwrap();
-
-    let mut actor_ref = system_ref
-        .spawn(
-            Box::new(|sys_ref, owner_seed| TestActor::new("root", sys_ref, owner_seed, None)),
-            TestOwnerHandler {
-                handle_event_to_owner_print: Box::new(|mut span, me: &mut MyContext, message| {
-                    span.event("print");
-                    me.to_owner_prints.push(message);
-                    Ok(())
-                }),
-                handle_request_to_owner_sub_1: Box::new(
-                    |span, _me: &mut MyContext, message, cb| {
-                        cb(span.child("sub_1 response"), Ok(message - 1))
-                    },
-                ),
-            },
-        )
-        .unwrap();
-
-    // Creates a tracer
-    let (span_tx, span_rx) = crossbeam_channel::bounded(10);
-    let tracer = Tracer::with_sender(AllSampler, span_tx);
+    //    let mut tracer = &mut *CONSOLE_TRACER;
+    //    let mut wtf = TRACER_SINGLETON.lock().unwrap();
+    //    *wtf = &tracer;
+    //*wtf = *ConsoleTracer::new();
     // Starts "root" span
     {
-        let mut root_span: HSpan = tracer.span("manual_example_span").start().into();
+        let mut actor_system = SingleThreadedGhostSystem::new();
+
+        #[derive(Debug)]
+        struct MyContext {
+            to_owner_prints: Vec<String>,
+            to_actor_add_resp: Vec<String>,
+        }
+
+        let my_context = Arc::new(GhostMutex::new(MyContext {
+            to_owner_prints: Vec::new(),
+            to_actor_add_resp: Vec::new(),
+        }));
+
+        let my_context_weak = Arc::downgrade(&my_context);
+
+        let (mut system_ref, finalize) = actor_system.create_external_system_ref();
+        finalize(my_context_weak).unwrap();
+
+        let mut actor_ref = system_ref
+            .spawn(
+                Box::new(|sys_ref, owner_seed| TestActor::new("root", sys_ref, owner_seed, None)),
+                TestOwnerHandler {
+                    handle_event_to_owner_print: Box::new(
+                        |mut span, me: &mut MyContext, message| {
+                            span.event("print");
+                            me.to_owner_prints.push(message);
+                            Ok(())
+                        },
+                    ),
+                    handle_request_to_owner_sub_1: Box::new(
+                        |span, _me: &mut MyContext, message, cb| {
+                            cb(span.child("sub_1 response"), Ok(message - 1))
+                        },
+                    ),
+                },
+            )
+            .unwrap();
+
+        let mut root_span: HSpan = TRACER_SINGLETON
+            .lock()
+            .unwrap()
+            .span("manual_example_root_span")
+            .start()
+            .into();
         root_span.event("start");
         actor_ref
             .event_to_actor_print(
@@ -90,7 +74,8 @@ fn manual_example() {
                 "test-from-framework".to_string(),
             )
             .unwrap();
-
+        // SystemTime is not monotonic so wait a bit to make sure previous span is prior to next span
+        std::thread::sleep(std::time::Duration::from_millis(1));
         actor_ref
             .request_to_actor_add_1(
                 Some(root_span.child("first request")),
@@ -119,18 +104,17 @@ fn manual_example() {
         actor_system.process().unwrap();
         actor_system.process().unwrap();
         actor_system.process().unwrap();
-    }
-    // Outputs finished spans to the standard output
-    while let Ok(span) = span_rx.try_recv() {
-        println!("# SPAN: {:?}", span);
-    }
 
-    assert_eq!("MyContext { to_owner_prints: [\"(root chain (sub_1 chain (sub_2 to_owner_print)))\", \"(root fwd sub_1 Ok(Ok(41))\", \"(root chain (sub_1 fwd sub_1 Ok(Ok(41)))\", \"(root chain (sub_1 fwd add_1 request))\", \"(root chain (sub_1 chain (sub_2 recv print (sub_1 fwd print (root fwd print test-from-framework)))))\", \"(root chain (sub_1 chain (sub_2 add 1 to 42)))\", \"(root chain (sub_1 chain (sub_2 rsp 42 - 1 = Ok(Ok(41)))))\", \"(root fwd add_1 request)\"], to_actor_add_resp: [\"Ok(Ok(43))\"] }", &format!("{:?}", my_context.lock()));
-    println!("my_context = {:#?}", my_context);
+        assert_eq!("MyContext { to_owner_prints: [\"(root chain (sub_1 chain (sub_2 to_owner_print)))\", \"(root fwd sub_1 Ok(Ok(41))\", \"(root chain (sub_1 fwd sub_1 Ok(Ok(41)))\", \"(root chain (sub_1 fwd add_1 request))\", \"(root chain (sub_1 chain (sub_2 recv print (sub_1 fwd print (root fwd print test-from-framework)))))\", \"(root chain (sub_1 chain (sub_2 add 1 to 42)))\", \"(root chain (sub_1 chain (sub_2 rsp 42 - 1 = Ok(Ok(41)))))\", \"(root fwd add_1 request)\"], to_actor_add_resp: [\"Ok(Ok(43))\"] }", &format!("{:?}", my_context.lock()));
+        println!("\n my_context = {:#?}", my_context);
 
-    // can we access it directly?
-    assert_eq!(
-        "test_mut_method_data",
-        &actor_ref.as_mut().test_mut_method()
-    );
+        // can we access it directly?
+        assert_eq!(
+            "test_mut_method_data",
+            &actor_ref.as_mut().test_mut_method()
+        );
+    }
+    let count = TRACER_SINGLETON.lock().unwrap().drain();
+    println!("span count = {}", count);
+    TRACER_SINGLETON.lock().unwrap().print();
 }

--- a/crates/ghost_actor/tests/manual_example.rs
+++ b/crates/ghost_actor/tests/manual_example.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use ghost_actor::prelude::*;
-use holochain_tracing::{tracer_console::ConsoleTracer, *};
+use holochain_tracing::*;
 
 mod manual_example_mod;
 #[allow(unused_imports)]
@@ -21,7 +21,7 @@ fn manual_example() {
             .into();
         root_span.event("start");
         // SystemTime is not monotonic so wait a bit to make sure following spans are shown after this span
-        std::thread::sleep(std::time::Duration::from_millis(1));
+        thread::sleep(Duration::from_millis(1));
 
         let mut actor_system = SingleThreadedGhostSystem::new();
 
@@ -69,7 +69,7 @@ fn manual_example() {
                 .unwrap();
         }
         // SystemTime is not monotonic so wait a bit to make sure following spans are shown after this span
-        std::thread::sleep(std::time::Duration::from_millis(1));
+        thread::sleep(Duration::from_millis(1));
         {
             let mut span = root_span.child("first request");
             span.set_tag(|| Tag::new("actor", actor_ref.as_mut().name()));
@@ -102,7 +102,7 @@ fn manual_example() {
         actor_system.process().unwrap();
         actor_system.process().unwrap();
 
-        //assert_eq!("MyContext { to_owner_prints: [\"(root chain (sub_1 chain (sub_2 to_owner_print)))\", \"(root fwd sub_1 Ok(Ok(41))\", \"(root chain (sub_1 fwd sub_1 Ok(Ok(41)))\", \"(root chain (sub_1 fwd add_1 request))\", \"(root chain (sub_1 chain (sub_2 recv print (sub_1 fwd print (root fwd print test-from-framework)))))\", \"(root chain (sub_1 chain (sub_2 add 1 to 42)))\", \"(root chain (sub_1 chain (sub_2 rsp 42 - 1 = Ok(Ok(41)))))\", \"(root fwd add_1 request)\"], to_actor_add_resp: [\"Ok(Ok(43))\"] }", &format!("{:?}", my_context.lock()));
+        assert_eq!("MyContext { to_owner_prints: [\"(root chain (sub_1 chain (sub_2 to_owner_print)))\", \"(root fwd sub_1 Ok(Ok(41))\", \"(root chain (sub_1 fwd sub_1 Ok(Ok(41)))\", \"(root chain (sub_1 fwd add_1 request))\", \"(root chain (sub_1 chain (sub_2 recv print (sub_1 fwd print (root fwd print test-from-framework)))))\", \"(root chain (sub_1 chain (sub_2 add 1 to 42)))\", \"(root chain (sub_1 chain (sub_2 rsp 42 - 1 = Ok(Ok(41)))))\", \"(root fwd add_1 request)\"], to_actor_add_resp: [\"Ok(Ok(43))\"] }", &format!("{:?}", my_context.lock()));
         println!("\n my_context = {:#?}", my_context);
 
         // can we access it directly?


### PR DESCRIPTION
Fixed remaining FIXME's in ghost-actor and use the updated holochain-tracing crate to use ConsoleTracer, so we get:
```
[manual_example_root_span] 
!event! start
	[first event] {actor = String("root")} 
		[send_protocol] {message_type = String("event_to_actor_print")} 
			[send_protocol] {message_type = String("event_to_actor_print")} 
				[send_protocol] {message_type = String("event_to_actor_print")} 
					[send_protocol] {message_type = String("event_to_owner_print")} 
						[trigger] 
							[send_protocol] {message_type = String("event_to_owner_print")} 
								[trigger] 
									[send_protocol] {message_type = String("event_to_owner_print")} 
										[trigger] 
										!event! print: "(root chain (sub_1 chain (sub_2 recv print (sub_1 fwd print (root fwd print test-from-framework)))))"
	[first request] {actor = String("root")} 
		[send_protocol] {message_type = String("request_to_actor_add_1")} 
			[send_protocol] {message_type = String("request_to_actor_add_1")} 
				[bookmarking] 
				[send_protocol] {message_type = String("request_to_actor_add_1")} 
					[bookmarking] 
					[send_protocol] {message_type = String("event_to_owner_print")} 
						[trigger] 
							[send_protocol] {message_type = String("event_to_owner_print")} 
								[trigger] 
									[send_protocol] {message_type = String("event_to_owner_print")} 
										[trigger] 
										!event! print: "(root chain (sub_1 chain (sub_2 add 1 to 42)))"
			[bookmarking] 
```
