### PR TITLE
remove unsafe impls on DeepRef

### DIFF
--- a/crates/ghost_actor/Cargo.toml
+++ b/crates/ghost_actor/Cargo.toml
@@ -13,7 +13,7 @@ repository = "https://github.com/holochain/lib3h"
 
 [dependencies]
 crossbeam-channel = "=0.3.8"
-holochain_tracing = { version = "=0.0.2", git = "https://github.com/holochain/holochain-tracing" }
+holochain_tracing = { version = "=0.0.2" }
 Inflector = "=0.11.4"
 lazy_static = "=1.2.0"
 lib3h_zombie_actor = { version = "=0.0.20", path = "../zombie_actor" }

--- a/crates/ghost_actor/src/ghost_deep_ref.rs
+++ b/crates/ghost_actor/src/ghost_deep_ref.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, Weak};
 
 /// will be invoked when the internal ref is updated
 pub(crate) type DeepRefSetCb<'lt, X> =
-    Box<dyn FnMut(Weak<GhostMutex<X>>) -> GhostResult<bool> + 'lt>;
+    Box<dyn FnMut(Weak<GhostMutex<X>>) -> GhostResult<bool> + 'lt + Send + Sync>;
 
 /// internal deep ref data
 struct DeepRefInner<'lt, X: 'lt + Send + Sync> {
@@ -72,9 +72,6 @@ pub(crate) struct DeepRef<'lt, X: 'lt + Send + Sync> {
     p: std::marker::PhantomData<&'lt i8>,
     r: Arc<GhostMutex<DeepRefInner<'lt, X>>>,
 }
-
-unsafe impl<'lt, X: 'lt + Send + Sync> Send for DeepRef<'lt, X> {}
-unsafe impl<'lt, X: 'lt + Send + Sync> Sync for DeepRef<'lt, X> {}
 
 impl<'lt, X: 'lt + Send + Sync> Clone for DeepRef<'lt, X> {
     fn clone(&self) -> Self {


### PR DESCRIPTION
## PR summary

These unsafe `impl`s have been bothering me. Finally got a chance to track down the bit missing on the callback signatures.

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
