### PR TITLE
Bump persistence 0.0.11

### DIFF
--- a/crates/lib3h/Cargo.toml
+++ b/crates/lib3h/Cargo.toml
@@ -17,7 +17,7 @@ backtrace = "=0.3.27"
 detach = { version = "=0.0.21", path = "../detach" }
 env_logger = "=0.6.1"
 hcid = "=0.0.6"
-holochain_persistence_api = "=0.0.10"
+holochain_persistence_api = "=0.0.11"
 holochain_tracing = "=0.0.1"
 # version on the left for release regex
 lib3h_protocol = { version = "=0.0.21", path = "../lib3h_protocol" }

--- a/crates/lib3h_protocol/Cargo.toml
+++ b/crates/lib3h_protocol/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/holochain/lib3h"
 [dependencies]
 backtrace = "=0.3.27"
 base64 = "=0.10.1"
-holochain_persistence_api = "=0.0.10"
+holochain_persistence_api = "=0.0.11"
 rmp-serde = "=0.13.7"
 serde = "=1.0.89"
 serde_derive = "=1.0.89"


### PR DESCRIPTION
## PR summary

A version bump for holochain_persistence. 0.0.11 fixes a bug with lmdb storage.

To my knowledge the version needs to be updated here before updating holochain core (open to other ideas though)

## Review checklist 
- [ ] The story has unit or integration tests
- [ ] No new bugs, and any tech-debt is identified and justified
- [ ] There is enough API documentation (how to use)
- [ ] There is enough code documentation (how the code works)
