### PR TITLE
Workings spans in Lib3h

### DIFF
--- a/crates/ghost_actor/Cargo.toml
+++ b/crates/ghost_actor/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
 crossbeam-channel = "=0.3.8"
-holochain_tracing = { path = "C:/github/holochain-tracing" }
+holochain_tracing = { version = "=0.0.2", git = "https://github.com/holochain/holochain-tracing" }
 Inflector = "=0.11.4"
 lazy_static = "=1.2.0"
 lib3h_zombie_actor = { version = "=0.0.19", path = "../zombie_actor" }

--- a/crates/ghost_actor/Cargo.toml
+++ b/crates/ghost_actor/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
 crossbeam-channel = "=0.3.8"
-holochain_tracing = { version = "=0.0.2", git = "https://github.com/holochain/holochain-tracing" }
+holochain_tracing = { version = "=0.0.3", git = "https://github.com/holochain/holochain-tracing" }
 Inflector = "=0.11.4"
 lazy_static = "=1.2.0"
 lib3h_zombie_actor = { version = "=0.0.20", path = "../zombie_actor" }

--- a/crates/ghost_actor/Cargo.toml
+++ b/crates/ghost_actor/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
 crossbeam-channel = "=0.3.8"
-holochain_tracing = { version = "=0.0.3", git = "https://github.com/holochain/holochain-tracing" }
+holochain_tracing = "=0.0.3"
 Inflector = "=0.11.4"
 lazy_static = "=1.2.0"
 lib3h_zombie_actor = { version = "=0.0.20", path = "../zombie_actor" }

--- a/crates/ghost_actor/src/ghost_actor.rs
+++ b/crates/ghost_actor/src/ghost_actor.rs
@@ -342,7 +342,7 @@ impl<
             parent_span.child("send_protocol")
         } else {
             let tracer = GHOST_TRACER.lock().unwrap();
-            tracer.span("(root).send_protocol").start().into()
+            tracer.span("(root) send_protocol").start().into()
         };
         let id = message.discriminant().clone().id().to_string();
         span.set_tag(move || Tag::new("message_type", id));

--- a/crates/ghost_actor/src/ghost_tracker.rs
+++ b/crates/ghost_actor/src/ghost_tracker.rs
@@ -232,7 +232,6 @@ impl<'lt, X: 'lt + Send + Sync, T: 'lt + Send + Sync> GhostTracker<'lt, X, T> {
 #[cfg(test)]
 mod tests {
     use crate::*;
-    use holochain_tracing::Span;
     use std::sync::Arc;
 
     #[test]

--- a/crates/ghost_actor/src/ghost_tracker.rs
+++ b/crates/ghost_actor/src/ghost_tracker.rs
@@ -254,7 +254,7 @@ mod tests {
 
         track
             .bookmark_with_options(
-                Span::fixme(),
+                holochain_tracing::test_span("test"),
                 Box::new(|_span, me, response| {
                     assert_eq!(
                         "Err(GhostError(Other(\"timeout\")))",
@@ -296,7 +296,7 @@ mod tests {
 
         let rid = track
             .bookmark(
-                Span::fixme(),
+                holochain_tracing::test_span("test"),
                 Box::new(|_span, me, response| {
                     me.got_response = format!("{:?}", response);
                     Ok(())
@@ -305,7 +305,11 @@ mod tests {
             .unwrap();
 
         track
-            .handle(Span::fixme(), rid, "test-response".to_string())
+            .handle(
+                holochain_tracing::test_span("test"),
+                rid,
+                "test-response".to_string(),
+            )
             .unwrap();
 
         sys.process().unwrap();

--- a/crates/ghost_actor/tests/manual_example_mod/test_actor.rs
+++ b/crates/ghost_actor/tests/manual_example_mod/test_actor.rs
@@ -109,7 +109,7 @@ impl<'lt, S: GhostSystemRef<'lt>> TestActor<'lt, S> {
                                 Some(span),
                                 format!("({} add 1 to {})", me.name, message),
                             )?;
-                            cb(Span::fixme(), Ok(message + 1))
+                            cb(span, Ok(message + 1))
                         }
                         Some(sub_actor) => sub_actor.request_to_actor_add_1(
                             Some(span),

--- a/crates/ghost_actor/tests/manual_example_mod/test_actor.rs
+++ b/crates/ghost_actor/tests/manual_example_mod/test_actor.rs
@@ -106,7 +106,7 @@ impl<'lt, S: GhostSystemRef<'lt>> TestActor<'lt, S> {
                     {
                         None => {
                             me.owner_ref.event_to_owner_print(
-                                Some(span),
+                                Some(span.child("print request")),
                                 format!("({} add 1 to {})", me.name, message),
                             )?;
                             cb(span, Ok(message + 1))

--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -18,7 +18,7 @@ detach = { version = "=0.0.20", path = "../detach" }
 env_logger = "=0.6.1"
 hcid = "=0.0.6"
 holochain_persistence_api = "=0.0.10"
-holochain_tracing = "=0.0.3"
+holochain_tracing = { version = "=0.0.3", git = "https://github.com/holochain/holochain-tracing" }
 # version on the left for release regex
 lib3h_protocol = { version = "=0.0.20", path = "../lib3h_protocol" }
 lib3h_p2p_protocol = { version = "=0.0.20", path = "../p2p_protocol" }

--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -18,7 +18,7 @@ detach = { version = "=0.0.20", path = "../detach" }
 env_logger = "=0.6.1"
 hcid = "=0.0.6"
 holochain_persistence_api = "=0.0.10"
-holochain_tracing = { path = "C:/github/holochain-tracing" }
+holochain_tracing = "=0.0.3"
 # version on the left for release regex
 lib3h_protocol = { version = "=0.0.20", path = "../lib3h_protocol" }
 lib3h_p2p_protocol = { version = "=0.0.20", path = "../p2p_protocol" }

--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -18,7 +18,7 @@ detach = { version = "=0.0.19", path = "../detach" }
 env_logger = "=0.6.1"
 hcid = "=0.0.6"
 holochain_persistence_api = "=0.0.10"
-holochain_tracing = "=0.0.1"
+holochain_tracing = { path = "C:/github/holochain-tracing" }
 # version on the left for release regex
 lib3h_protocol = { version = "=0.0.19", path = "../lib3h_protocol" }
 lib3h_p2p_protocol = { version = "=0.0.19", path = "../p2p_protocol" }

--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -18,7 +18,7 @@ detach = { version = "=0.0.20", path = "../detach" }
 env_logger = "=0.6.1"
 hcid = "=0.0.6"
 holochain_persistence_api = "=0.0.10"
-holochain_tracing = { version = "=0.0.3", git = "https://github.com/holochain/holochain-tracing" }
+holochain_tracing = "=0.0.3"
 # version on the left for release regex
 lib3h_protocol = { version = "=0.0.20", path = "../lib3h_protocol" }
 lib3h_p2p_protocol = { version = "=0.0.20", path = "../p2p_protocol" }

--- a/crates/lib3h/src/bin/demo.rs
+++ b/crates/lib3h/src/bin/demo.rs
@@ -2,7 +2,6 @@
 extern crate detach;
 
 use detach::Detach;
-use holochain_tracing::*;
 use lib3h::{
     dht::mirror_dht::MirrorDht,
     engine::{engine_actor::*, *},
@@ -75,7 +74,7 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
         let dht_factory = MirrorDht::new_with_config;
 
         let e1 = GhostEngine::new(
-            Span::fixme(),
+            holochain_tracing::test_span("demo"),
             crypto.clone(),
             config.clone(),
             "send-demo-e1",
@@ -92,8 +91,14 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
             config.bind_url = Url::parse("wss://127.0.0.1:63519").unwrap().into();
         }
 
-        let e2 =
-            GhostEngine::new(Span::fixme(), crypto, config, "send-demo-e2", dht_factory).unwrap();
+        let e2 = GhostEngine::new(
+            holochain_tracing::test_span("demo"),
+            crypto,
+            config,
+            "send-demo-e2",
+            dht_factory,
+        )
+        .unwrap();
         let e2_addr = e2.advertise();
         println!("e2: {}", e2_addr);
 
@@ -111,7 +116,7 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
 
         out.engine1
             .request(
-                Span::fixme(),
+                holochain_tracing::test_span("demo"),
                 ClientToLib3h::Bootstrap(BootstrapData {
                     network_or_space_address: NET_ID.into(),
                     bootstrap_uri: out.engine2_addr.clone(),
@@ -128,7 +133,7 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
 
         out.engine1
             .request(
-                Span::fixme(),
+                holochain_tracing::test_span("demo"),
                 ClientToLib3h::JoinSpace(SpaceData {
                     request_id: "".to_string(),
                     space_address: SPACE_ADDR.into(),
@@ -143,7 +148,7 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
 
         out.engine2
             .request(
-                Span::fixme(),
+                holochain_tracing::test_span("demo"),
                 ClientToLib3h::JoinSpace(SpaceData {
                     request_id: "".to_string(),
                     space_address: SPACE_ADDR.into(),
@@ -226,7 +231,7 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
     pub fn send_1_to_2(&mut self) {
         self.engine1
             .request(
-                Span::fixme(),
+                holochain_tracing::test_span("demo"),
                 ClientToLib3h::SendDirectMessage(DirectMessageData {
                     space_address: SPACE_ADDR.into(),
                     request_id: "TEST_REQ_ID".to_string(),
@@ -252,7 +257,7 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
     pub fn query_1(&mut self) {
         self.engine1
             .request(
-                Span::fixme(),
+                holochain_tracing::test_span("demo"),
                 ClientToLib3h::QueryEntry(QueryEntryData {
                     space_address: SPACE_ADDR.into(),
                     entry_address: ENTRY_ADDR.into(),
@@ -272,7 +277,7 @@ impl<'lt> EngineContainer<GhostEngine<'lt>> {
     pub fn publish_1(&mut self) {
         self.engine1
             .publish(
-                Span::fixme(),
+                holochain_tracing::test_span("demo"),
                 ClientToLib3h::PublishEntry(ProvidedEntryData {
                     space_address: SPACE_ADDR.into(),
                     provider_agent_id: A_1_ID.into(),

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -409,6 +409,7 @@ impl MirrorDht {
             // Owner is asking us to hold a peer info
             DhtRequestToChild::HoldPeer(new_peer_data) => {
                 trace!("DhtRequestToChild::HoldPeer: {:?}", new_peer_data);
+                let span_hold = span.child("handle DhtRequestToChild::HoldPeer");
                 // Get peer_list before adding new peer (to use when doing gossipTo)
                 let others_list = self.get_other_peer_list();
                 // Store it
@@ -436,8 +437,10 @@ impl MirrorDht {
                     peer_name_list: others_list,
                     bundle: buf.into(),
                 };
+
                 self.endpoint_self.publish(
-                    span.follower("TODO-name DhtRequestToChild::HoldPeer"),
+                    span_hold
+                        .child("send event DhtRequestToParent::GossipTo all the received PeerData"),
                     DhtRequestToParent::GossipTo(gossip_evt),
                 )?;
 
@@ -446,7 +449,9 @@ impl MirrorDht {
                     let gossip_data = self.gossip_self(vec![new_peer_data.peer_name.clone()]);
                     if gossip_data.peer_name_list.len() > 0 {
                         self.endpoint_self.publish(
-                            span.follower("TODO-name DhtRequestToChild::HoldPeer"),
+                            span_hold.child(
+                                "send event DhtRequestToParent::GossipTo all our own PeerData",
+                            ),
                             DhtRequestToParent::GossipTo(gossip_data),
                         )?;
                     }

--- a/crates/lib3h/src/dht/mirror_dht.rs
+++ b/crates/lib3h/src/dht/mirror_dht.rs
@@ -342,8 +342,11 @@ impl
         }
         let (did_work, command_list) = self.internal_process().unwrap(); // FIXME unwrap
         for command in command_list {
-            self.endpoint_self
-                .publish(Span::todo("where does span come from?"), command)?;
+            self.endpoint_self.publish(
+                Span::todo("get span from engine.process() in ghost-actor-v2 ?"),
+                // holochain_tracing::new_root_span("debug mirro_dht process command"),
+                command,
+            )?;
         }
         Ok(did_work.into())
     }

--- a/crates/lib3h/src/engine/ghost_engine_wrapper.rs
+++ b/crates/lib3h/src/engine/ghost_engine_wrapper.rs
@@ -8,7 +8,6 @@ use crate::{
 use std::convert::TryInto;
 
 use detach::Detach;
-use holochain_tracing::Span;
 use lib3h_ghost_actor::*;
 use lib3h_protocol::{
     data_types::{ConnectedData, GenericResultData, Opaque},

--- a/crates/lib3h/src/engine/ghost_engine_wrapper.rs
+++ b/crates/lib3h/src/engine/ghost_engine_wrapper.rs
@@ -1,6 +1,7 @@
 use crate::{
     engine::{engine_actor::GhostEngineParentWrapper, CanAdvertise, GhostEngine},
     error::*,
+    new_root_span,
     track::Tracker,
 };
 
@@ -226,10 +227,11 @@ where
         if let Ok(client_to_lib3h) = maybe_client_to_lib3h {
             debug!("client_to_lib3h: {:?}", client_to_lib3h);
             let result = if request_id == "" {
-                self.engine.publish(Span::fixme(), client_to_lib3h)
+                self.engine
+                    .publish(new_root_span("client_to_lib3h event"), client_to_lib3h)
             } else {
                 self.engine.request(
-                    Span::fixme(),
+                    new_root_span("client_to_lib3h request"),
                     client_to_lib3h,
                     LegacyLib3h::make_callback(request_id.to_string(), space_addr, agent_id),
                 )

--- a/crates/lib3h/src/engine/space_layer.rs
+++ b/crates/lib3h/src/engine/space_layer.rs
@@ -109,6 +109,7 @@ impl<'engine> GhostEngine<'engine> {
                     DhtRequestToParent::GossipTo(gossip_data) => {
                         let from_peer_name = &space_gateway.as_mut().as_mut().this_peer().peer_name;
                         handle_GossipTo(
+                            span.child("handle_GossipTo"),
                             chain_id.0.clone().into(),
                             space_gateway,
                             from_peer_name,

--- a/crates/lib3h/src/engine/space_layer.rs
+++ b/crates/lib3h/src/engine/space_layer.rs
@@ -156,7 +156,7 @@ impl<'engine> GhostEngine<'engine> {
                                 Some(RealEngineTrackerData::HoldEntryRequested),
                             );
                             self.lib3h_endpoint.publish(
-                                Span::fixme(),
+                                span.child("send event Lib3hToClient::HandleStoreEntryAspect"),
                                 Lib3hToClient::HandleStoreEntryAspect(lib3h_msg),
                             )?;
                         }
@@ -175,7 +175,7 @@ impl<'engine> GhostEngine<'engine> {
                         };
                         self.lib3h_endpoint
                             .request(
-                                Span::fixme(),
+                                span.child("send request HandleFetchEntry"),
                                 Lib3hToClient::HandleFetchEntry(msg.clone()),
                                 Box::new(move |me, response| {
                                     let mut is_data_for_author_list = false;
@@ -215,7 +215,7 @@ impl<'engine> GhostEngine<'engine> {
                                                 is_data_for_author_list);
                                             if is_data_for_author_list {
                                                 space_gateway.publish(
-                                                    Span::fixme(),
+                                                    span.child("send event GatewayRequestToChild::DhtRequestToChild::BroadcastEntry"),
                                                     GatewayRequestToChild::Dht(DhtRequestToChild::BroadcastEntry(entry)))?;
                                             } else {
                                                 request.respond(Ok(
@@ -283,7 +283,7 @@ impl<'engine> GhostEngine<'engine> {
         match p2p_msg {
             P2pProtocol::DirectMessage(dm_data) => {
                 self.lib3h_endpoint.request(
-                    span,
+                    span.child("request Lib3hToClient::HandleSendDirectMessage"),
                     Lib3hToClient::HandleSendDirectMessage(dm_data),
                     Box::new(move |me, resp| match resp {
                         GhostCallbackData::Response(Ok(
@@ -306,7 +306,9 @@ impl<'engine> GhostEngine<'engine> {
                             );
 
                             space_gateway.publish(
-                                Span::fixme(),
+                                span.child(
+                                    "send event GatewayRequestToChild::Transport::SendMessage",
+                                ),
                                 GatewayRequestToChild::Transport(
                                     RequestToChild::create_send_message(
                                         Lib3hUri::with_agent_id(&to_agent_id),
@@ -351,7 +353,7 @@ impl<'engine> GhostEngine<'engine> {
                     &gossip_data.to_peer_name.agent_id(),
                 )?;
                 space_gateway.publish(
-                    span.follower("TODO"),
+                    span.child("send event GatewayRequestToChild::DhtRequestToChild::HandleGossip"),
                     GatewayRequestToChild::Dht(DhtRequestToChild::HandleGossip(remote_gossip)),
                 )?;
             }

--- a/crates/lib3h/src/gateway/gateway_actor.rs
+++ b/crates/lib3h/src/gateway/gateway_actor.rs
@@ -4,7 +4,6 @@ use crate::{
     error::*,
     gateway::{protocol::*, send_data_types::*, P2pGateway},
 };
-use holochain_tracing::Span;
 use lib3h_ghost_actor::prelude::*;
 use lib3h_p2p_protocol::p2p::P2pMessage;
 
@@ -40,7 +39,8 @@ impl
 
         // Update this_peer cache
         self.inner_dht.request(
-            Span::fixme(),
+            // new_root_span("Update this_peer cache"),
+            holochain_tracing::test_span("debug"),
             DhtRequestToChild::RequestThisPeer,
             Box::new(|mut me, response| {
                 let response = {
@@ -119,7 +119,7 @@ impl P2pGateway {
             GatewayRequestToChild::SendAll(payload) => {
                 trace!("send all: {:?}", String::from_utf8_lossy(&payload));
                 self.inner_dht.request(
-                    Span::fixme(),
+                    span.child("request DhtRequestToChild::RequestPeerList"),
                     DhtRequestToChild::RequestPeerList,
                     Box::new(move |me, response| {
                         match response {
@@ -136,7 +136,7 @@ impl P2pGateway {
                                     let uri = peer.get_uri();
                                     me.send_with_full_low_uri(
                                         SendWithFullLowUri {
-                                            span: Span::fixme(),
+                                            span: span.child("send_with_full_low_uri"),
                                             full_low_uri: uri,
                                             payload: payload.clone().into(),
                                         },

--- a/crates/lib3h/src/gateway/gateway_dht.rs
+++ b/crates/lib3h/src/gateway/gateway_dht.rs
@@ -104,8 +104,11 @@ impl P2pGateway {
                 unreachable!();
             }
             DhtRequestToParent::RequestEntry(_) => {
+                let span_request = span.child("request GatewayRequestToParent::Dht::RequestEntry");
+                let span_broadcast =
+                    span_request.child("request GatewayRequestToParent::Dht::BroadcastEntry");
                 self.endpoint_self.request(
-                    span,
+                    span_request,
                     GatewayRequestToParent::Dht(payload),
                     Box::new(|me, response| {
                         trace!("Received requestEntry response in Gateway");
@@ -118,8 +121,10 @@ impl P2pGateway {
                         // #fullsync - received entry response after request from gossip list handling,
                         // treat it as an entry from author list handling.
                         if let DhtRequestToParentResponse::RequestEntry(entry) = dht_response {
-                            me.inner_dht
-                                .publish(Span::fixme(), DhtRequestToChild::BroadcastEntry(entry))?;
+                            me.inner_dht.publish(
+                                span_broadcast,
+                                DhtRequestToChild::BroadcastEntry(entry),
+                            )?;
                         }
                         Ok(())
                     }),

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -20,14 +20,14 @@ impl P2pGateway {
         // TODO #199: This is prbably wrong in that a different level of URI should be being bubbled up.
         // depends on how & what we decide to send up to the client.
         self.endpoint_self.publish(
-            span.child("publish Transport::IncomingConnection"),
+            span.child("send event GatewayRequestToParent::Transport::IncomingConnection"),
             GatewayRequestToParent::Transport(
                 transport::protocol::RequestToParent::IncomingConnection { uri: uri.clone() },
             ),
         )?;
 
         self.inner_dht.request(
-            span.child("request DHT::RequestThisPeer"),
+            span.child("request DhtRequestToChild::RequestThisPeer"),
             DhtRequestToChild::RequestThisPeer,
             Box::new(move |me, response| {
                 let response = {
@@ -55,7 +55,7 @@ impl P2pGateway {
                     let buf = our_peer_name.into_bytes().into();
                     me.send_with_full_low_uri(
                         SendWithFullLowUri {
-                            span: span.follower("TODO send"),
+                            span: span.follower("SendWithFullLowUri"),
                             full_low_uri: uri.clone(),
                             payload: buf,
                         },
@@ -280,20 +280,20 @@ impl P2pGateway {
         match &msg {
             transport::protocol::RequestToParent::Unbind(_uri) => {
                 self.endpoint_self.publish(
-                    span.child("publish Transport::Unbind"),
+                    span.child("send event GatewayRequestToParent::Transport::Unbind"),
                     GatewayRequestToParent::Transport(msg.clone()),
                 )?;
             }
             transport::protocol::RequestToParent::Disconnect(_uri) => {
                 self.endpoint_self.publish(
-                    span.child("publish Transport::Disconnect"),
+                    span.child("send event GatewayRequestToParent::Transport::Disconnect"),
                     GatewayRequestToParent::Transport(msg.clone()),
                 )?;
             }
             transport::protocol::RequestToParent::ErrorOccured { uri: _, error: _ } => {
                 // pass any errors back up the chain so network layer can handle them (i.e.)
                 self.endpoint_self.publish(
-                    span.child("publish Transport::ErrorOccured"),
+                    span.child("send event GatewayRequestToParent::Transport::ErrorOccured"),
                     GatewayRequestToParent::Transport(msg.clone()),
                 )?;
             }

--- a/crates/lib3h/src/gateway/gateway_transport.rs
+++ b/crates/lib3h/src/gateway/gateway_transport.rs
@@ -20,14 +20,14 @@ impl P2pGateway {
         // TODO #199: This is prbably wrong in that a different level of URI should be being bubbled up.
         // depends on how & what we decide to send up to the client.
         self.endpoint_self.publish(
-            Span::fixme(),
+            span.child("publish Transport::IncomingConnection"),
             GatewayRequestToParent::Transport(
                 transport::protocol::RequestToParent::IncomingConnection { uri: uri.clone() },
             ),
         )?;
 
         self.inner_dht.request(
-            span.child("handle_incoming_connection"),
+            span.child("request DHT::RequestThisPeer"),
             DhtRequestToChild::RequestThisPeer,
             Box::new(move |me, response| {
                 let response = {
@@ -146,7 +146,7 @@ impl P2pGateway {
                         .into();
                         self.send_with_full_low_uri(
                             SendWithFullLowUri {
-                                span: Span::fixme(),
+                                span: span.child("send_with_full_low_uri"),
                                 full_low_uri: uri,
                                 payload: pong,
                             },
@@ -280,20 +280,20 @@ impl P2pGateway {
         match &msg {
             transport::protocol::RequestToParent::Unbind(_uri) => {
                 self.endpoint_self.publish(
-                    Span::fixme(),
+                    span.child("publish Transport::Unbind"),
                     GatewayRequestToParent::Transport(msg.clone()),
                 )?;
             }
             transport::protocol::RequestToParent::Disconnect(_uri) => {
                 self.endpoint_self.publish(
-                    Span::fixme(),
+                    span.child("publish Transport::Disconnect"),
                     GatewayRequestToParent::Transport(msg.clone()),
                 )?;
             }
             transport::protocol::RequestToParent::ErrorOccured { uri: _, error: _ } => {
                 // pass any errors back up the chain so network layer can handle them (i.e.)
                 self.endpoint_self.publish(
-                    Span::fixme(),
+                    span.child("publish Transport::ErrorOccured"),
                     GatewayRequestToParent::Transport(msg.clone()),
                 )?;
             }
@@ -304,7 +304,7 @@ impl P2pGateway {
                     self.identifier.nickname, uri
                 );
                 self.handle_incoming_connection(
-                    span.child("transport::protocol::RequestToParent::IncomingConnection"),
+                    span.child("handle_incoming_connection: IncomingConnection"),
                     uri.clone(),
                 )?;
             }

--- a/crates/lib3h/src/gateway/gateway_transport_send.rs
+++ b/crates/lib3h/src/gateway/gateway_transport_send.rs
@@ -5,7 +5,6 @@ use crate::{
     message_encoding::encoding_protocol,
     transport,
 };
-use holochain_tracing::Span;
 use lib3h_ghost_actor::prelude::*;
 use lib3h_protocol::{data_types::*, types::*};
 use rmp_serde::Serializer;
@@ -139,7 +138,7 @@ impl P2pGateway {
                         trace!("send to {}", uri);
                         me.priv_send_with_full_low_uri(
                             SendWithFullLowUri {
-                                span: Span::fixme(),
+                                span: send_data.span.child("SendWithFullLowUri"),
                                 full_low_uri: uri,
                                 payload: send_data.payload,
                             },
@@ -200,7 +199,9 @@ impl P2pGateway {
         let payload = send_data.payload.clone();
 
         self.message_encoding.request(
-            Span::fixme(),
+            send_data
+                .span
+                .child("request RequestToChild::EncodePayload"),
             encoding_protocol::RequestToChild::EncodePayload { payload },
             Box::new(move |me, resp| {
                 match resp {
@@ -268,7 +269,7 @@ impl P2pGateway {
         uri.clear_agent_id();
 
         self.inner_transport.request(
-            Span::fixme(),
+            send_data.span.child("request RequestToChild::SendMessage"),
             transport::protocol::RequestToChild::SendMessage { uri, payload },
             Box::new(move |me, resp| {
                 match resp {

--- a/crates/lib3h/src/gateway/p2p_gateway.rs
+++ b/crates/lib3h/src/gateway/p2p_gateway.rs
@@ -3,7 +3,7 @@ use crate::{
     engine::GatewayId,
     gateway::{GatewayOutputWrapType, P2pGateway},
     message_encoding::*,
-    new_root_span, transport,
+    transport,
 };
 use detach::prelude::*;
 use lib3h_ghost_actor::prelude::*;

--- a/crates/lib3h/src/gateway/p2p_gateway.rs
+++ b/crates/lib3h/src/gateway/p2p_gateway.rs
@@ -3,7 +3,7 @@ use crate::{
     engine::GatewayId,
     gateway::{GatewayOutputWrapType, P2pGateway},
     message_encoding::*,
-    transport,
+    new_root_span, transport,
 };
 use detach::prelude::*;
 use lib3h_ghost_actor::prelude::*;
@@ -48,12 +48,12 @@ impl P2pGateway {
             identifier: identifier,
             inner_transport: Detach::new(transport::protocol::TransportActorParentWrapperDyn::new(
                 inner_transport,
-                "to_child_transport_",
+                "gateway_to_child_transport_",
             )),
             inner_dht: Detach::new(ChildDhtWrapperDyn::new(dht, "gateway_dht_")),
             message_encoding: Detach::new(GhostParentWrapper::new(
                 MessageEncoding::new(),
-                "to_message_encoding_",
+                "gateway_to_message_encoding_",
             )),
             endpoint_parent: Some(endpoint_parent),
             endpoint_self,
@@ -73,7 +73,7 @@ impl P2pGateway {
         let inner_dht = &mut self.inner_dht;
         inner_dht
             .request(
-                holochain_tracing::Span::fixme(),
+                crate::new_root_span("get_peer_list"),
                 crate::dht::dht_protocol::DhtRequestToChild::RequestPeerList,
                 Box::new(|_, r| {
                     eprintln!("1 got: {:?}", r);

--- a/crates/lib3h/src/lib.rs
+++ b/crates/lib3h/src/lib.rs
@@ -39,6 +39,17 @@ pub mod transport;
 // FIXME
 // pub mod transport_wss;
 
+// Global Tracer
+lazy_static! {
+    pub static ref LIB3H_TRACER: std::sync::Mutex<holochain_tracing::Tracer> =
+        std::sync::Mutex::new(holochain_tracing::null_tracer());
+}
+
+pub fn new_root_span(op_name: &str) -> holochain_tracing::Span {
+    let tracer = LIB3H_TRACER.lock().unwrap();
+    tracer.span(format!("(root).{}", op_name)).start().into()
+}
+
 #[cfg(test)]
 mod tests {
     extern crate test;

--- a/crates/lib3h/src/lib.rs
+++ b/crates/lib3h/src/lib.rs
@@ -47,7 +47,7 @@ lazy_static! {
 
 pub fn new_root_span(op_name: &str) -> holochain_tracing::Span {
     let tracer = LIB3H_TRACER.lock().unwrap();
-    tracer.span(format!("(root).{}", op_name)).start().into()
+    tracer.span(format!("(root) {}", op_name)).start().into()
 }
 
 #[cfg(test)]

--- a/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
+++ b/crates/lib3h/src/transport/memory_mock/ghost_transport_memory.rs
@@ -319,7 +319,7 @@ impl
                                         // if so we can add the message directly to our own inbox
                                         trace!("Send-to-self: payload:{:?}", payload);
                                         self.endpoint_self.publish(
-                                            span.child("publish ReceivedData"),
+                                            span.child("send event RequestToParent::ReceivedData"),
                                             RequestToParent::ReceivedData { uri: uri, payload },
                                         )?;
                                     } else {

--- a/crates/lib3h/src/transport/transport_multiplex/mod.rs
+++ b/crates/lib3h/src/transport/transport_multiplex/mod.rs
@@ -27,7 +27,6 @@ mod tests {
     use crate::{error::Lib3hError, gateway::protocol::*, transport::protocol::*};
     use detach::prelude::*;
     use holochain_persistence_api::hash::HashString;
-    use holochain_tracing::Span;
     use lib3h_ghost_actor::prelude::*;
     use lib3h_protocol::{data_types::Opaque, uri::Lib3hUri};
 

--- a/crates/lib3h/src/transport/transport_multiplex/mod.rs
+++ b/crates/lib3h/src/transport/transport_multiplex/mod.rs
@@ -107,7 +107,7 @@ mod tests {
                 }
             }
             loop {
-                let span = Span::fixme();
+                let span = holochain_tracing::test_span("");
                 match self.mock_receiver.try_recv() {
                     Ok((uri, payload)) => {
                         self.endpoint_self.publish(
@@ -153,7 +153,7 @@ mod tests {
         // send a message from route A
         route_a
             .request(
-                Span::fixme(),
+                holochain_tracing::test_span(""),
                 RequestToChild::create_send_message(addr_none.clone(), "hello-from-a".into()),
                 Box::new(|_, response| {
                     assert_eq!(&format!("{:?}", response), "");

--- a/crates/lib3h/src/transport/transport_multiplex/mplex.rs
+++ b/crates/lib3h/src/transport/transport_multiplex/mplex.rs
@@ -313,8 +313,7 @@ impl<
         let data = msg.take_message().expect("exists");
         if msg.is_request() {
             self.inner_gateway.as_mut().request(
-                msg.span()
-                    .follower("TODO follower of message in handle_msg_from_parent"),
+                msg.span().child("handle_msg_from_parent"),
                 data,
                 Box::new(move |_, response| {
                     let response = {
@@ -333,8 +332,7 @@ impl<
         } else {
             let orig_req = data.clone();
             self.inner_gateway.as_mut().request(
-                msg.span()
-                    .follower("TODO follower of message in handle_msg_from_parent"),
+                msg.span().child("handle_msg_from_parent"),
                 data,
                 Box::new(move |_, response| {
                     match response {

--- a/crates/lib3h/tests/engine_test.rs
+++ b/crates/lib3h/tests/engine_test.rs
@@ -149,7 +149,7 @@ fn basic_track_test_wss() {
     basic_track_test(&mut engine);
     // Print spans
     let count = reporter.drain();
-    println!("span count = {}", count);
+    println!("Report span count = {}", count);
     reporter.print(false);
 }
 

--- a/crates/lib3h/tests/engine_test.rs
+++ b/crates/lib3h/tests/engine_test.rs
@@ -75,7 +75,7 @@ fn basic_setup_mock_bootstrap<'engine>(
     let root_span: Span = LIB3H_TRACER
         .lock()
         .unwrap()
-        .span("basic_setup_mock_root: GhostEngine::new()")
+        .span("(root) basic_setup_mock: GhostEngine::new()")
         .start()
         .into();
     let engine = GhostEngine::new(
@@ -113,7 +113,7 @@ fn basic_setup_wss<'engine>(name: &str) -> GhostEngine<'engine> {
     let root_span: Span = LIB3H_TRACER
         .lock()
         .unwrap()
-        .span("basic_setup_mock_root: GhostEngine::new()")
+        .span("(root) basic_setup_mock: GhostEngine::new()")
         .start()
         .into();
     let engine = GhostEngine::new(
@@ -176,7 +176,7 @@ fn basic_track_test<'engine>(mut engine: &mut GhostEngine<'engine>) {
     let mut root_span: Span = LIB3H_TRACER
         .lock()
         .unwrap()
-        .span("basic_track_test_root")
+        .span("(root) basic_track_test")
         .start()
         .into();
     root_span.event("start");
@@ -200,8 +200,7 @@ fn basic_track_test<'engine>(mut engine: &mut GhostEngine<'engine>) {
 
     parent_endpoint
         .publish(
-            // root_span.child("publish join space"),
-            Span::fixme(),
+            root_span.child("send event ClientToLib3h::JoinSpace"),
             ClientToLib3h::JoinSpace(track_space.clone()),
         )
         .unwrap();

--- a/crates/lib3h/tests/engine_test.rs
+++ b/crates/lib3h/tests/engine_test.rs
@@ -12,11 +12,10 @@ extern crate regex;
 
 #[macro_use]
 extern crate log;
-use holochain_tracing::test_span;
 
 use lib3h_ghost_actor::{wait1_for_callback, wait1_for_messages};
 
-use holochain_tracing::Span;
+use holochain_tracing::{tracer_console::*, Span};
 use lib3h::{
     dht::mirror_dht::MirrorDht,
     engine::{EngineConfig, GhostEngine, TransportConfig},
@@ -25,10 +24,10 @@ use lib3h::{
 
 use lib3h_ghost_actor::prelude::*;
 
-use crate::lib3h::engine::CanAdvertise;
+use crate::lib3h::{engine::CanAdvertise, LIB3H_TRACER};
 use lib3h_protocol::{data_types::*, protocol::*, uri::Lib3hUri};
 use lib3h_sodium::SodiumCryptoSystem;
-use std::path::PathBuf;
+use std::{path::PathBuf, thread, time::Duration};
 use url::Url;
 use utils::{constants::*, test_network_id};
 
@@ -73,8 +72,14 @@ fn basic_setup_mock_bootstrap<'engine>(
         dht_timeout_threshold: 1000,
         dht_custom_config: vec![],
     };
+    let root_span: Span = LIB3H_TRACER
+        .lock()
+        .unwrap()
+        .span("basic_setup_mock_root: GhostEngine::new()")
+        .start()
+        .into();
     let engine = GhostEngine::new(
-        Span::fixme(),
+        root_span,
         Box::new(SodiumCryptoSystem::new()),
         config,
         name.into(),
@@ -105,8 +110,14 @@ fn basic_setup_wss<'engine>(name: &str) -> GhostEngine<'engine> {
         dht_timeout_threshold: 2000,
         dht_custom_config: vec![],
     };
+    let root_span: Span = LIB3H_TRACER
+        .lock()
+        .unwrap()
+        .span("basic_setup_mock_root: GhostEngine::new()")
+        .start()
+        .into();
     let engine = GhostEngine::new(
-        Span::fixme(),
+        root_span,
         Box::new(SodiumCryptoSystem::new()),
         config,
         name,
@@ -120,30 +131,58 @@ fn basic_setup_wss<'engine>(name: &str) -> GhostEngine<'engine> {
 }
 
 //--------------------------------------------------------------------------------------------------
-// Utils
-//--------------------------------------------------------------------------------------------------
-
-//--------------------------------------------------------------------------------------------------
 // Custom tests
 //--------------------------------------------------------------------------------------------------
 
 #[test]
 fn basic_track_test_wss() {
     enable_logging_for_test(true);
+    // Create tracer & reporter
+    let (tracer, mut reporter) = new_tracer_with_console_reporter();
+    {
+        let mut singleton = LIB3H_TRACER.lock().unwrap();
+        *singleton = tracer;
+    }
     // Setup
     let mut engine: GhostEngine = basic_setup_wss("wss_test_node");
+    // Launch
     basic_track_test(&mut engine);
+    // Print spans
+    let count = reporter.drain();
+    println!("span count = {}", count);
+    reporter.print(false);
 }
 
 #[test]
 fn basic_track_test_mock() {
     enable_logging_for_test(true);
+    // Create tracer & reporter
+    let (tracer, mut reporter) = new_tracer_with_console_reporter();
+    {
+        let mut singleton = LIB3H_TRACER.lock().unwrap();
+        *singleton = tracer;
+    }
     // Setup
     let mut engine: GhostEngine = basic_setup_mock("alex", "basic_track_test_mock");
+    // Launch
     basic_track_test(&mut engine);
+    // Print spans
+    let count = reporter.drain();
+    println!("span count = {}", count);
+    reporter.print(false);
 }
 
 fn basic_track_test<'engine>(mut engine: &mut GhostEngine<'engine>) {
+    let mut root_span: Span = LIB3H_TRACER
+        .lock()
+        .unwrap()
+        .span("basic_track_test_root")
+        .start()
+        .into();
+    root_span.event("start");
+    // SystemTime is not monotonic so wait a bit to make sure following spans are shown after this span
+    thread::sleep(Duration::from_millis(1));
+
     // Test
     let mut track_space = SpaceData {
         request_id: "track_a_1".into(),
@@ -161,15 +200,16 @@ fn basic_track_test<'engine>(mut engine: &mut GhostEngine<'engine>) {
 
     parent_endpoint
         .publish(
-            test_span("publish join space"),
+            // root_span.child("publish join space"),
+            Span::fixme(),
             ClientToLib3h::JoinSpace(track_space.clone()),
         )
         .unwrap();
     let handle_get_gossip_entry_list_regex =
-        "HandleGetGossipingEntryList\\(GetListData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), request_id: \"[\\w\\d_~]*\" \\}\\)";
+            "HandleGetGossipingEntryList\\(GetListData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), request_id: \"[\\w\\d_~]*\" \\}\\)";
 
     let handle_get_authoring_entry_list_regex =
-        "HandleGetAuthoringEntryList\\(GetListData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), request_id: \"[\\w\\d_~]*\" \\}\\)";
+            "HandleGetAuthoringEntryList\\(GetListData \\{ space_address: SpaceHash\\(HashString\\(\"appA\"\\)\\), provider_agent_id: AgentPubKey\\(HashString\\(\"alex\"\\)\\), request_id: \"[\\w\\d_~]*\" \\}\\)";
 
     let regexes = vec![
         handle_get_authoring_entry_list_regex,

--- a/crates/lib3h/tests/integration_test.rs
+++ b/crates/lib3h/tests/integration_test.rs
@@ -18,12 +18,13 @@ extern crate multihash;
 mod node_mock;
 mod test_suites;
 
-use holochain_tracing::Span;
+use holochain_tracing::{tracer_console::*, Span};
 use lib3h::{
     dht::mirror_dht::MirrorDht,
     engine::{ghost_engine_wrapper::WrappedGhostLib3h, EngineConfig, GhostEngine, TransportConfig},
     error::Lib3hResult,
     transport::websocket::tls::TlsConfig,
+    LIB3H_TRACER,
 };
 use lib3h_protocol::{types::*, uri::Lib3hUri};
 use node_mock::NodeMock;
@@ -209,16 +210,30 @@ fn print_test_name(print_str: &str, test_fn: *mut std::os::raw::c_void) {
 #[test]
 fn test_two_memory_nodes_basic_suite() {
     enable_logging_for_test(true);
+    // Create tracer & reporter
+    let (tracer, mut reporter) = new_tracer_with_console_reporter();
+    {
+        let mut singleton = LIB3H_TRACER.lock().unwrap();
+        *singleton = tracer;
+    }
+    // Launch each test
     for (test_fn, can_setup) in TWO_NODES_BASIC_TEST_FNS.iter() {
-        launch_two_memory_nodes_test(*test_fn, *can_setup).unwrap();
+        launch_two_memory_nodes_test(*test_fn, *can_setup, &mut reporter).unwrap();
     }
 }
 
 #[test]
 fn test_two_memory_nodes_get_lists_suite() {
     enable_logging_for_test(true);
+    // Create tracer & reporter
+    let (tracer, mut reporter) = new_tracer_with_console_reporter();
+    {
+        let mut singleton = LIB3H_TRACER.lock().unwrap();
+        *singleton = tracer;
+    }
+    // Launch each test
     for (test_fn, can_setup) in TWO_NODES_GET_LISTS_TEST_FNS.iter() {
-        launch_two_memory_nodes_test(*test_fn, *can_setup).unwrap();
+        launch_two_memory_nodes_test(*test_fn, *can_setup, &mut reporter).unwrap();
     }
 }
 
@@ -226,8 +241,15 @@ fn test_two_memory_nodes_get_lists_suite() {
 #[ignore] // test is flakey
 fn test_two_memory_nodes_spaces_suite() {
     enable_logging_for_test(true);
+    // Create tracer & reporter
+    let (tracer, mut reporter) = new_tracer_with_console_reporter();
+    {
+        let mut singleton = LIB3H_TRACER.lock().unwrap();
+        *singleton = tracer;
+    }
+    // Launch each test
     for (test_fn, can_setup) in TWO_NODES_SPACES_TEST_FNS.iter() {
-        launch_two_memory_nodes_test(*test_fn, *can_setup).unwrap();
+        launch_two_memory_nodes_test(*test_fn, *can_setup, &mut reporter).unwrap();
     }
 }
 
@@ -242,13 +264,24 @@ fn test_three_memory_nodes_basic_suite() {
 #[ignore]
 fn test_two_memory_nodes_connection_suite() {
     enable_logging_for_test(true);
+    // Create tracer & reporter
+    let (tracer, mut reporter) = new_tracer_with_console_reporter();
+    {
+        let mut singleton = LIB3H_TRACER.lock().unwrap();
+        *singleton = tracer;
+    }
+    // Launch each test
     for (test_fn, can_setup) in TWO_NODES_CONNECTION_TEST_FNS.iter() {
-        launch_two_memory_nodes_test(*test_fn, *can_setup).unwrap();
+        launch_two_memory_nodes_test(*test_fn, *can_setup, &mut reporter).unwrap();
     }
 }
 
 // Do general test with config
-fn launch_two_memory_nodes_test(test_fn: TwoNodesTestFn, can_setup: bool) -> Result<(), ()> {
+fn launch_two_memory_nodes_test(
+    test_fn: TwoNodesTestFn,
+    can_setup: bool,
+    reporter: &mut ConsoleReporter,
+) -> Result<(), ()> {
     let test_fn_ptr = test_fn as *mut std::os::raw::c_void;
     debug!("");
     print_test_name("IN-MEMORY TWO NODES TEST: ", test_fn_ptr);
@@ -267,9 +300,13 @@ fn launch_two_memory_nodes_test(test_fn: TwoNodesTestFn, can_setup: bool) -> Res
     test_fn(&mut alex, &mut billy, options);
 
     // Wrap-up test
-    debug!("========================");
+    debug!("-----------------------");
     print_test_name("IN-MEMORY TWO NODES TEST END: ", test_fn_ptr);
-
+    // Print spans
+    let count = reporter.drain();
+    println!("Report: span count = {}", count);
+    reporter.print(false);
+    debug!("========================");
     // Done
     Ok(())
 }

--- a/crates/lib3h/tests/transport.rs
+++ b/crates/lib3h/tests/transport.rs
@@ -5,7 +5,7 @@ extern crate lazy_static;
 extern crate lib3h_zombie_actor as lib3h_ghost_actor;
 
 use detach::prelude::*;
-use holochain_tracing::{test_span, Span};
+use holochain_tracing::test_span;
 use lib3h::transport::{error::*, protocol::*};
 use lib3h_ghost_actor::prelude::*;
 use lib3h_protocol::{data_types::Opaque, uri::Lib3hUri};

--- a/crates/lib3h/tests/transport.rs
+++ b/crates/lib3h/tests/transport.rs
@@ -256,7 +256,7 @@ impl TestTransport {
         let our_url = self.bound_url.as_ref().unwrap();
         if let Ok(events) = mockernet.process_for(our_url.clone()) {
             for e in events {
-                let span = Span::fixme();
+                let span = holochain_tracing::test_span("mockernet");
                 match e {
                     MockernetEvent::Message { from, payload } => {
                         self.endpoint_self

--- a/crates/zombie_actor/Cargo.toml
+++ b/crates/zombie_actor/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/holochain/lib3h"
 backtrace = "=0.3.27"
 crossbeam-channel = "=0.3.8"
 detach = { version = "=0.0.20", path = "../detach" }
-holochain_tracing = "=0.0.3"
+holochain_tracing = { version = "=0.0.3", git = "https://github.com/holochain/holochain-tracing" }
 nanoid = "=0.2.0"
 parking_lot = "=0.7.1"
 shrinkwraprs = "=0.2.1"

--- a/crates/zombie_actor/Cargo.toml
+++ b/crates/zombie_actor/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/holochain/lib3h"
 backtrace = "=0.3.27"
 crossbeam-channel = "=0.3.8"
 detach = { version = "=0.0.19", path = "../detach" }
-holochain_tracing = "=0.0.1"
+holochain_tracing = { path = "C:/github/holochain-tracing" }
 nanoid = "=0.2.0"
 shrinkwraprs = "=0.2.1"
 log = "=0.4.8"

--- a/crates/zombie_actor/Cargo.toml
+++ b/crates/zombie_actor/Cargo.toml
@@ -16,7 +16,7 @@ backtrace = "=0.3.27"
 crossbeam-channel = "=0.3.8"
 detach = { version = "=0.0.20", path = "../detach" }
 lock_api = "=0.1.5"
-holochain_tracing = { version = "=0.0.3", git = "https://github.com/holochain/holochain-tracing" }
+holochain_tracing = "=0.0.3"
 nanoid = "=0.2.0"
 parking_lot = "=0.7.1"
 shrinkwraprs = "=0.2.1"

--- a/crates/zombie_actor/Cargo.toml
+++ b/crates/zombie_actor/Cargo.toml
@@ -15,6 +15,7 @@ repository = "https://github.com/holochain/lib3h"
 backtrace = "=0.3.27"
 crossbeam-channel = "=0.3.8"
 detach = { version = "=0.0.20", path = "../detach" }
+lock_api = "=0.1.5"
 holochain_tracing = { version = "=0.0.3", git = "https://github.com/holochain/holochain-tracing" }
 nanoid = "=0.2.0"
 parking_lot = "=0.7.1"

--- a/crates/zombie_actor/Cargo.toml
+++ b/crates/zombie_actor/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/holochain/lib3h"
 backtrace = "=0.3.27"
 crossbeam-channel = "=0.3.8"
 detach = { version = "=0.0.20", path = "../detach" }
-holochain_tracing = { path = "C:/github/holochain-tracing" }
+holochain_tracing = "=0.0.3"
 nanoid = "=0.2.0"
 parking_lot = "=0.7.1"
 shrinkwraprs = "=0.2.1"

--- a/crates/zombie_actor/src/ghost_channel.rs
+++ b/crates/zombie_actor/src/ghost_channel.rs
@@ -2,7 +2,7 @@ use crate::{
     ghost_error::ErrorKind, Backtwrap, GhostCallback, GhostError, GhostResult, GhostTracker,
     GhostTrackerBookmarkOptions, GhostTrackerBuilder, RequestId, WorkWasDone,
 };
-use holochain_tracing::Span;
+use holochain_tracing::{test_span, Span};
 
 /// enum used internally as the protocol for our crossbeam_channels
 /// allows us to be explicit about which messages are requests or responses.
@@ -86,7 +86,7 @@ impl<
             request_id: None,
             message: None,
             sender,
-            span: Span::fixme(),
+            span: test_span("test"),
         }
     }
 
@@ -130,7 +130,6 @@ impl<
     /// send a response back to the origin of this request
     pub fn respond(self, payload: Result<RequestToSelfResponse, Error>) -> GhostResult<()> {
         if let Some(request_id) = &self.request_id {
-            println!("respond: span = {:?}", self.span);
             self.sender.send(GhostEndpointMessage::Response {
                 responder_bt: Backtwrap::new(),
                 request_id: request_id.clone(),
@@ -445,13 +444,12 @@ impl<
     >
 {
     /// publish an event to the remote side, not expecting a response
-    fn publish(&mut self, mut span: Span, payload: RequestToOther) -> GhostResult<()> {
+    fn publish(&mut self, span: Span, payload: RequestToOther) -> GhostResult<()> {
         self.sender.send(GhostEndpointMessage::Request {
             requester_bt: Backtwrap::new(),
             request_id: None,
             payload,
-            // span,
-            span: Span::fixme(),
+            span,
         })?;
         Ok(())
     }
@@ -460,7 +458,7 @@ impl<
     /// the callback will be invoked.
     fn request(
         &mut self,
-        mut span: Span,
+        span: Span,
         payload: RequestToOther,
         cb: GhostCallback<UserData, RequestToOtherResponse, Error>,
     ) -> GhostResult<()> {
@@ -471,7 +469,7 @@ impl<
     /// the callback will be invoked, override the default timeout.
     fn request_options(
         &mut self,
-        mut span: Span,
+        span: Span,
         payload: RequestToOther,
         cb: GhostCallback<UserData, RequestToOtherResponse, Error>,
         options: GhostTrackRequestOptions,


### PR DESCRIPTION
Added a LIB3H_TRACER singleton and removed all fixme() and todos() to something useful when appropriate (some spans might still be a bit off but since ghost actor is going to change I don't see the point in making this perfect at this stage)
Added console reporting to engine test and integration test

example:
```
[(root) client_to_lib3h event] 
    [handle PublishEntry] 
        [request Lib3hToClient::HandleStoreEntryAspect] 
        !event! RequestId("billyRO0YRGMx4BtnSmSCImbyl")
            [bookmark] 
        [handle_RequestToChild] 
        [handle_dht_RequestToChild] 
            [handle_request_from_parent] 
            [DhtRequestToChild::BroadcastEntry] 
                [handle_dht_RequestToParent] 
                    [handle_space_request] 
                        [handle_GossipTo] 
                            [Transport Transport::SendMessage] 
                                [handle_RequestToChild] 
                                    [send_with_partial_high_uri] 
                                        [SendWithFullLowUri] 
                                            [request RequestToChild::EncodePayload] 
                                            !event! RequestId("gateway_to_message_encoding_mpIBeCkRkWtxWzhI73GBZ")
                                                [bookmark] 
                                                [send request] 
                                            [request RequestToChild::SendMessage] 
                                            !event! RequestId("gateway_to_child_transport_F5plamn6RyPGAH0Hn6Mho")
                                                [bookmark] 
                                                [send request] 
                                                    [TransportEndpointAsActor::process_concrete, self] 
                                                    !event! RequestId("~46IHev9TUSc7PZpyJqRW")
                                                        [bookmark] 
                                                        [send request] 
                                                            [request GatewayRequestToChild::Transport::SendMessage] 
                                                            !event! RequestId("mplex_to_inner_gateway_FgNA60ek8fEw94feGMkG4")
                                                                [bookmark] 
                                                                [send request] 
                                                                    [handle_RequestToChild] 
                                                                        [send_with_partial_high_uri] 
                                                                            [dht::RequestPeer] 
                                                                            !event! RequestId("gateway_dht_wlxfZNTP5XZmvUUEExnsN")
                                                                                [bookmark] 
                                                                                [send request] 
                                                                                    [handle_request_from_parent] 
                                                                            [SendWithFullLowUri] 
                                                                                [request RequestToChild::EncodePayload] 
                                                                                !event! RequestId("gateway_to_message_encoding_W8aZK4T8lSKfIgkQfW3Db")
                                                                                    [bookmark] 
                                                                                    [send request] 
                                                                                [request RequestToChild::SendMessage] 
                                                                                !event! RequestId("gateway_to_child_transport_ekKxyAjt16u1wkjDDR8Ye")
                                                                                    [bookmark] 
                                                                                    [send request] 
                                                                                        [process_concrete] 
                                                                                        !event! SendMessage to 'mem://addr_1/'
                                        [dht::RequestPeer] 
                                        !event! RequestId("gateway_dht_rP5~AHWrXB2JmGIJQgeDm")
                                            [bookmark] 
                                            [send request] 
                                                [handle_request_from_parent] 
```